### PR TITLE
Fix business admin lookup test isolation

### DIFF
--- a/tests/business-admin-lookup.test.ts
+++ b/tests/business-admin-lookup.test.ts
@@ -5,8 +5,27 @@ import test from 'node:test';
 import { findBusinessByTwilioNumber, searchBusinessesForAdmin } from '../lib/business.ts';
 import { db } from '../lib/db.ts';
 
+function uniqueDigits(seed: string) {
+  const digits = seed.replace(/\D/g, '').padEnd(10, '7');
+  return digits.slice(-10);
+}
+
+function makeTwilioPhone(seed: string) {
+  const digits = uniqueDigits(seed);
+  return {
+    e164: `+1${digits}`,
+    formatted: `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`,
+  };
+}
+
+function makeSid(prefix: string, seed: string) {
+  const normalized = seed.replace(/-/g, '').padEnd(32, '0');
+  return `${prefix}${normalized.slice(0, 32)}`;
+}
+
 test('findBusinessByTwilioNumber matches legacy formatted database values by normalized number', async () => {
   const seed = randomUUID();
+  const twilioPhone = makeTwilioPhone(seed);
   const business = await db.business.create({
     data: {
       ownerClerkId: `lookup-owner-${seed}`,
@@ -17,16 +36,16 @@ test('findBusinessByTwilioNumber matches legacy formatted database values by nor
       serviceLabel1: 'Repair',
       serviceLabel2: 'Install',
       serviceLabel3: 'Maintenance',
-      twilioPhoneNumber: '(877) 748-0449',
-      twilioPrimaryPhoneNumber: '(877) 748-0449',
-      twilioPhoneNumberSid: `PN${seed.replace(/-/g, '').slice(0, 32)}`,
-      twilioPrimaryNumberSid: `PX${seed.replace(/-/g, '').slice(0, 32)}`,
+      twilioPhoneNumber: twilioPhone.formatted,
+      twilioPrimaryPhoneNumber: twilioPhone.formatted,
+      twilioPhoneNumberSid: makeSid('PN', `${seed}phone`),
+      twilioPrimaryNumberSid: makeSid('PX', `${seed}primary`),
     },
   });
 
   try {
-    const byE164 = await findBusinessByTwilioNumber('+18777480449');
-    const byFormatted = await findBusinessByTwilioNumber('(877) 748-0449');
+    const byE164 = await findBusinessByTwilioNumber(twilioPhone.e164);
+    const byFormatted = await findBusinessByTwilioNumber(twilioPhone.formatted);
 
     assert.equal(byE164?.id, business.id);
     assert.equal(byFormatted?.id, business.id);
@@ -37,6 +56,7 @@ test('findBusinessByTwilioNumber matches legacy formatted database values by nor
 
 test('searchBusinessesForAdmin finds businesses by owner email, business id, Twilio phone number, and number sid', async () => {
   const seed = randomUUID();
+  const twilioPhone = makeTwilioPhone(seed);
   const business = await db.business.create({
     data: {
       ownerClerkId: `search-owner-${seed}`,
@@ -48,11 +68,11 @@ test('searchBusinessesForAdmin finds businesses by owner email, business id, Twi
       serviceLabel1: 'Repair',
       serviceLabel2: 'Install',
       serviceLabel3: 'Maintenance',
-      twilioPhoneNumber: '+18777480449',
-      twilioPrimaryPhoneNumber: '+18777480449',
-      twilioPhoneNumberSid: `PN${seed.replace(/-/g, '').slice(0, 32)}`,
-      twilioPrimaryNumberSid: `PY${seed.replace(/-/g, '').slice(0, 32)}`,
-      twilioMessagingServiceSid: `MG${seed.replace(/-/g, '').slice(0, 32)}`,
+      twilioPhoneNumber: twilioPhone.e164,
+      twilioPrimaryPhoneNumber: twilioPhone.e164,
+      twilioPhoneNumberSid: makeSid('PN', `${seed}phone`),
+      twilioPrimaryNumberSid: makeSid('PY', `${seed}primary`),
+      twilioMessagingServiceSid: makeSid('MG', `${seed}service`),
       notificationSettings: {
         create: {
           ownerEmail: `owner-${seed.slice(0, 8)}@example.com`,
@@ -68,7 +88,7 @@ test('searchBusinessesForAdmin finds businesses by owner email, business id, Twi
   try {
     const byEmail = await searchBusinessesForAdmin(business.notificationSettings!.ownerEmail!);
     const byId = await searchBusinessesForAdmin(business.id);
-    const byPhone = await searchBusinessesForAdmin('(877) 748-0449');
+    const byPhone = await searchBusinessesForAdmin(twilioPhone.formatted);
     const bySid = await searchBusinessesForAdmin(business.twilioPhoneNumberSid!);
 
     assert.equal(byEmail.some((item) => item.id === business.id), true);


### PR DESCRIPTION
## Summary
- make  generate unique Twilio phone numbers and SIDs per run
- keep the lookup assertions intact for formatted and E.164 searches without depending on dirty local DB state
- restore full-suite repeatability so 
> callbackcloser@0.1.0 test
> tsx --test tests/*.test.ts

TAP version 13
# Subtest: pending owner helper generates recognizable placeholder ids
ok 1 - pending owner helper generates recognizable placeholder ids
  ---
  duration_ms: 16.346291
  ...
# Subtest: admin provisioning checklist surfaces incomplete rollout steps clearly
ok 2 - admin provisioning checklist surfaces incomplete rollout steps clearly
  ---
  duration_ms: 55.705708
  ...
# Subtest: admin provisioning checklist shows completed rollout when owner, messaging, and webhooks are ready
ok 3 - admin provisioning checklist shows completed rollout when owner, messaging, and webhooks are ready
  ---
  duration_ms: 13.379208
  ...
# Subtest: findBusinessByTwilioNumber matches legacy formatted database values by normalized number
ok 4 - findBusinessByTwilioNumber matches legacy formatted database values by normalized number
  ---
  duration_ms: 1549.046417
  ...
# Subtest: searchBusinessesForAdmin finds businesses by owner email, business id, Twilio phone number, and number sid
ok 5 - searchBusinessesForAdmin finds businesses by owner email, business id, Twilio phone number, and number sid
  ---
  duration_ms: 1117.153083
  ...
# Subtest: falls back to VERCEL_URL when NEXT_PUBLIC_APP_URL is missing
ok 6 - falls back to VERCEL_URL when NEXT_PUBLIC_APP_URL is missing
  ---
  duration_ms: 2.649708
  ...
# Subtest: falls back to VERCEL_URL when NEXT_PUBLIC_APP_URL is invalid
ok 7 - falls back to VERCEL_URL when NEXT_PUBLIC_APP_URL is invalid
  ---
  duration_ms: 0.969583
  ...
# Subtest: prefers valid NEXT_PUBLIC_APP_URL over Vercel fallback
ok 8 - prefers valid NEXT_PUBLIC_APP_URL over Vercel fallback
  ---
  duration_ms: 0.460791
  ...
# Subtest: founder billing bypass only activates for the configured founder-owned business
ok 9 - founder billing bypass only activates for the configured founder-owned business
  ---
  duration_ms: 3.683917
  ...
# Subtest: founder billing bypass maps the founder-owned smoke-test business to starter usage limits
ok 10 - founder billing bypass maps the founder-owned smoke-test business to starter usage limits
  ---
  duration_ms: 1.140375
  ...
# Subtest: billing and settings pages keep founder-only bypass copy out of the customer UI
ok 11 - billing and settings pages keep founder-only bypass copy out of the customer UI
  ---
  duration_ms: 1.506292
  ...
# Subtest: lead qualifies once service type and urgency are known
ok 12 - lead qualifies once service type and urgency are known
  ---
  duration_ms: 3.84875
  ...
# Subtest: lead can qualify from callback intent even without urgency
ok 13 - lead can qualify from callback intent even without urgency
  ---
  duration_ms: 0.925542
  ...
# Subtest: lead stays new until required qualification fields are present
ok 14 - lead stays new until required qualification fields are present
  ---
  duration_ms: 0.902167
  ...
# Subtest: lead inbox stays list-only while lead detail is the main action workspace
ok 15 - lead inbox stays list-only while lead detail is the main action workspace
  ---
  duration_ms: 4.482875
  ...
# Subtest: legal public pages exist with required headings
ok 16 - legal public pages exist with required headings
  ---
  duration_ms: 4.04525
  ...
# Subtest: sms consent page includes required disclosures and trust links
ok 17 - sms consent page includes required disclosures and trust links
  ---
  duration_ms: 2.962125
  ...
# Subtest: public-facing surfaces link to trust and contact routes
ok 18 - public-facing surfaces link to trust and contact routes
  ---
  duration_ms: 3.46675
  ...
# Subtest: live smoke readiness passes when all blockers are satisfied
ok 19 - live smoke readiness passes when all blockers are satisfied
  ---
  duration_ms: 2.018917
  ...
# Subtest: live smoke readiness blocks when billing is inactive
ok 20 - live smoke readiness blocks when billing is inactive
  ---
  duration_ms: 1.622
  ...
# Subtest: live smoke readiness blocks when assigned Twilio number cannot be verified in the account
ok 21 - live smoke readiness blocks when assigned Twilio number cannot be verified in the account
  ---
  duration_ms: 0.580333
  ...
# Subtest: live smoke readiness blocks when demo mode is enabled
ok 22 - live smoke readiness blocks when demo mode is enabled
  ---
  duration_ms: 0.837666
  ...
# Subtest: live smoke readiness blocks when owner notify phone has opted out or capacity is exhausted
ok 23 - live smoke readiness blocks when owner notify phone has opted out or capacity is exhausted
  ---
  duration_ms: 0.556542
  ...
# app.error {
#   source: 'test.route',
#   event: 'synthetic_error',
#   correlationId: 'corr-test',
#   error: 'boom',
#   metadata: {},
#   timestamp: '2026-04-16T14:09:22.494Z'
# }
# Subtest: getCorrelationIdFromRequest prefers explicit x-correlation-id header
ok 24 - getCorrelationIdFromRequest prefers explicit x-correlation-id header
  ---
  duration_ms: 150.291583
  ...
# Subtest: getCorrelationIdFromRequest falls back to x-request-id when needed
ok 25 - getCorrelationIdFromRequest falls back to x-request-id when needed
  ---
  duration_ms: 1.496583
  ...
# Subtest: withCorrelationIdHeader sets response header
ok 26 - withCorrelationIdHeader sets response header
  ---
  duration_ms: 17.802084
  ...
# Subtest: reportApplicationError is safe when alerts are disabled
ok 27 - reportApplicationError is safe when alerts are disabled
  ---
  duration_ms: 16.103875
  ...
# Subtest: owner notification service claims a lead once and dedupes per channel
ok 28 - owner notification service claims a lead once and dedupes per channel
  ---
  duration_ms: 4.809792
  ...
# Subtest: normalizePhoneNumberToE164 converts common US inputs into E.164
ok 29 - normalizePhoneNumberToE164 converts common US inputs into E.164
  ---
  duration_ms: 7.36575
  ...
# Subtest: normalizePhoneNumber preserves raw values for non-E.164-compatible input while strict normalization rejects them
ok 30 - normalizePhoneNumber preserves raw values for non-E.164-compatible input while strict normalization rejects them
  ---
  duration_ms: 1.204
  ...
# Subtest: phoneNumbersEqual matches equivalent values and audit masking hides most digits
ok 31 - phoneNumbersEqual matches equivalent values and audit masking hides most digits
  ---
  duration_ms: 1.81625
  ...
# Subtest: settings page no longer exposes shared Twilio number inventory
ok 32 - settings page no longer exposes shared Twilio number inventory
  ---
  duration_ms: 4.794042
  ...
# Subtest: landing page product promise stays aligned to missed-call recovery workflow
ok 33 - landing page product promise stays aligned to missed-call recovery workflow
  ---
  duration_ms: 2.595458
  ...
# Subtest: message delivery issue helpers flag failed and fallback statuses
ok 34 - message delivery issue helpers flag failed and fallback statuses
  ---
  duration_ms: 0.370834
  ...
# Subtest: blocks production when demo mode is enabled without override
ok 35 - blocks production when demo mode is enabled without override
  ---
  duration_ms: 1.340541
  ...
# Subtest: allows production demo mode only with explicit override
ok 36 - allows production demo mode only with explicit override
  ---
  duration_ms: 0.502417
  ...
# Subtest: does not block demo mode in non-production
ok 37 - does not block demo mode in non-production
  ---
  duration_ms: 0.208541
  ...
# Subtest: runClerkPreflight passes for same-origin auth URLs
ok 38 - runClerkPreflight passes for same-origin auth URLs
  ---
  duration_ms: 9.585834
  ...
# Subtest: runClerkPreflight fails when sign-in URL origin mismatches app URL
ok 39 - runClerkPreflight fails when sign-in URL origin mismatches app URL
  ---
  duration_ms: 0.753667
  ...
# Subtest: runStripePreflight fails when webhook secret is missing
ok 40 - runStripePreflight fails when webhook secret is missing
  ---
  duration_ms: 3.49775
  ...
# Subtest: runTwilioPreflight fails when explicit configured URLs drift from NEXT_PUBLIC_APP_URL
ok 41 - runTwilioPreflight fails when explicit configured URLs drift from NEXT_PUBLIC_APP_URL
  ---
  duration_ms: 6.021791
  ...
# Subtest: runTwilioPreflight passes in production signature mode without a shared webhook token
ok 42 - runTwilioPreflight passes in production signature mode without a shared webhook token
  ---
  duration_ms: 0.773291
  ...
# Subtest: runTwilioPreflight expects tokenized URLs only in explicit token mode
ok 43 - runTwilioPreflight expects tokenized URLs only in explicit token mode
  ---
  duration_ms: 4.697333
  ...
# Subtest: runDatabasePreflight reports pass and fail outcomes
ok 44 - runDatabasePreflight reports pass and fail outcomes
  ---
  duration_ms: 0.283666
  ...
# Subtest: runProviderPreflight aggregates provider checks and exposes fail count
ok 45 - runProviderPreflight aggregates provider checks and exposes fail count
  ---
  duration_ms: 15.599042
  ...
# Subtest: public CTA links do not nest button elements inside next/link anchors
ok 46 - public CTA links do not nest button elements inside next/link anchors
  ---
  duration_ms: 2.8015
  ...
# Subtest: clerk auth surfaces use explicit path routing and fallback redirects
ok 47 - clerk auth surfaces use explicit path routing and fallback redirects
  ---
  duration_ms: 1.079709
  ...
# Subtest: consumeRateLimit blocks once limit is exceeded and resets after window
ok 48 - consumeRateLimit blocks once limit is exceeded and resets after window
  ---
  duration_ms: 1.281166
  ...
# Subtest: getClientIpAddress prefers x-forwarded-for first value
ok 49 - getClientIpAddress prefers x-forwarded-for first value
  ---
  duration_ms: 50.569917
  ...
# Subtest: getRateLimitNumber uses fallback for invalid env input
ok 50 - getRateLimitNumber uses fallback for invalid env input
  ---
  duration_ms: 0.356459
  ...
# Subtest: recording access denies unauthenticated requests
ok 51 - recording access denies unauthenticated requests
  ---
  duration_ms: 7.129709
  ...
# Subtest: recording access denies users outside the lead business
ok 52 - recording access denies users outside the lead business
  ---
  duration_ms: 0.562541
  ...
# Subtest: recording access denies when no recording URL is present
ok 53 - recording access denies when no recording URL is present
  ---
  duration_ms: 0.503167
  ...
# Subtest: recording access allows authenticated owner with recording URL
ok 54 - recording access allows authenticated owner with recording URL
  ---
  duration_ms: 0.437709
  ...
# Subtest: recording access denies when business owner id is missing
ok 55 - recording access denies when business owner id is missing
  ---
  duration_ms: 0.514833
  ...
# Subtest: recording URL validation requires https and Twilio recording host/path allowlist
ok 56 - recording URL validation requires https and Twilio recording host/path allowlist
  ---
  duration_ms: 10.085375
  ...
# Subtest: recording URL normalization returns Twilio media URL and rejects invalid input
ok 57 - recording URL normalization returns Twilio media URL and rejects invalid input
  ---
  duration_ms: 1.012375
  ...
# Subtest: allows same-origin requests via Origin header
ok 58 - allows same-origin requests via Origin header
  ---
  duration_ms: 141.824833
  ...
# Subtest: rejects mismatched Origin header
ok 59 - rejects mismatched Origin header
  ---
  duration_ms: 0.862083
  ...
# Subtest: allows same-origin referrer when Origin header is missing
ok 60 - allows same-origin referrer when Origin header is missing
  ---
  duration_ms: 1.007792
  ...
# Subtest: allows requests with no Origin/Referrer (non-browser clients)
ok 61 - allows requests with no Origin/Referrer (non-browser clients)
  ---
  duration_ms: 5.670584
  ...
# Subtest: getSecurityHeaders includes baseline headers
ok 62 - getSecurityHeaders includes baseline headers
  ---
  duration_ms: 6.750416
  ...
# Subtest: getSecurityHeaders includes HSTS in production
ok 63 - getSecurityHeaders includes HSTS in production
  ---
  duration_ms: 2.816584
  ...
# Subtest: public simulator is gated and isolated from real customer delivery
ok 64 - public simulator is gated and isolated from real customer delivery
  ---
  duration_ms: 5.170833
  ...
# Subtest: homepage and nav both point See Demo directly to /simulator
ok 65 - homepage and nav both point See Demo directly to /simulator
  ---
  duration_ms: 5.681875
  ...
# Subtest: simulator route is a distinct public page with its own metadata and disabled-state copy
ok 66 - simulator route is a distinct public page with its own metadata and disabled-state copy
  ---
  duration_ms: 1.793083
  ...
# Subtest: protected app surfaces use shared tenant-scoped access helpers
ok 67 - protected app surfaces use shared tenant-scoped access helpers
  ---
  duration_ms: 5.387833
  ...
# Subtest: tenant-scoped helpers block cross-business reads and writes while preserving own access
ok 68 - tenant-scoped helpers block cross-business reads and writes while preserving own access
  ---
  duration_ms: 4905.245542
  ...
# Subtest: voice TwiML includes recording attributes on <Dial>
ok 69 - voice TwiML includes recording attributes on <Dial>
  ---
  duration_ms: 12.870167
  ...
# Subtest: extractTwilioRecordingMetadata parses recording callback fields
ok 70 - extractTwilioRecordingMetadata parses recording callback fields
  ---
  duration_ms: 3.871125
  ...
# Subtest: extractTwilioRecordingMetadata returns null when payload has no recording fields
ok 71 - extractTwilioRecordingMetadata returns null when payload has no recording fields
  ---
  duration_ms: 0.375125
  ...
# twilio.webhook-auth {
#   route: 'webhook-auth',
#   event: 'missing_x_twilio_signature_header',
#   decision: 'reject'
# }
# twilio.webhook-auth {
#   route: 'webhook-auth',
#   event: 'production_requires_signature_validation',
#   decision: 'reject',
#   nodeEnv: 'production',
#   vercelEnv: null
# }
# app.error {
#   source: 'twilio.webhook-auth',
#   event: 'production_requires_signature_validation',
#   correlationId: 'n/a',
#   error: 'unknown_error',
#   metadata: { decision: 'reject', nodeEnv: 'production', vercelEnv: null },
#   timestamp: '2026-04-16T14:09:25.891Z'
# }
# Subtest: accepts valid X-Twilio-Signature when signature validation is enabled
ok 72 - accepts valid X-Twilio-Signature when signature validation is enabled
  ---
  duration_ms: 4.131958
  ...
# Subtest: rejects invalid X-Twilio-Signature when signature validation is enabled
ok 73 - rejects invalid X-Twilio-Signature when signature validation is enabled
  ---
  duration_ms: 2.1885
  ...
# Subtest: falls back to shared token in non-production when signature validation is enabled
ok 74 - falls back to shared token in non-production when signature validation is enabled
  ---
  duration_ms: 4.820167
  ...
# Subtest: rejects shared-token auth mode in production when signature validation is disabled
ok 75 - rejects shared-token auth mode in production when signature validation is disabled
  ---
  duration_ms: 3.502041
  ...
# Subtest: does not allow shared-token fallback in production when signature is missing
ok 76 - does not allow shared-token fallback in production when signature is missing
  ---
  duration_ms: 0.720083
  ...
# Subtest: rejects the old shared-token fallback path for subaccount webhooks in production
ok 77 - rejects the old shared-token fallback path for subaccount webhooks in production
  ---
  duration_ms: 0.359333
  ...
# Subtest: accepts valid subaccount X-Twilio-Signature in production with subaccount auth token resolution
ok 78 - accepts valid subaccount X-Twilio-Signature in production with subaccount auth token resolution
  ---
  duration_ms: 0.746042
  ...
# Subtest: classifies STOP-like / START-like / HELP commands case-insensitively
ok 79 - classifies STOP-like / START-like / HELP commands case-insensitively
  ---
  duration_ms: 3.284958
  ...
# Subtest: STOP flow persists opt-out and returns compliant confirmation
ok 80 - STOP flow persists opt-out and returns compliant confirmation
  ---
  duration_ms: 16.694042
  ...
# Subtest: START flow clears opt-out and returns confirmation
ok 81 - START flow clears opt-out and returns confirmation
  ---
  duration_ms: 2.929625
  ...
# Subtest: HELP flow returns help text without writing consent state
ok 82 - HELP flow returns help text without writing consent state
  ---
  duration_ms: 0.659875
  ...
# Subtest: non-compliance inbound SMS returns handled=false
ok 83 - non-compliance inbound SMS returns handled=false
  ---
  duration_ms: 1.158333
  ...
# Subtest: status webhook retry responses are stable across replay attempts
ok 84 - status webhook retry responses are stable across replay attempts
  ---
  duration_ms: 143.423292
  ...
# Subtest: sms webhook retry responses are stable across replay attempts
ok 85 - sms webhook retry responses are stable across replay attempts
  ---
  duration_ms: 4.325916
  ...
# Subtest: webhook update builder syncs all webhook targets by default
ok 86 - webhook update builder syncs all webhook targets by default
  ---
  duration_ms: 1.820417
  ...
# Subtest: webhook update builder can sync only voice or only sms/status targets
ok 87 - webhook update builder can sync only voice or only sms/status targets
  ---
  duration_ms: 0.519708
  ...
# Subtest: claimUsageLimitNotification returns true only for first claim
ok 88 - claimUsageLimitNotification returns true only for first claim
  ---
  duration_ms: 2.277625
  ...
# Subtest: formatUsageTierLabel returns readable tier names
ok 89 - formatUsageTierLabel returns readable tier names
  ---
  duration_ms: 0.770083
  ...
# Subtest: formatUsageSummary returns used and remaining values
ok 90 - formatUsageSummary returns used and remaining values
  ---
  duration_ms: 0.584208
  ...
# Subtest: resolveAutomationBlockReason prioritizes inactive billing and usage limits
ok 91 - resolveAutomationBlockReason prioritizes inactive billing and usage limits
  ---
  duration_ms: 0.2675
  ...
# Subtest: describeAutomationBlockReason includes blocked counts and usage values
ok 92 - describeAutomationBlockReason includes blocked counts and usage values
  ---
  duration_ms: 0.1655
  ...
# Subtest: getCurrentMonthWindowUtc uses America/New_York boundaries (EST month)
ok 93 - getCurrentMonthWindowUtc uses America/New_York boundaries (EST month)
  ---
  duration_ms: 33.006292
  ...
# Subtest: getCurrentMonthWindowUtc handles DST shift across March in America/New_York
ok 94 - getCurrentMonthWindowUtc handles DST shift across March in America/New_York
  ---
  duration_ms: 0.191542
  ...
# Subtest: starter and pro limits block when used equals limit
ok 95 - starter and pro limits block when used equals limit
  ---
  duration_ms: 0.153417
  ...
# Subtest: resolveUsageTierFromSubscription maps active stripe price IDs to tiers
ok 96 - resolveUsageTierFromSubscription maps active stripe price IDs to tiers
  ---
  duration_ms: 0.301541
  ...
1..96
# tests 96
# suites 0
# pass 96
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 8506.512208 goes green again

## Validation
- npx tsx --test tests/business-admin-lookup.test.ts
- npx tsx --test tests/business-admin-lookup.test.ts
- npm install
- npm run typecheck
- npm run lint
- npm run test

## PR triage
- #38 should be rebased after this lands because it carries an overlapping version of the same test fix
- #39 should be narrowed before merge because it stacks on #38 and includes stale env/test drift
- #33 is obsolete as written because current main is already business-scoped for Twilio messaging services
- #27 is obsolete because provider preflight already exists on main