### PR TITLE
Add public product demo page

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -1,0 +1,269 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { PublicDemoReplay } from '@/components/demo/public-demo-replay';
+import { PublicSiteFooter } from '@/components/public-site-footer';
+import { PublicSiteNav } from '@/components/public-site-nav';
+import { Badge } from '@/components/ui/badge';
+import { buttonVariants } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  demoConversationMessages,
+  demoHeroStats,
+  demoInboxLeads,
+  demoLeadDetail,
+  demoOwnerAlert,
+  demoTrustPoints,
+  demoWorkflowSteps,
+} from '@/lib/demo-data';
+import { cn } from '@/lib/utils';
+
+export const metadata: Metadata = {
+  title: 'Live Product Demo | CallbackCloser',
+  description: 'See how CallbackCloser turns a missed HVAC call into a qualified lead and owner alert in under 30 seconds.',
+};
+
+function getLeadRowBadgeVariant(status: string) {
+  if (status === 'Qualified') return 'success';
+  if (status === 'Contacted') return 'secondary';
+  return 'outline';
+}
+
+export default function DemoPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <PublicSiteNav />
+
+      <main>
+        <section className="border-b bg-gradient-to-b from-background via-background to-muted/30">
+          <div className="container grid gap-10 py-16 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:py-20">
+            <div className="space-y-8">
+              <div className="space-y-4">
+                <Badge variant="outline">Public HVAC demo</Badge>
+                <div className="space-y-4">
+                  <h1 className="max-w-4xl text-4xl font-semibold tracking-tight sm:text-5xl">
+                    Turn missed HVAC calls into paying jobs while the lead is still hot
+                  </h1>
+                  <p className="max-w-2xl text-lg text-muted-foreground">
+                    This is a safe public walkthrough of the real CallbackCloser flow: missed call, instant text, lead qualification, and the owner alert
+                    that tells your team who to call first.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-3">
+                  <Link className={buttonVariants({ size: 'lg' })} href="/contact">
+                    See this on your business
+                  </Link>
+                  <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} href="#demo-workspace">
+                    Watch the demo
+                  </Link>
+                  <Link className={buttonVariants({ size: 'lg', variant: 'ghost' })} href="/sign-up">
+                    Get set up in 10 minutes
+                  </Link>
+                </div>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-3">
+                {demoHeroStats.map((stat) => (
+                  <div key={stat.label} className="rounded-2xl border bg-card/85 p-4 shadow-sm">
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">{stat.label}</p>
+                    <p className="mt-2 text-lg font-semibold">{stat.value}</p>
+                    <p className="mt-2 text-sm text-muted-foreground">{stat.detail}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <Card className="overflow-hidden border-primary/20 bg-card/95 shadow-lg">
+              <CardHeader className="border-b bg-gradient-to-r from-primary/10 via-background to-secondary/40">
+                <CardTitle>What you are looking at</CardTitle>
+                <CardDescription>A realistic public demo page built for live sales calls. No login, no real customer data, no live Twilio traffic.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 p-6 text-sm">
+                {demoTrustPoints.map((point) => (
+                  <div key={point} className="rounded-2xl border bg-background/80 p-4">
+                    {point}
+                  </div>
+                ))}
+                <div className="rounded-2xl border border-accent/40 bg-accent/20 p-4">
+                  <p className="font-medium">30-second sales story</p>
+                  <p className="mt-2 text-muted-foreground">
+                    A homeowner calls, the business misses it, CallbackCloser texts instantly, the lead replies, and the owner gets a ready-to-call HVAC job
+                    instead of a dead voicemail.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        <section className="container space-y-8 py-12" id="demo-workspace">
+          <div className="max-w-2xl space-y-3">
+            <Badge variant="outline">Live-looking product view</Badge>
+            <h2 className="text-3xl font-semibold tracking-tight">See the recovered lead before your prospect zones out</h2>
+            <p className="text-muted-foreground">
+              The inbox on the left looks like the real app. The selected lead opens into the same kind of conversation and owner handoff your team would
+              use after setup.
+            </p>
+          </div>
+
+          <div className="grid gap-6 xl:grid-cols-[0.8fr_1.2fr]">
+            <Card className="bg-card/90">
+              <CardHeader>
+                <CardTitle>Recovered leads</CardTitle>
+                <CardDescription>What the owner sees when CallbackCloser has already done the first part of the follow-up.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {demoInboxLeads.map((lead, index) => (
+                  <div
+                    key={lead.id}
+                    className={cn(
+                      'rounded-2xl border p-4',
+                      index === 0 ? 'border-primary/30 bg-primary/5' : 'bg-background/80',
+                    )}
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="font-medium">{lead.customerName}</p>
+                        <p className="text-sm text-muted-foreground">{lead.customerPhone}</p>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <Badge variant={getLeadRowBadgeVariant(lead.status)}>{lead.status}</Badge>
+                        <Badge variant={lead.readiness === 'Hot Lead' ? 'destructive' : lead.readiness === 'Working' ? 'secondary' : 'outline'}>
+                          {lead.readiness}
+                        </Badge>
+                      </div>
+                    </div>
+                    <div className="mt-4 grid gap-2 text-sm text-muted-foreground sm:grid-cols-2">
+                      <p>{lead.serviceType}</p>
+                      <p>{lead.urgency}</p>
+                      <p>{lead.location}</p>
+                      <p>{lead.createdLabel}</p>
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            <PublicDemoReplay messages={demoConversationMessages} ownerAlert={demoOwnerAlert} />
+          </div>
+        </section>
+
+        <section className="border-y bg-muted/20">
+          <div className="container grid gap-6 py-14 lg:grid-cols-[1fr_1fr]">
+            <Card className="bg-card/90">
+              <CardHeader>
+                <CardTitle>Lead detail at a glance</CardTitle>
+                <CardDescription>This is the context your prospect needs to understand immediately on a sales call.</CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-4 md:grid-cols-2">
+                <div className="rounded-xl border bg-background/85 p-4 text-sm">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Customer</p>
+                  <p className="mt-2 font-medium">{demoLeadDetail.customerName}</p>
+                  <p className="mt-1 text-muted-foreground">{demoLeadDetail.customerPhone}</p>
+                </div>
+                <div className="rounded-xl border bg-background/85 p-4 text-sm">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Issue</p>
+                  <p className="mt-2 font-medium">{demoLeadDetail.issueSummary}</p>
+                  <p className="mt-1 text-muted-foreground">{demoLeadDetail.serviceType}</p>
+                </div>
+                <div className="rounded-xl border bg-background/85 p-4 text-sm">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Urgency</p>
+                  <p className="mt-2 font-medium">{demoLeadDetail.urgency}</p>
+                  <p className="mt-1 text-muted-foreground">{demoLeadDetail.callbackWindow}</p>
+                </div>
+                <div className="rounded-xl border bg-background/85 p-4 text-sm">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Timing</p>
+                  <p className="mt-2 font-medium">Created {demoLeadDetail.createdAt}</p>
+                  <p className="mt-1 text-muted-foreground">Qualified {demoLeadDetail.qualifiedAt}</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="border-accent/40 bg-accent/20">
+              <CardHeader>
+                <CardTitle>The owner alert is the sales moment</CardTitle>
+                <CardDescription>
+                  This is where a missed call stops feeling like lost revenue and starts looking like a job the owner can actually close.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="rounded-2xl border bg-background/90 p-5">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <p className="text-lg font-semibold">{demoOwnerAlert.headline}</p>
+                    <Badge variant="success">Ready to call</Badge>
+                  </div>
+                  <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                    <div className="rounded-xl border bg-muted/20 p-3 text-sm">
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">Service</p>
+                      <p className="mt-2 font-medium">{demoOwnerAlert.service}</p>
+                    </div>
+                    <div className="rounded-xl border bg-muted/20 p-3 text-sm">
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">Urgency</p>
+                      <p className="mt-2 font-medium">{demoOwnerAlert.urgency}</p>
+                    </div>
+                    <div className="rounded-xl border bg-muted/20 p-3 text-sm">
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">Call now</p>
+                      <p className="mt-2 font-medium">{demoOwnerAlert.customerPhone}</p>
+                    </div>
+                  </div>
+                  <p className="mt-4 text-sm text-muted-foreground">{demoOwnerAlert.summary}</p>
+                </div>
+                <div className="flex flex-wrap gap-3">
+                  <Link className={buttonVariants()} href="/contact">
+                    Want this on your business?
+                  </Link>
+                  <Link className={buttonVariants({ variant: 'outline' })} href="/sign-up">
+                    Try CallbackCloser on your number
+                  </Link>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        <section className="container space-y-6 py-14" id="how-it-works">
+          <div className="max-w-2xl space-y-3">
+            <Badge variant="outline">How it works</Badge>
+            <h2 className="text-3xl font-semibold tracking-tight">Three steps. One clearer handoff.</h2>
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            {demoWorkflowSteps.map((step, index) => (
+              <Card key={step.title} className="bg-card/90">
+                <CardHeader>
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-full border font-medium">{index + 1}</div>
+                    <CardTitle>{step.title}</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent className="text-sm text-muted-foreground">{step.detail}</CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        <section className="border-t bg-gradient-to-b from-background to-muted/30">
+          <div className="container space-y-6 py-16 text-center">
+            <Badge variant="outline">Close with a demo, not a long explanation</Badge>
+            <div className="space-y-3">
+              <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">Want this on your business?</h2>
+              <p className="mx-auto max-w-2xl text-muted-foreground">
+                CallbackCloser is built to help HVAC teams recover missed jobs fast. If this looks like the kind of handoff your team needs, the next step is
+                getting it on your number and running one live test.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Link className={buttonVariants({ size: 'lg' })} href="/contact">
+                Book a setup call
+              </Link>
+              <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} href="/sign-up">
+                Start free pilot
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <PublicSiteFooter />
+    </div>
+  );
+}

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
 };
 
 function getLeadRowBadgeVariant(status: string) {
-  if (status === 'Qualified') return 'success';
+  if (status === 'Ready for callback') return 'success';
   if (status === 'Contacted') return 'secondary';
   return 'outline';
 }
@@ -42,24 +42,25 @@ export default function DemoPage() {
                 <Badge variant="outline">Public HVAC demo</Badge>
                 <div className="space-y-4">
                   <h1 className="max-w-4xl text-4xl font-semibold tracking-tight sm:text-5xl">
-                    Turn missed HVAC calls into paying jobs while the lead is still hot
+                    Stop losing jobs when you miss the call
                   </h1>
                   <p className="max-w-2xl text-lg text-muted-foreground">
-                    This is a safe public walkthrough of the real CallbackCloser flow: missed call, instant text, lead qualification, and the owner alert
-                    that tells your team who to call first.
+                    When someone calls and you can&apos;t answer, CallbackCloser texts them instantly, qualifies the job, and sends you a hot lead to call
+                    back.
+                  </p>
+                  <p className="max-w-2xl text-base font-medium text-foreground/90">
+                    Every missed call could be a $300-$1,000 job. CallbackCloser helps make sure it doesn&apos;t go to the next company.
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-3">
                   <Link className={buttonVariants({ size: 'lg' })} href="/contact">
-                    See this on your business
+                    Want this running on your number?
                   </Link>
                   <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} href="#demo-workspace">
-                    Watch the demo
-                  </Link>
-                  <Link className={buttonVariants({ size: 'lg', variant: 'ghost' })} href="/sign-up">
-                    Get set up in 10 minutes
+                    See it in action
                   </Link>
                 </div>
+                <p className="text-sm text-muted-foreground">I can set this up for your business in 10 minutes.</p>
               </div>
 
               <div className="grid gap-3 sm:grid-cols-3">
@@ -75,8 +76,8 @@ export default function DemoPage() {
 
             <Card className="overflow-hidden border-primary/20 bg-card/95 shadow-lg">
               <CardHeader className="border-b bg-gradient-to-r from-primary/10 via-background to-secondary/40">
-                <CardTitle>What you are looking at</CardTitle>
-                <CardDescription>A realistic public demo page built for live sales calls. No login, no real customer data, no live Twilio traffic.</CardDescription>
+                <CardTitle>This is exactly what your customer sees after you miss their call.</CardTitle>
+                <CardDescription>They call. You miss it. We text them right away, ask what they need, and send you the lead while they&apos;re still ready to book.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4 p-6 text-sm">
                 {demoTrustPoints.map((point) => (
@@ -85,11 +86,13 @@ export default function DemoPage() {
                   </div>
                 ))}
                 <div className="rounded-2xl border border-accent/40 bg-accent/20 p-4">
-                  <p className="font-medium">30-second sales story</p>
-                  <p className="mt-2 text-muted-foreground">
-                    A homeowner calls, the business misses it, CallbackCloser texts instantly, the lead replies, and the owner gets a ready-to-call HVAC job
-                    instead of a dead voicemail.
-                  </p>
+                  <p className="font-medium">What usually happens without this</p>
+                  <p className="mt-2 text-muted-foreground">Customer calls -&gt; no answer -&gt; calls the next company</p>
+                </div>
+                <div className="rounded-2xl border border-primary/30 bg-primary/5 p-4">
+                  <p className="font-medium">What happens with CallbackCloser</p>
+                  <p className="mt-2 text-muted-foreground">Customer calls -&gt; gets a text right away -&gt; replies -&gt; you get the lead</p>
+                  <p className="mt-3 text-sm font-medium text-foreground/90">Speed is the difference between a lost call and a booked job.</p>
                 </div>
               </CardContent>
             </Card>
@@ -99,18 +102,17 @@ export default function DemoPage() {
         <section className="container space-y-8 py-12" id="demo-workspace">
           <div className="max-w-2xl space-y-3">
             <Badge variant="outline">Live-looking product view</Badge>
-            <h2 className="text-3xl font-semibold tracking-tight">See the recovered lead before your prospect zones out</h2>
+            <h2 className="text-3xl font-semibold tracking-tight">Here&apos;s what happens after a missed HVAC call</h2>
             <p className="text-muted-foreground">
-              The inbox on the left looks like the real app. The selected lead opens into the same kind of conversation and owner handoff your team would
-              use after setup.
+              They call. You miss it. We text them right away, ask what they need, and send you the lead while they&apos;re still ready to book.
             </p>
           </div>
 
           <div className="grid gap-6 xl:grid-cols-[0.8fr_1.2fr]">
             <Card className="bg-card/90">
               <CardHeader>
-                <CardTitle>Recovered leads</CardTitle>
-                <CardDescription>What the owner sees when CallbackCloser has already done the first part of the follow-up.</CardDescription>
+                <CardTitle>Recent leads recovered from missed calls</CardTitle>
+                <CardDescription>These are calls that likely would have gone cold without a fast follow-up.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
                 {demoInboxLeads.map((lead, index) => (
@@ -152,24 +154,29 @@ export default function DemoPage() {
           <div className="container grid gap-6 py-14 lg:grid-cols-[1fr_1fr]">
             <Card className="bg-card/90">
               <CardHeader>
-                <CardTitle>Lead detail at a glance</CardTitle>
-                <CardDescription>This is the context your prospect needs to understand immediately on a sales call.</CardDescription>
+                <CardTitle>New HVAC lead</CardTitle>
+                <CardDescription>Hot lead details ready for callback.</CardDescription>
               </CardHeader>
               <CardContent className="grid gap-4 md:grid-cols-2">
                 <div className="rounded-xl border bg-background/85 p-4 text-sm">
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Customer</p>
-                  <p className="mt-2 font-medium">{demoLeadDetail.customerName}</p>
-                  <p className="mt-1 text-muted-foreground">{demoLeadDetail.customerPhone}</p>
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Status</p>
+                  <p className="mt-2 font-medium">{demoLeadDetail.readiness}</p>
+                  <p className="mt-1 text-muted-foreground">{demoLeadDetail.status}</p>
                 </div>
                 <div className="rounded-xl border bg-background/85 p-4 text-sm">
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Issue</p>
-                  <p className="mt-2 font-medium">{demoLeadDetail.issueSummary}</p>
-                  <p className="mt-1 text-muted-foreground">{demoLeadDetail.serviceType}</p>
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Service</p>
+                  <p className="mt-2 font-medium">{demoLeadDetail.serviceType}</p>
+                  <p className="mt-1 text-muted-foreground">{demoLeadDetail.issueSummary}</p>
                 </div>
                 <div className="rounded-xl border bg-background/85 p-4 text-sm">
                   <p className="text-xs uppercase tracking-wide text-muted-foreground">Urgency</p>
                   <p className="mt-2 font-medium">{demoLeadDetail.urgency}</p>
                   <p className="mt-1 text-muted-foreground">{demoLeadDetail.callbackWindow}</p>
+                </div>
+                <div className="rounded-xl border bg-background/85 p-4 text-sm">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Customer</p>
+                  <p className="mt-2 font-medium">{demoLeadDetail.customerName}</p>
+                  <p className="mt-1 text-muted-foreground">{demoLeadDetail.customerPhone}</p>
                 </div>
                 <div className="rounded-xl border bg-background/85 p-4 text-sm">
                   <p className="text-xs uppercase tracking-wide text-muted-foreground">Timing</p>
@@ -181,18 +188,16 @@ export default function DemoPage() {
 
             <Card className="border-accent/40 bg-accent/20">
               <CardHeader>
-                <CardTitle>The owner alert is the sales moment</CardTitle>
-                <CardDescription>
-                  This is where a missed call stops feeling like lost revenue and starts looking like a job the owner can actually close.
-                </CardDescription>
+                <CardTitle>This is what you get instantly</CardTitle>
+                <CardDescription>Instead of losing the call, you get another shot at the job.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="rounded-2xl border bg-background/90 p-5">
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <p className="text-lg font-semibold">{demoOwnerAlert.headline}</p>
-                    <Badge variant="success">Ready to call</Badge>
+                    <Badge variant="success">Ready for callback</Badge>
                   </div>
-                  <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                  <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
                     <div className="rounded-xl border bg-muted/20 p-3 text-sm">
                       <p className="text-xs uppercase tracking-wide text-muted-foreground">Service</p>
                       <p className="mt-2 font-medium">{demoOwnerAlert.service}</p>
@@ -200,6 +205,10 @@ export default function DemoPage() {
                     <div className="rounded-xl border bg-muted/20 p-3 text-sm">
                       <p className="text-xs uppercase tracking-wide text-muted-foreground">Urgency</p>
                       <p className="mt-2 font-medium">{demoOwnerAlert.urgency}</p>
+                    </div>
+                    <div className="rounded-xl border bg-muted/20 p-3 text-sm">
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">Issue</p>
+                      <p className="mt-2 font-medium">{demoOwnerAlert.issue}</p>
                     </div>
                     <div className="rounded-xl border bg-muted/20 p-3 text-sm">
                       <p className="text-xs uppercase tracking-wide text-muted-foreground">Call now</p>
@@ -213,7 +222,7 @@ export default function DemoPage() {
                     Want this on your business?
                   </Link>
                   <Link className={buttonVariants({ variant: 'outline' })} href="/sign-up">
-                    Try CallbackCloser on your number
+                    See it on your number
                   </Link>
                 </div>
               </CardContent>
@@ -224,7 +233,8 @@ export default function DemoPage() {
         <section className="container space-y-6 py-14" id="how-it-works">
           <div className="max-w-2xl space-y-3">
             <Badge variant="outline">How it works</Badge>
-            <h2 className="text-3xl font-semibold tracking-tight">Three steps. One clearer handoff.</h2>
+            <h2 className="text-3xl font-semibold tracking-tight">How it works</h2>
+            <p className="text-muted-foreground">Most callers move on fast. This gives you a chance to win the job before they call someone else.</p>
           </div>
           <div className="grid gap-4 md:grid-cols-3">
             {demoWorkflowSteps.map((step, index) => (
@@ -247,16 +257,15 @@ export default function DemoPage() {
             <div className="space-y-3">
               <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">Want this on your business?</h2>
               <p className="mx-auto max-w-2xl text-muted-foreground">
-                CallbackCloser is built to help HVAC teams recover missed jobs fast. If this looks like the kind of handoff your team needs, the next step is
-                getting it on your number and running one live test.
+                I can set it up on your number and have you live fast.
               </p>
             </div>
             <div className="flex flex-wrap items-center justify-center gap-3">
-              <Link className={buttonVariants({ size: 'lg' })} href="/contact">
-                Book a setup call
+              <Link className={buttonVariants({ size: 'lg' })} href="/sign-up">
+                See it on your number
               </Link>
-              <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} href="/sign-up">
-                Start free pilot
+              <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} href="/contact">
+                Book a quick setup call
               </Link>
             </div>
           </div>

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -60,7 +60,7 @@ export default function DemoPage() {
                     See it in action
                   </Link>
                 </div>
-                <p className="text-sm text-muted-foreground">I can set this up for your business in 10 minutes.</p>
+                <p className="text-sm text-muted-foreground">Get this live on your number fast, without changing how your team already works.</p>
               </div>
 
               <div className="grid gap-3 sm:grid-cols-3">
@@ -257,7 +257,7 @@ export default function DemoPage() {
             <div className="space-y-3">
               <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">Want this on your business?</h2>
               <p className="mx-auto max-w-2xl text-muted-foreground">
-                I can set it up on your number and have you live fast.
+                We can set it up on your number and get you live fast.
               </p>
             </div>
             <div className="flex flex-wrap items-center justify-center gap-3">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -148,7 +148,7 @@ export default function LandingPage() {
                   <Link className={buttonVariants({ size: 'lg' })} href="/sign-up">
                     Start Free Pilot
                   </Link>
-                  <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} href="/simulator">
+                  <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} href="/demo">
                     See Demo
                   </Link>
                   <Link className={buttonVariants({ size: 'lg', variant: 'ghost' })} href="/pricing">
@@ -216,12 +216,12 @@ export default function LandingPage() {
                   </p>
                 </div>
                 <div className="rounded-2xl border bg-background/80 p-4">
-                  <p className="font-medium">Try the live product demo loop</p>
+                  <p className="font-medium">Show the product in 30 seconds</p>
                   <p className="mt-2 text-muted-foreground">
-                    Open the missed-call simulator to watch the recovery text, caller intake, owner alert, and dashboard handoff play out end to end.
+                    Open the public demo to show the missed-call follow-up, owner alert, and dashboard handoff without login or setup.
                   </p>
-                  <Link className={buttonVariants({ className: 'mt-4' })} href="/simulator">
-                    Open missed-call simulator
+                  <Link className={buttonVariants({ className: 'mt-4' })} href="/demo">
+                    Open public demo
                   </Link>
                 </div>
               </CardContent>

--- a/components/demo/public-demo-replay.tsx
+++ b/components/demo/public-demo-replay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -51,7 +51,7 @@ export function PublicDemoReplay({
     return () => window.clearTimeout(timeout);
   }, [isReplaying, visibleCount, messages.length]);
 
-  const visibleMessages = useMemo(() => messages.slice(0, visibleCount), [messages, visibleCount]);
+  const visibleMessages = messages.slice(0, visibleCount);
   const replayStage = getReplayStage(visibleMessages.length, messages.length);
   const ownerAlertReady = replayStage === 'qualified';
 

--- a/components/demo/public-demo-replay.tsx
+++ b/components/demo/public-demo-replay.tsx
@@ -26,6 +26,7 @@ export function PublicDemoReplay({
     headline: string;
     service: string;
     urgency: string;
+    issue: string;
     customerName: string;
     customerPhone: string;
     summary: string;
@@ -61,13 +62,11 @@ export function PublicDemoReplay({
           <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div className="space-y-2">
               <div className="flex flex-wrap items-center gap-2">
-                <CardTitle>Lead workspace</CardTitle>
-                <Badge variant="success">Qualified</Badge>
+                <CardTitle>Live customer conversation</CardTitle>
+                <Badge variant="success">Ready for callback</Badge>
                 <Badge variant="destructive">Hot Lead</Badge>
               </div>
-              <CardDescription>
-                This mirrors the real CallbackCloser lead detail flow: missed call, text follow-up, qualification, and owner handoff.
-              </CardDescription>
+              <CardDescription>Short, natural messages that get replies fast.</CardDescription>
             </div>
             <div className="flex flex-wrap gap-2">
               <Button
@@ -121,7 +120,7 @@ export function PublicDemoReplay({
                 <div className="rounded-xl border bg-muted/20 p-3">
                   <p className="text-xs uppercase tracking-wide text-muted-foreground">What got captured</p>
                   <p className="mt-2 font-medium">
-                    {replayStage === 'qualified' ? `${ownerAlert.service} • ${ownerAlert.urgency}` : 'Issue + service + urgency in progress'}
+                    {replayStage === 'qualified' ? `${ownerAlert.issue} • ${ownerAlert.service} • ${ownerAlert.urgency}` : 'Issue + service + urgency in progress'}
                   </p>
                 </div>
               </div>
@@ -130,11 +129,11 @@ export function PublicDemoReplay({
             <div className="rounded-2xl border bg-background/80 p-4">
               <div className="mb-3 flex items-center justify-between gap-3">
                 <div>
-                  <p className="font-medium">Conversation history</p>
-                  <p className="text-sm text-muted-foreground">Watch the missed-call follow-up unfold step by step.</p>
+                  <p className="font-medium">Live customer conversation</p>
+                  <p className="text-sm text-muted-foreground">Short, natural messages that get replies fast.</p>
                 </div>
                 <Badge variant={ownerAlertReady ? 'success' : 'outline'}>
-                  {ownerAlertReady ? 'Qualified' : 'In progress'}
+                  {ownerAlertReady ? 'Ready for callback' : 'In progress'}
                 </Badge>
               </div>
               <div className="space-y-3">
@@ -166,14 +165,17 @@ export function PublicDemoReplay({
             <Card className={cn('border-primary/20 bg-primary/5 transition-all', ownerAlertReady && 'border-accent/40 bg-accent/20')}>
               <CardHeader>
                 <div className="flex flex-wrap items-center justify-between gap-3">
-                  <CardTitle>{ownerAlert.headline}</CardTitle>
+                  <CardTitle>This is what you get instantly</CardTitle>
                   <Badge variant={ownerAlertReady ? 'success' : 'outline'}>
                     {ownerAlertReady ? 'Owner alert sent' : 'Waiting on qualification'}
                   </Badge>
                 </div>
-                <CardDescription>The sales moment: what the owner sees after the lead is qualified.</CardDescription>
+                <CardDescription>Instead of losing the call, you get another shot at the job.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4 text-sm">
+                <div className="rounded-xl border bg-background/85 p-4">
+                  <p className="text-lg font-semibold">{ownerAlert.headline}</p>
+                </div>
                 <div className="grid grid-cols-2 gap-3">
                   <div className="rounded-xl border bg-background/85 p-3">
                     <p className="text-xs uppercase tracking-wide text-muted-foreground">Service</p>
@@ -183,6 +185,10 @@ export function PublicDemoReplay({
                     <p className="text-xs uppercase tracking-wide text-muted-foreground">Urgency</p>
                     <p className="mt-2 font-medium">{ownerAlert.urgency}</p>
                   </div>
+                </div>
+                <div className="rounded-xl border bg-background/85 p-3">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Issue</p>
+                  <p className="mt-2 font-medium">{ownerAlert.issue}</p>
                 </div>
                 <div className="rounded-xl border bg-background/85 p-4">
                   <p className="text-xs uppercase tracking-wide text-muted-foreground">Call now</p>
@@ -199,11 +205,11 @@ export function PublicDemoReplay({
             </Card>
 
             <div className="rounded-2xl border bg-background/80 p-4 text-sm">
-              <p className="font-medium">Why this closes faster</p>
+              <p className="font-medium">Speed is the difference between a lost call and a booked job.</p>
               <div className="mt-3 space-y-2 text-muted-foreground">
                 <p>- The homeowner gets a fast reply while the problem still feels urgent.</p>
-                <p>- The owner sees repair intent and timing before making the callback.</p>
-                <p>- The conversation is captured in one place instead of lost across voicemail and manual texting.</p>
+                <p>- You see repair intent and timing before making the callback.</p>
+                <p>- The conversation stays in one place instead of getting lost in voicemail.</p>
               </div>
             </div>
           </div>

--- a/components/demo/public-demo-replay.tsx
+++ b/components/demo/public-demo-replay.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { DemoConversationMessage } from '@/lib/demo-data';
+import { cn } from '@/lib/utils';
+
+const REPLAY_INTERVAL_MS = 850;
+
+function getReplayStage(messageCount: number, totalMessages: number) {
+  if (messageCount >= totalMessages) return 'qualified';
+  if (messageCount >= Math.max(totalMessages - 1, 1)) return 'qualifying';
+  if (messageCount > 0) return 'active';
+  return 'idle';
+}
+
+export function PublicDemoReplay({
+  messages,
+  ownerAlert,
+}: {
+  messages: DemoConversationMessage[];
+  ownerAlert: {
+    headline: string;
+    service: string;
+    urgency: string;
+    customerName: string;
+    customerPhone: string;
+    summary: string;
+    footer: string;
+  };
+}) {
+  const [visibleCount, setVisibleCount] = useState(messages.length);
+  const [isReplaying, setIsReplaying] = useState(false);
+
+  useEffect(() => {
+    if (!isReplaying) return;
+
+    if (visibleCount >= messages.length) {
+      setIsReplaying(false);
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setVisibleCount((current) => Math.min(current + 1, messages.length));
+    }, REPLAY_INTERVAL_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [isReplaying, visibleCount, messages.length]);
+
+  const visibleMessages = useMemo(() => messages.slice(0, visibleCount), [messages, visibleCount]);
+  const replayStage = getReplayStage(visibleMessages.length, messages.length);
+  const ownerAlertReady = replayStage === 'qualified';
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+      <Card className="overflow-hidden bg-card/95">
+        <CardHeader className="border-b bg-gradient-to-r from-primary/10 via-background to-secondary/40">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <CardTitle>Lead workspace</CardTitle>
+                <Badge variant="success">Qualified</Badge>
+                <Badge variant="destructive">Hot Lead</Badge>
+              </div>
+              <CardDescription>
+                This mirrors the real CallbackCloser lead detail flow: missed call, text follow-up, qualification, and owner handoff.
+              </CardDescription>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                onClick={() => {
+                  setVisibleCount(0);
+                  setIsReplaying(true);
+                }}
+                type="button"
+                variant="outline"
+              >
+                Replay demo
+              </Button>
+              <Button
+                onClick={() => {
+                  setVisibleCount(messages.length);
+                  setIsReplaying(false);
+                }}
+                type="button"
+              >
+                Show full flow
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-4 p-6 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+          <div className="space-y-3">
+            <div className="rounded-2xl border bg-background/80 p-4 text-sm">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="font-medium">{ownerAlert.customerName}</p>
+                  <p className="text-muted-foreground">{ownerAlert.customerPhone}</p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="secondary">{ownerAlert.service}</Badge>
+                  <Badge variant="destructive">{ownerAlert.urgency}</Badge>
+                </div>
+              </div>
+              <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                <div className="rounded-xl border bg-muted/20 p-3">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Callback state</p>
+                  <p className="mt-2 font-medium">
+                    {replayStage === 'idle'
+                      ? 'Missed call detected'
+                      : replayStage === 'active'
+                        ? 'Texting lead now'
+                        : replayStage === 'qualifying'
+                          ? 'Qualifying by text'
+                          : 'Owner ready to call'}
+                  </p>
+                </div>
+                <div className="rounded-xl border bg-muted/20 p-3">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">What got captured</p>
+                  <p className="mt-2 font-medium">
+                    {replayStage === 'qualified' ? `${ownerAlert.service} • ${ownerAlert.urgency}` : 'Issue + service + urgency in progress'}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-2xl border bg-background/80 p-4">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div>
+                  <p className="font-medium">Conversation history</p>
+                  <p className="text-sm text-muted-foreground">Watch the missed-call follow-up unfold step by step.</p>
+                </div>
+                <Badge variant={ownerAlertReady ? 'success' : 'outline'}>
+                  {ownerAlertReady ? 'Qualified' : 'In progress'}
+                </Badge>
+              </div>
+              <div className="space-y-3">
+                {visibleMessages.map((message) => (
+                  <div
+                    key={message.id}
+                    className={cn(
+                      'rounded-xl border p-3 text-sm transition-opacity',
+                      message.sender === 'system' ? 'bg-primary/5' : 'bg-card',
+                    )}
+                  >
+                    <div className="mb-1 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                      <span>{message.label}</span>
+                      <span>{message.timestamp}</span>
+                    </div>
+                    <p className="whitespace-pre-wrap">{message.body}</p>
+                  </div>
+                ))}
+                {visibleMessages.length === 0 ? (
+                  <div className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">
+                    Hit replay to reveal the missed-call text thread like a live sales walkthrough.
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <Card className={cn('border-primary/20 bg-primary/5 transition-all', ownerAlertReady && 'border-accent/40 bg-accent/20')}>
+              <CardHeader>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <CardTitle>{ownerAlert.headline}</CardTitle>
+                  <Badge variant={ownerAlertReady ? 'success' : 'outline'}>
+                    {ownerAlertReady ? 'Owner alert sent' : 'Waiting on qualification'}
+                  </Badge>
+                </div>
+                <CardDescription>The sales moment: what the owner sees after the lead is qualified.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm">
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="rounded-xl border bg-background/85 p-3">
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">Service</p>
+                    <p className="mt-2 font-medium">{ownerAlert.service}</p>
+                  </div>
+                  <div className="rounded-xl border bg-background/85 p-3">
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">Urgency</p>
+                    <p className="mt-2 font-medium">{ownerAlert.urgency}</p>
+                  </div>
+                </div>
+                <div className="rounded-xl border bg-background/85 p-4">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Call now</p>
+                  <p className="mt-2 text-lg font-semibold">{ownerAlert.customerPhone}</p>
+                  <p className="mt-2 text-muted-foreground">{ownerAlert.summary}</p>
+                </div>
+                <div className="rounded-xl border bg-background/85 p-4">
+                  <p className="font-medium">{ownerAlert.footer}</p>
+                  <p className="mt-2 text-muted-foreground">
+                    Open the lead, read the full text thread, and call back with the right context instead of guessing from voicemail.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <div className="rounded-2xl border bg-background/80 p-4 text-sm">
+              <p className="font-medium">Why this closes faster</p>
+              <div className="mt-3 space-y-2 text-muted-foreground">
+                <p>- The homeowner gets a fast reply while the problem still feels urgent.</p>
+                <p>- The owner sees repair intent and timing before making the callback.</p>
+                <p>- The conversation is captured in one place instead of lost across voicemail and manual texting.</p>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/public-site-footer.tsx
+++ b/components/public-site-footer.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 const footerLinks = [
   { href: '/pricing', label: 'Pricing' },
-  { href: '/simulator', label: 'Missed-Call Demo' },
+  { href: '/demo', label: 'Missed-Call Demo' },
   { href: '/contact', label: 'Contact' },
   { href: '/privacy', label: 'Privacy Policy' },
   { href: '/terms', label: 'Terms & Conditions' },

--- a/components/public-site-nav.tsx
+++ b/components/public-site-nav.tsx
@@ -7,7 +7,7 @@ const primaryLinks = [
   { href: '/pricing', label: 'Pricing' },
   { href: '/#how-it-works', label: 'How it works' },
   { href: '/#proof', label: 'Results' },
-  { href: '/simulator', label: 'See demo' },
+  { href: '/demo', label: 'See demo' },
   { href: '/contact', label: 'Contact' },
   { href: '/sms-consent', label: 'SMS Consent' },
 ];

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -5,7 +5,7 @@ export type DemoInboxLead = {
   serviceType: string;
   urgency: string;
   location: string;
-  status: 'Qualified' | 'New' | 'Contacted';
+  status: 'Ready for callback' | 'New' | 'Contacted';
   readiness: 'Hot Lead' | 'Working' | 'Needs follow-up';
   createdLabel: string;
 };
@@ -22,21 +22,21 @@ export const demoInboxLeads: DemoInboxLead[] = [
   {
     id: 'lead-hvac-repair',
     customerName: 'Jamie Carter',
-    customerPhone: '+1 (512) 555-0189',
-    serviceType: 'AC repair',
+    customerPhone: '+1 (865) 555-0148',
+    serviceType: 'Repair',
     urgency: 'Today',
-    location: 'Austin, TX 78704',
-    status: 'Qualified',
+    location: 'Knoxville, TN 37923',
+    status: 'Ready for callback',
     readiness: 'Hot Lead',
     createdLabel: '2 minutes ago',
   },
   {
     id: 'lead-no-cool',
     customerName: 'Maya Brooks',
-    customerPhone: '+1 (512) 555-0114',
+    customerPhone: '+1 (865) 555-0194',
     serviceType: 'No-cool diagnosis',
     urgency: 'This afternoon',
-    location: 'Round Rock, TX 78664',
+    location: 'Farragut, TN 37934',
     status: 'Contacted',
     readiness: 'Working',
     createdLabel: '14 minutes ago',
@@ -44,10 +44,10 @@ export const demoInboxLeads: DemoInboxLead[] = [
   {
     id: 'lead-maintenance',
     customerName: 'Ryan Patel',
-    customerPhone: '+1 (512) 555-0172',
+    customerPhone: '+1 (865) 555-0112',
     serviceType: 'Spring tune-up',
     urgency: 'This week',
-    location: 'Cedar Park, TX 78613',
+    location: 'Powell, TN 37849',
     status: 'New',
     readiness: 'Needs follow-up',
     createdLabel: '31 minutes ago',
@@ -59,28 +59,28 @@ export const demoConversationMessages: DemoConversationMessage[] = [
     id: 'msg-1',
     sender: 'system',
     label: 'CallbackCloser',
-    body: 'Hey Jamie, sorry we missed your call. What is going on with your HVAC?',
+    body: 'Hey — sorry we missed your call. What’s going on with your HVAC?',
     timestamp: '2:14 PM',
   },
   {
     id: 'msg-2',
     sender: 'customer',
     label: 'Jamie Carter',
-    body: 'AC is not cooling at all.',
+    body: 'My AC isn’t cooling.',
     timestamp: '2:14 PM',
   },
   {
     id: 'msg-3',
     sender: 'system',
     label: 'CallbackCloser',
-    body: 'Got it. Is this a repair or a new install?',
+    body: 'Got it — is this a repair or a new install?',
     timestamp: '2:15 PM',
   },
   {
     id: 'msg-4',
     sender: 'customer',
     label: 'Jamie Carter',
-    body: 'Repair.',
+    body: 'Repair',
     timestamp: '2:15 PM',
   },
   {
@@ -97,50 +97,57 @@ export const demoConversationMessages: DemoConversationMessage[] = [
     body: 'Today if possible.',
     timestamp: '2:16 PM',
   },
+  {
+    id: 'msg-7',
+    sender: 'system',
+    label: 'CallbackCloser',
+    body: 'Perfect — someone will reach out shortly. If there’s anything else we should know, you can text it here.',
+    timestamp: '2:16 PM',
+  },
 ];
 
 export const demoHeroStats = [
   {
+    label: 'Missed call value',
+    value: '$300-$1,000 jobs',
+    detail: 'One missed HVAC call can turn into a repair job that goes to the next company.',
+  },
+  {
     label: 'Response speed',
-    value: '< 60 seconds',
-    detail: 'Missed callers hear back before they move on to the next HVAC company.',
+    value: 'Texts in seconds',
+    detail: 'The homeowner gets a reply before they start calling down the list.',
   },
   {
-    label: 'Lead quality',
-    value: 'Service + urgency captured',
-    detail: 'Your team sees the repair need and timing before making the callback.',
-  },
-  {
-    label: 'Owner handoff',
+    label: 'What you get back',
     value: 'Hot lead alert',
-    detail: 'Qualified jobs are handed off with the context needed to close fast.',
+    detail: 'You see the issue, service type, and urgency before you call them back.',
   },
 ];
 
 export const demoWorkflowSteps = [
   {
-    title: 'Customer calls',
-    detail: 'A homeowner tries to book service while your team is on jobs.',
+    title: 'Customer calls your business',
+    detail: 'A homeowner reaches out when they need HVAC help now.',
   },
   {
-    title: 'You miss it',
-    detail: 'Instead of going dark, CallbackCloser starts the follow-up immediately.',
+    title: 'You miss the call',
+    detail: 'Instead of silence, CallbackCloser starts the follow-up immediately.',
   },
   {
-    title: 'We text and qualify',
-    detail: 'You get the job type, urgency, and callback context without chasing the lead.',
+    title: 'CallbackCloser texts and sends the lead',
+    detail: 'You get the issue, service type, urgency, and callback context while they are still ready to book.',
   },
 ];
 
 export const demoLeadDetail = {
   customerName: 'Jamie Carter',
-  customerPhone: '+1 (512) 555-0189',
+  customerPhone: '+1 (865) 555-0148',
   serviceType: 'Repair',
-  issueSummary: 'AC is not cooling',
+  issueSummary: 'AC not cooling',
   urgency: 'Today',
-  location: 'Austin, TX 78704',
+  location: 'Knoxville, TN 37923',
   callbackWindow: 'Call back before 4 PM',
-  status: 'Qualified',
+  status: 'Ready for callback',
   readiness: 'Hot Lead',
   createdAt: 'Today · 2:14 PM',
   qualifiedAt: '2:16 PM',
@@ -150,14 +157,15 @@ export const demoOwnerAlert = {
   headline: 'New HVAC lead',
   service: 'Repair',
   urgency: 'Today',
+  issue: 'AC not cooling',
   customerName: 'Jamie Carter',
-  customerPhone: '+1 (512) 555-0189',
-  summary: 'AC is not cooling. Austin, TX 78704. Asked for service today and can answer before 4 PM.',
+  customerPhone: '+1 (865) 555-0148',
+  summary: 'Instead of losing the call, you get another shot at the job.',
   footer: 'View in dashboard',
 };
 
 export const demoTrustPoints = [
   'Public demo only. No login, no real customer data, no live Twilio traffic.',
-  'Built to look like the real CallbackCloser lead workspace your team would use.',
+  'Built to feel like the real CallbackCloser lead workspace your team would use.',
   'Safe to open during live sales calls when you need to show the value fast.',
 ];

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -1,0 +1,163 @@
+export type DemoInboxLead = {
+  id: string;
+  customerName: string;
+  customerPhone: string;
+  serviceType: string;
+  urgency: string;
+  location: string;
+  status: 'Qualified' | 'New' | 'Contacted';
+  readiness: 'Hot Lead' | 'Working' | 'Needs follow-up';
+  createdLabel: string;
+};
+
+export type DemoConversationMessage = {
+  id: string;
+  sender: 'system' | 'customer';
+  label: string;
+  body: string;
+  timestamp: string;
+};
+
+export const demoInboxLeads: DemoInboxLead[] = [
+  {
+    id: 'lead-hvac-repair',
+    customerName: 'Jamie Carter',
+    customerPhone: '+1 (512) 555-0189',
+    serviceType: 'AC repair',
+    urgency: 'Today',
+    location: 'Austin, TX 78704',
+    status: 'Qualified',
+    readiness: 'Hot Lead',
+    createdLabel: '2 minutes ago',
+  },
+  {
+    id: 'lead-no-cool',
+    customerName: 'Maya Brooks',
+    customerPhone: '+1 (512) 555-0114',
+    serviceType: 'No-cool diagnosis',
+    urgency: 'This afternoon',
+    location: 'Round Rock, TX 78664',
+    status: 'Contacted',
+    readiness: 'Working',
+    createdLabel: '14 minutes ago',
+  },
+  {
+    id: 'lead-maintenance',
+    customerName: 'Ryan Patel',
+    customerPhone: '+1 (512) 555-0172',
+    serviceType: 'Spring tune-up',
+    urgency: 'This week',
+    location: 'Cedar Park, TX 78613',
+    status: 'New',
+    readiness: 'Needs follow-up',
+    createdLabel: '31 minutes ago',
+  },
+];
+
+export const demoConversationMessages: DemoConversationMessage[] = [
+  {
+    id: 'msg-1',
+    sender: 'system',
+    label: 'CallbackCloser',
+    body: 'Hey Jamie, sorry we missed your call. What is going on with your HVAC?',
+    timestamp: '2:14 PM',
+  },
+  {
+    id: 'msg-2',
+    sender: 'customer',
+    label: 'Jamie Carter',
+    body: 'AC is not cooling at all.',
+    timestamp: '2:14 PM',
+  },
+  {
+    id: 'msg-3',
+    sender: 'system',
+    label: 'CallbackCloser',
+    body: 'Got it. Is this a repair or a new install?',
+    timestamp: '2:15 PM',
+  },
+  {
+    id: 'msg-4',
+    sender: 'customer',
+    label: 'Jamie Carter',
+    body: 'Repair.',
+    timestamp: '2:15 PM',
+  },
+  {
+    id: 'msg-5',
+    sender: 'system',
+    label: 'CallbackCloser',
+    body: 'How soon do you need someone out?',
+    timestamp: '2:15 PM',
+  },
+  {
+    id: 'msg-6',
+    sender: 'customer',
+    label: 'Jamie Carter',
+    body: 'Today if possible.',
+    timestamp: '2:16 PM',
+  },
+];
+
+export const demoHeroStats = [
+  {
+    label: 'Response speed',
+    value: '< 60 seconds',
+    detail: 'Missed callers hear back before they move on to the next HVAC company.',
+  },
+  {
+    label: 'Lead quality',
+    value: 'Service + urgency captured',
+    detail: 'Your team sees the repair need and timing before making the callback.',
+  },
+  {
+    label: 'Owner handoff',
+    value: 'Hot lead alert',
+    detail: 'Qualified jobs are handed off with the context needed to close fast.',
+  },
+];
+
+export const demoWorkflowSteps = [
+  {
+    title: 'Customer calls',
+    detail: 'A homeowner tries to book service while your team is on jobs.',
+  },
+  {
+    title: 'You miss it',
+    detail: 'Instead of going dark, CallbackCloser starts the follow-up immediately.',
+  },
+  {
+    title: 'We text and qualify',
+    detail: 'You get the job type, urgency, and callback context without chasing the lead.',
+  },
+];
+
+export const demoLeadDetail = {
+  customerName: 'Jamie Carter',
+  customerPhone: '+1 (512) 555-0189',
+  serviceType: 'Repair',
+  issueSummary: 'AC is not cooling',
+  urgency: 'Today',
+  location: 'Austin, TX 78704',
+  callbackWindow: 'Call back before 4 PM',
+  status: 'Qualified',
+  readiness: 'Hot Lead',
+  createdAt: 'Today · 2:14 PM',
+  qualifiedAt: '2:16 PM',
+};
+
+export const demoOwnerAlert = {
+  headline: 'New HVAC lead',
+  service: 'Repair',
+  urgency: 'Today',
+  customerName: 'Jamie Carter',
+  customerPhone: '+1 (512) 555-0189',
+  summary: 'AC is not cooling. Austin, TX 78704. Asked for service today and can answer before 4 PM.',
+  footer: 'View in dashboard',
+};
+
+export const demoTrustPoints = [
+  'Public demo only. No login, no real customer data, no live Twilio traffic.',
+  'Built to look like the real CallbackCloser lead workspace your team would use.',
+  'Safe to open during live sales calls when you need to show the value fast.',
+];

--- a/tests/public-demo-route.test.ts
+++ b/tests/public-demo-route.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+function read(relativePath: string) {
+  return readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+}
+
+test('public demo route is auth-free and built from isolated demo data', () => {
+  const demoPage = read('app/demo/page.tsx');
+  const demoData = read('lib/demo-data.ts');
+  const middleware = read('middleware.ts');
+
+  assert.match(demoPage, /Live Product Demo \| CallbackCloser/);
+  assert.match(demoPage, /PublicDemoReplay/);
+  assert.match(demoPage, /safe public walkthrough/i);
+  assert.match(demoPage, /No login, no real customer data, no live Twilio traffic/i);
+  assert.match(demoPage, /from ['"]@\/lib\/demo-data['"]/);
+  assert.doesNotMatch(demoPage, /requireBusiness|getBusinessForOwnerClerkId|db\./);
+  assert.doesNotMatch(middleware, /\/demo\(.\*\)/);
+  assert.match(demoData, /Jamie Carter/);
+  assert.match(demoData, /New HVAC lead/);
+});

--- a/tests/public-demo-route.test.ts
+++ b/tests/public-demo-route.test.ts
@@ -14,11 +14,13 @@ test('public demo route is auth-free and built from isolated demo data', () => {
 
   assert.match(demoPage, /Live Product Demo \| CallbackCloser/);
   assert.match(demoPage, /PublicDemoReplay/);
-  assert.match(demoPage, /safe public walkthrough/i);
-  assert.match(demoPage, /No login, no real customer data, no live Twilio traffic/i);
+  assert.match(demoPage, /Stop losing jobs when you miss the call/i);
+  assert.match(demoPage, /This is exactly what your customer sees after you miss their call/i);
+  assert.match(demoData, /No login, no real customer data, no live Twilio traffic/i);
   assert.match(demoPage, /from ['"]@\/lib\/demo-data['"]/);
   assert.doesNotMatch(demoPage, /requireBusiness|getBusinessForOwnerClerkId|db\./);
   assert.doesNotMatch(middleware, /\/demo\(.\*\)/);
   assert.match(demoData, /Jamie Carter/);
   assert.match(demoData, /New HVAC lead/);
+  assert.match(demoData, /Ready for callback/);
 });

--- a/tests/simulator-route.test.ts
+++ b/tests/simulator-route.test.ts
@@ -7,12 +7,12 @@ function read(relativePath: string) {
   return readFileSync(path.join(process.cwd(), relativePath), 'utf8');
 }
 
-test('homepage and nav both point See Demo directly to /simulator', () => {
+test('homepage and nav both point See Demo directly to /demo', () => {
   const home = read('app/page.tsx');
   const nav = read('components/public-site-nav.tsx');
 
-  assert.match(home, /href="\/simulator"/);
-  assert.match(nav, /href: '\/simulator'/);
+  assert.match(home, /href="\/demo"/);
+  assert.match(nav, /href: '\/demo'/);
 });
 
 test('simulator route is a distinct public page with its own metadata and disabled-state copy', () => {


### PR DESCRIPTION
## Summary
- add a public auth-free /demo route with realistic HVAC demo data
- reuse product styling for a lead inbox, conversation replay, owner alert, and clear CTAs
- add focused route coverage for demo safety and update public demo links

## Validation
- npm run typecheck
- npm run lint
- npm run build
- npm test