### PR TITLE
Build owner-first admin operator dashboard

### DIFF
--- a/app/admin/[businessId]/page.tsx
+++ b/app/admin/[businessId]/page.tsx
@@ -2,12 +2,22 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 import {
+  archiveBusinessAction,
   connectBusinessOwnerAction,
+  deleteTestBusinessAction,
   provisionBusinessAction,
   resyncBusinessWebhooksAction,
+  restoreBusinessAction,
   saveAdminBusinessProfileAction,
+  sendBusinessTestSmsAction,
   setBusinessProvisioningStatusAction,
 } from '@/app/admin/actions';
+import {
+  buildAdminBusinessEvents,
+  buildAdminNextStep,
+  canDeleteTestBusiness,
+  isBusinessArchived,
+} from '@/lib/admin-dashboard';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -25,7 +35,15 @@ import {
   listAdminTwilioNumbers,
 } from '@/lib/admin-provisioning';
 import { db } from '@/lib/db';
-import { formatDateTime } from '@/lib/lead-presenters';
+import {
+  formatDateTime,
+  formatRelativeTime,
+  formatMessageStatus,
+  getLeadCallbackState,
+  getLeadStatusBadgeVariant,
+  leadReadinessLabels,
+  leadStatusLabels,
+} from '@/lib/lead-presenters';
 import { getManagedTextingNumber, getManagedTwilioStatusSummary, managedTwilioStatusLabels } from '@/lib/managed-twilio';
 import { formatPhoneForDisplay } from '@/lib/phone';
 import { getBusinessBillingAccessState } from '@/lib/subscription';
@@ -43,11 +61,19 @@ const changedFieldLabels: Record<string, string> = {
   a2pCampaignSid: 'A2P campaign SID',
   a2pFailureReason: 'A2P failure reason',
   managedTwilioStatus: 'managed Twilio status',
+  isTestBusiness: 'test business flag',
 };
 
 function getQueryValue(searchParams: Record<string, string | string[] | undefined> | undefined, key: string) {
   const value = searchParams?.[key];
   return typeof value === 'string' ? value : null;
+}
+
+function getNextStepBadgeVariant(tone: 'healthy' | 'pending' | 'attention' | 'paused') {
+  if (tone === 'healthy') return 'success' as const;
+  if (tone === 'attention') return 'destructive' as const;
+  if (tone === 'paused') return 'outline' as const;
+  return 'secondary' as const;
 }
 
 function StatusButton({
@@ -85,7 +111,7 @@ function WebhookResyncButton({
     <form action={resyncBusinessWebhooksAction}>
       <input type="hidden" name="businessId" value={businessId} />
       <input type="hidden" name="target" value={target} />
-      <Button type="submit" variant="outline">
+      <Button type="submit" size="sm" variant="outline">
         {label}
       </Button>
     </form>
@@ -101,37 +127,85 @@ export default async function AdminBusinessDetailPage({
 }) {
   await requireAdmin();
 
-  const [
-    business,
-    successfulLeadCount,
-    leadCount,
-    callCount,
-    messageCount,
-  ] = await Promise.all([
-    db.business.findUnique({
-      where: { id: params.businessId },
-      include: {
-        notificationSettings: true,
-      },
-    }),
-    db.lead.count({
-      where: {
-        businessId: params.businessId,
-        OR: [{ ownerNotifiedAt: { not: null } }, { notifiedAt: { not: null } }],
-      },
-    }),
-    db.lead.count({ where: { businessId: params.businessId } }),
-    db.call.count({ where: { businessId: params.businessId } }),
-    db.message.count({ where: { businessId: params.businessId } }),
-  ]);
+  const [business, successfulLeadCount, leadCount, callCount, messageCount, recentLeads, recentCalls, recentMessages, recentOwnerNotifications] =
+    await Promise.all([
+      db.business.findUnique({
+        where: { id: params.businessId },
+        include: {
+          notificationSettings: true,
+        },
+      }),
+      db.lead.count({
+        where: {
+          businessId: params.businessId,
+          OR: [{ ownerNotifiedAt: { not: null } }, { notifiedAt: { not: null } }],
+        },
+      }),
+      db.lead.count({ where: { businessId: params.businessId } }),
+      db.call.count({ where: { businessId: params.businessId } }),
+      db.message.count({ where: { businessId: params.businessId } }),
+      db.lead.findMany({
+        where: { businessId: params.businessId },
+        orderBy: [{ lastInteractionAt: 'desc' }, { createdAt: 'desc' }],
+        take: 6,
+        select: {
+          id: true,
+          status: true,
+          readiness: true,
+          billingRequired: true,
+          smsState: true,
+          summary: true,
+          notifiedAt: true,
+          ownerNotifiedAt: true,
+          createdAt: true,
+          lastInteractionAt: true,
+        },
+      }),
+      db.call.findMany({
+        where: { businessId: params.businessId },
+        orderBy: { createdAt: 'desc' },
+        take: 6,
+        select: {
+          id: true,
+          status: true,
+          missed: true,
+          answered: true,
+          dialCallStatus: true,
+          createdAt: true,
+        },
+      }),
+      db.message.findMany({
+        where: { businessId: params.businessId, direction: 'OUTBOUND' },
+        orderBy: { createdAt: 'desc' },
+        take: 8,
+        select: {
+          id: true,
+          leadId: true,
+          participant: true,
+          direction: true,
+          status: true,
+          body: true,
+          createdAt: true,
+        },
+      }),
+      db.ownerNotification.findMany({
+        where: { businessId: params.businessId },
+        orderBy: { createdAt: 'desc' },
+        take: 8,
+        select: {
+          id: true,
+          channel: true,
+          status: true,
+          error: true,
+          createdAt: true,
+          destination: true,
+        },
+      }),
+    ]);
 
   if (!business) notFound();
 
-  const [
-    ownerState,
-    webhookSnapshot,
-    availableNumbers,
-  ] = await Promise.all([
+  const [ownerState, webhookSnapshot, availableNumbers] = await Promise.all([
     getAdminOwnerState(business, business.notificationSettings),
     getTwilioWebhookSnapshot(business),
     listAdminTwilioNumbers(business),
@@ -147,6 +221,19 @@ export default async function AdminBusinessDetailPage({
     ownerConnected: ownerState.connected,
     webhookSnapshot,
   });
+  const nextStep = buildAdminNextStep({
+    business,
+    notificationSettings: business.notificationSettings,
+    ownerConnected: ownerState.connected,
+  });
+  const recentEvents = buildAdminBusinessEvents({
+    business,
+    messages: recentMessages,
+    ownerNotifications: recentOwnerNotifications,
+    leads: recentLeads,
+    calls: recentCalls,
+  }).slice(0, 10);
+  const assignedNumber = getManagedTextingNumber(business);
 
   const created = getQueryValue(searchParams, 'created') === '1';
   const saved = getQueryValue(searchParams, 'saved') === '1';
@@ -154,6 +241,9 @@ export default async function AdminBusinessDetailPage({
   const provisioned = getQueryValue(searchParams, 'provisioned') === '1';
   const synced = getQueryValue(searchParams, 'synced');
   const statusSaved = getQueryValue(searchParams, 'statusSaved');
+  const testSms = getQueryValue(searchParams, 'testSms') === '1';
+  const archived = getQueryValue(searchParams, 'archived') === '1';
+  const restored = getQueryValue(searchParams, 'restored') === '1';
   const error = getQueryValue(searchParams, 'error');
   const changed = (getQueryValue(searchParams, 'changed') || '')
     .split(',')
@@ -165,22 +255,35 @@ export default async function AdminBusinessDetailPage({
     <div className="container space-y-6 py-8">
       <div className="space-y-2">
         <Link className="text-sm text-muted-foreground underline underline-offset-4" href="/admin">
-          Back to admin dashboard
+          Back to operator board
         </Link>
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <h1 className="text-2xl font-semibold tracking-tight">{business.name}</h1>
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-3xl font-semibold tracking-tight">{business.name}</h1>
+              {business.isTestBusiness ? <Badge variant="outline">Test</Badge> : null}
+              {isBusinessArchived(business) ? <Badge variant="outline">Archived</Badge> : null}
+            </div>
             <p className="text-sm text-muted-foreground">
-              Internal provisioning console for owner setup, Twilio configuration, webhook sync, and go-live status.
+              One page for business health, recovery actions, safe editing, support workspace access, and recent operator context.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Badge variant={getAdminProvisioningStatusVariant(business.provisioningStatus)}>
-              {adminProvisioningStatusLabels[business.provisioningStatus]}
-            </Badge>
-            <Badge variant={rolloutStatus.badgeVariant}>{rolloutStatus.label}</Badge>
-            <Badge variant={customerStatus.badgeVariant}>{customerStatus.label}</Badge>
+            <Link className={buttonVariants({ variant: 'default' })} href={`/admin/${business.id}/workspace`}>
+              Open support workspace
+            </Link>
+            <Link className={buttonVariants({ variant: 'outline' })} href="/admin">
+              Back to board
+            </Link>
           </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant={getAdminProvisioningStatusVariant(business.provisioningStatus)}>
+            {adminProvisioningStatusLabels[business.provisioningStatus]}
+          </Badge>
+          <Badge variant={rolloutStatus.badgeVariant}>{rolloutStatus.label}</Badge>
+          <Badge variant={customerStatus.badgeVariant}>{customerStatus.label}</Badge>
+          <Badge variant={getNextStepBadgeVariant(nextStep.tone)}>{nextStep.title}</Badge>
         </div>
       </div>
 
@@ -199,35 +302,106 @@ export default async function AdminBusinessDetailPage({
               : 'Owner state updated.'}
         </div>
       ) : null}
-      {provisioned ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Provisioning finished. Review the checklist and mark the business live when ready.</div> : null}
+      {provisioned ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Provisioning finished. Review the health sections below.</div> : null}
       {synced ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Webhook sync complete for {synced.toLowerCase()}.</div> : null}
       {statusSaved ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business status updated to {statusSaved.replace(/_/g, ' ')}.</div> : null}
+      {testSms ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Admin test SMS sent.</div> : null}
+      {archived ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business archived safely. Automation is paused.</div> : null}
+      {restored ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business restored and ready for review.</div> : null}
       {error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{error}</div> : null}
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
-        {[
-          { label: 'Leads', value: leadCount },
-          { label: 'Calls', value: callCount },
-          { label: 'Messages', value: messageCount },
-          { label: 'Qualified alerts', value: successfulLeadCount },
-          { label: 'Billing', value: billingAccess.billingActive ? 'Active' : business.subscriptionStatus.toLowerCase() },
-        ].map((item) => (
-          <Card key={item.label} className="bg-card/90">
-            <CardHeader className="pb-2">
-              <CardDescription>{item.label}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <p className="text-xl font-semibold">{item.value}</p>
-            </CardContent>
-          </Card>
-        ))}
+      <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
+        <Card className="border-primary/20 bg-primary/5">
+          <CardHeader>
+            <CardTitle>What should I do next?</CardTitle>
+            <CardDescription>Plain-English guidance to keep the founder out of the weeds.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="rounded-xl border bg-background/80 p-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-lg font-semibold">{nextStep.title}</p>
+                  <p className="mt-2 max-w-3xl text-sm text-muted-foreground">{nextStep.detail}</p>
+                </div>
+                <Badge variant={getNextStepBadgeVariant(nextStep.tone)}>{nextStep.actionLabel}</Badge>
+              </div>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              {[
+                { label: 'Leads', value: leadCount },
+                { label: 'Calls', value: callCount },
+                { label: 'Messages', value: messageCount },
+                { label: 'Qualified alerts', value: successfulLeadCount },
+              ].map((item) => (
+                <div key={item.label} className="rounded-xl border bg-background/80 p-4">
+                  <p className="text-sm text-muted-foreground">{item.label}</p>
+                  <p className="mt-2 text-2xl font-semibold">{item.value}</p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-card/90">
+          <CardHeader>
+            <CardTitle>Quick actions</CardTitle>
+            <CardDescription>Common fixes and shortcuts should be one click away.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap gap-2">
+              <form action={provisionBusinessAction}>
+                <input type="hidden" name="businessId" value={business.id} />
+                <input type="hidden" name="mode" value="NEW_NUMBER" />
+                <Button size="sm" type="submit">
+                  Re-run provisioning
+                </Button>
+              </form>
+              <WebhookResyncButton businessId={business.id} target="ALL" label="Re-sync webhooks" />
+              {business.provisioningStatus === 'PAUSED' ? (
+                <StatusButton businessId={business.id} status="ONBOARDING" label="Resume automation" />
+              ) : (
+                <StatusButton businessId={business.id} status="PAUSED" label="Pause automation" variant="outline" />
+              )}
+              {business.provisioningStatus === 'LIVE' ? null : <StatusButton businessId={business.id} status="LIVE" label="Mark live" variant="secondary" />}
+            </div>
+
+            <form action={sendBusinessTestSmsAction} className="rounded-xl border bg-background/80 p-4">
+              <input type="hidden" name="businessId" value={business.id} />
+              <div className="space-y-2">
+                <Label htmlFor="destinationPhone">Send test SMS</Label>
+                <Input
+                  id="destinationPhone"
+                  name="destinationPhone"
+                  type="tel"
+                  defaultValue={business.notificationSettings?.ownerPhone || business.notifyPhone || ''}
+                  placeholder="+1 555 123 4567"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Sends a short admin verification message from the assigned business line to the destination above.
+                </p>
+              </div>
+              <Button className="mt-3" size="sm" type="submit" variant="outline">
+                Send test SMS
+              </Button>
+            </form>
+
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`/admin/${business.id}/workspace`}>
+                Open support workspace
+              </Link>
+              <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`#recent-events`}>
+                Open recent events
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
       <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
         <Card className="bg-card/90">
           <CardHeader>
-            <CardTitle>Business identity</CardTitle>
-            <CardDescription>Save the customer profile, routing defaults, owner alerts, internal notes, and admin-only Twilio mapping fields.</CardDescription>
+            <CardTitle>Business info</CardTitle>
+            <CardDescription>Edit the business, owner contact settings, internal notes, and admin-only Twilio mapping safely from one place.</CardDescription>
           </CardHeader>
           <CardContent>
             <form action={saveAdminBusinessProfileAction} className="grid gap-4 md:grid-cols-2">
@@ -238,18 +412,11 @@ export default async function AdminBusinessDetailPage({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="ownerName">Owner name</Label>
-                <Input id="ownerName" name="ownerName" defaultValue={business.ownerName || ''} placeholder="Casey Owner" />
+                <Input id="ownerName" name="ownerName" defaultValue={business.ownerName || ''} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="ownerEmail">Owner email</Label>
-                <Input
-                  id="ownerEmail"
-                  name="ownerEmail"
-                  type="email"
-                  defaultValue={business.notificationSettings?.ownerEmail || ''}
-                  placeholder="owner@business.com"
-                  required
-                />
+                <Input id="ownerEmail" name="ownerEmail" type="email" defaultValue={business.notificationSettings?.ownerEmail || ''} required />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="ownerPhone">Owner alert phone</Label>
@@ -258,7 +425,6 @@ export default async function AdminBusinessDetailPage({
                   name="ownerPhone"
                   type="tel"
                   defaultValue={business.notificationSettings?.ownerPhone || business.notifyPhone || ''}
-                  placeholder="+1 555 123 4567"
                 />
               </div>
               <div className="space-y-2">
@@ -271,14 +437,7 @@ export default async function AdminBusinessDetailPage({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="missedCallSeconds">Missed-call timeout</Label>
-                <Input
-                  id="missedCallSeconds"
-                  name="missedCallSeconds"
-                  type="number"
-                  min={5}
-                  max={90}
-                  defaultValue={business.missedCallSeconds}
-                />
+                <Input id="missedCallSeconds" name="missedCallSeconds" type="number" min={5} max={90} defaultValue={business.missedCallSeconds} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="serviceLabel1">Primary service label</Label>
@@ -292,88 +451,74 @@ export default async function AdminBusinessDetailPage({
                 <Label htmlFor="serviceLabel3">Tertiary service label</Label>
                 <Input id="serviceLabel3" name="serviceLabel3" defaultValue={business.serviceLabel3} />
               </div>
+              <label className="md:col-span-2 flex items-start gap-2 rounded-xl border bg-background/80 p-3 text-sm">
+                <input defaultChecked={business.isTestBusiness} name="isTestBusiness" type="checkbox" value="true" />
+                <span>Test/demo business. Required for safe destructive delete after archive.</span>
+              </label>
               <div className="space-y-3 md:col-span-2">
                 <Label htmlFor="internalNotes">Internal notes</Label>
                 <Textarea
                   id="internalNotes"
                   name="internalNotes"
                   defaultValue={business.internalNotes || ''}
-                  placeholder="Store launch notes, customer preferences, or any follow-up needed for this rollout."
                   rows={5}
+                  placeholder="Store launch notes, handoff context, or anything the founder should not have to remember."
                 />
               </div>
+
               <div className="md:col-span-2 space-y-3 rounded-xl border bg-background/80 p-4">
                 <div>
-                  <p className="text-sm font-medium">Owner notifications</p>
-                  <p className="text-xs text-muted-foreground">These control the owner alerts CallbackCloser sends when a lead is qualified.</p>
+                  <p className="text-sm font-medium">Automation settings</p>
+                  <p className="text-xs text-muted-foreground">Critical owner alert toggles and operational state.</p>
                 </div>
-                <div className="flex flex-wrap gap-4 text-sm">
-                  <label className="flex items-center gap-2">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <label className="flex items-center gap-2 text-sm">
                     <input type="checkbox" name="notifySms" defaultChecked={business.notificationSettings?.notifySms ?? true} />
-                    SMS alerts
+                    Owner SMS alerts
                   </label>
-                  <label className="flex items-center gap-2">
+                  <label className="flex items-center gap-2 text-sm">
                     <input type="checkbox" name="notifyEmail" defaultChecked={business.notificationSettings?.notifyEmail ?? true} />
-                    Email alerts
+                    Owner email alerts
                   </label>
-                  <label className="flex items-center gap-2">
+                  <label className="flex items-center gap-2 text-sm">
                     <input type="checkbox" name="notifyInApp" defaultChecked={business.notificationSettings?.notifyInApp ?? true} />
                     In-app alerts
                   </label>
-                  <label className="flex items-center gap-2">
+                  <label className="flex items-center gap-2 text-sm">
                     <input type="checkbox" name="urgentOnly" defaultChecked={business.notificationSettings?.urgentOnly ?? false} />
                     Urgent leads only
                   </label>
                 </div>
               </div>
+
               <div className="md:col-span-2 space-y-4 rounded-xl border border-primary/20 bg-primary/5 p-4">
                 <div>
-                  <p className="text-sm font-medium">Internal database editor</p>
+                  <p className="text-sm font-medium">Admin Twilio editor</p>
                   <p className="text-xs text-muted-foreground">
-                    Internal admin-only. Twilio numbers are normalized to E.164 on save, the primary and legacy lookup fields are updated together, and
-                    manual mapping changes clear the last webhook sync timestamp until the next resync confirms the assignment.
+                    Use this for safe business corrections, manual provisioning repair, or A2P tracking without leaving admin.
                   </p>
                 </div>
                 <div className="grid gap-4 md:grid-cols-2">
                   <div className="space-y-2">
-                    <Label htmlFor="twilioPhoneNumber">Twilio number</Label>
+                    <Label htmlFor="twilioPhoneNumber">Assigned number</Label>
                     <Input
                       id="twilioPhoneNumber"
                       name="twilioPhoneNumber"
                       type="tel"
                       defaultValue={business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber || ''}
-                      placeholder="+18777480449"
                     />
                   </div>
                   <div className="space-y-2">
-                    <Label htmlFor="twilioPhoneNumberSid">Twilio number SID</Label>
+                    <Label htmlFor="twilioPhoneNumberSid">Number SID</Label>
                     <Input
                       id="twilioPhoneNumberSid"
                       name="twilioPhoneNumberSid"
                       defaultValue={business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid || ''}
-                      placeholder="PN..."
                     />
                   </div>
                   <div className="space-y-2">
-                    <Label htmlFor="twilioMessagingServiceSid">Messaging service SID</Label>
-                    <Input
-                      id="twilioMessagingServiceSid"
-                      name="twilioMessagingServiceSid"
-                      defaultValue={business.twilioMessagingServiceSid || ''}
-                      placeholder="MG..."
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="a2pCustomerProfileSid">A2P customer profile SID</Label>
-                    <Input id="a2pCustomerProfileSid" name="a2pCustomerProfileSid" defaultValue={business.a2pCustomerProfileSid || ''} placeholder="BU..." />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="a2pBrandSid">A2P brand SID</Label>
-                    <Input id="a2pBrandSid" name="a2pBrandSid" defaultValue={business.a2pBrandSid || ''} placeholder="BN..." />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="a2pCampaignSid">A2P campaign SID</Label>
-                    <Input id="a2pCampaignSid" name="a2pCampaignSid" defaultValue={business.a2pCampaignSid || ''} placeholder="QE..." />
+                    <Label htmlFor="twilioMessagingServiceSid">Messaging Service SID</Label>
+                    <Input id="twilioMessagingServiceSid" name="twilioMessagingServiceSid" defaultValue={business.twilioMessagingServiceSid || ''} />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="managedTwilioStatus">Managed Twilio status</Label>
@@ -385,24 +530,37 @@ export default async function AdminBusinessDetailPage({
                       ))}
                     </Select>
                   </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="a2pCustomerProfileSid">Customer profile SID</Label>
+                    <Input id="a2pCustomerProfileSid" name="a2pCustomerProfileSid" defaultValue={business.a2pCustomerProfileSid || ''} />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="a2pBrandSid">Brand SID</Label>
+                    <Input id="a2pBrandSid" name="a2pBrandSid" defaultValue={business.a2pBrandSid || ''} />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="a2pCampaignSid">Campaign SID</Label>
+                    <Input id="a2pCampaignSid" name="a2pCampaignSid" defaultValue={business.a2pCampaignSid || ''} />
+                  </div>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="a2pFailureReason">A2P failure or attention note</Label>
+                  <Label htmlFor="a2pFailureReason">A2P or launch attention note</Label>
                   <Textarea
                     id="a2pFailureReason"
                     name="a2pFailureReason"
                     defaultValue={business.a2pFailureReason || ''}
-                    placeholder="Use this for rejection reasons, carrier requests, or the exact next operator action needed."
                     rows={3}
+                    placeholder="Record exactly what is blocking live messaging or what manual action is still needed."
                   />
                 </div>
                 <label className="flex items-start gap-2 rounded-lg border bg-background/80 p-3 text-sm">
                   <input className="mt-1" type="checkbox" name="confirmCriticalFieldClears" value="true" />
-                  <span>I understand this may clear a live Twilio mapping or owner alert destination and should only be used for internal corrections.</span>
+                  <span>I understand this can clear live Twilio mappings or alert routing and should only be used for deliberate internal corrections.</span>
                 </label>
               </div>
+
               <div className="md:col-span-2">
-                <Button type="submit">Save business details</Button>
+                <Button type="submit">Save business settings</Button>
               </div>
             </form>
           </CardContent>
@@ -411,81 +569,45 @@ export default async function AdminBusinessDetailPage({
         <div className="space-y-6">
           <Card className="bg-card/90">
             <CardHeader>
-              <CardTitle>Owner account</CardTitle>
-              <CardDescription>Connect an existing Clerk user by ID or email. If the owner has not signed up yet, CallbackCloser will send an invite.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="rounded-xl border bg-background/80 p-4 text-sm">
-                <p className="font-medium">{ownerState.name || business.ownerName || 'Owner not named yet'}</p>
-                <p className="mt-1 text-muted-foreground">{ownerState.email || business.notificationSettings?.ownerEmail || 'Owner email missing'}</p>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <Badge variant={ownerState.connected ? 'success' : ownerState.pending ? 'outline' : 'destructive'}>
-                    {ownerState.connected ? 'Connected' : ownerState.pending ? 'Pending invite' : 'Needs connection'}
-                  </Badge>
-                  {ownerState.clerkUserId ? <Badge variant="outline">{ownerState.clerkUserId}</Badge> : null}
-                </div>
-                {ownerState.invitedAt ? <p className="mt-2 text-xs text-muted-foreground">Invite sent {formatDateTime(ownerState.invitedAt)}</p> : null}
-              </div>
-              <form action={connectBusinessOwnerAction} className="space-y-4">
-                <input type="hidden" name="businessId" value={business.id} />
-                <div className="space-y-2">
-                  <Label htmlFor="connectOwnerEmail">Owner email</Label>
-                  <Input
-                    id="connectOwnerEmail"
-                    name="ownerEmail"
-                    type="email"
-                    defaultValue={business.notificationSettings?.ownerEmail || ''}
-                    placeholder="owner@business.com"
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="connectOwnerName">Owner name</Label>
-                  <Input id="connectOwnerName" name="ownerName" defaultValue={business.ownerName || ''} placeholder="Casey Owner" />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="ownerClerkId">Existing Clerk user ID</Label>
-                  <Input id="ownerClerkId" name="ownerClerkId" defaultValue={ownerState.connected ? ownerState.clerkUserId || '' : ''} placeholder="user_..." />
-                </div>
-                <Button type="submit">Create or connect owner</Button>
-              </form>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-card/90">
-            <CardHeader>
-              <CardTitle>Provisioning status</CardTitle>
-              <CardDescription>Internal rollout state plus the exact setup steps still blocking go-live.</CardDescription>
+              <CardTitle>Provisioning health</CardTitle>
+              <CardDescription>Checklist-style visibility into subaccount, number, webhooks, and readiness.</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid gap-3 sm:grid-cols-2">
                 <div className="rounded-xl border bg-background/80 p-4 text-sm">
-                  <p className="font-medium text-foreground">Current status</p>
+                  <p className="font-medium">Current status</p>
                   <div className="mt-2 flex flex-wrap gap-2">
                     <Badge variant={getAdminProvisioningStatusVariant(business.provisioningStatus)}>
                       {adminProvisioningStatusLabels[business.provisioningStatus]}
                     </Badge>
-                    <Badge variant={managedSummary.messagingReady ? 'success' : managedSummary.onboardingReady ? 'secondary' : 'outline'}>
-                      {managedSummary.messagingReady ? 'Approved' : managedSummary.onboardingReady ? 'A2P pending' : 'Setup pending'}
+                    <Badge variant={managedSummary.messagingReady ? 'success' : managedSummary.attentionRequired ? 'destructive' : 'secondary'}>
+                      {managedSummary.messagingReady ? 'Healthy' : managedSummary.attentionRequired ? 'Needs attention' : 'Pending'}
                     </Badge>
                   </div>
-                  <p className="mt-3 text-muted-foreground">Last run: {formatDateTime(business.provisioningLastRunAt)}</p>
-                  {business.provisioningError ? <p className="mt-2 text-destructive">{business.provisioningError}</p> : null}
+                  <p className="mt-3 text-xs text-muted-foreground">Last provisioning run: {formatDateTime(business.provisioningLastRunAt)}</p>
+                  {business.provisioningError ? <p className="mt-2 text-sm text-destructive">{business.provisioningError}</p> : null}
                 </div>
                 <div className="rounded-xl border bg-background/80 p-4 text-sm">
-                  <p className="font-medium text-foreground">Checklist</p>
-                  <div className="mt-3 space-y-3">
-                    {checklist.map((item) => (
-                      <div key={item.key} className="rounded-lg border bg-card p-3">
-                        <div className="flex items-center justify-between gap-3">
-                          <span className="font-medium">{item.label}</span>
-                          <Badge variant={item.complete ? 'success' : 'outline'}>{item.complete ? 'Done' : 'Pending'}</Badge>
-                        </div>
-                        <p className="mt-2 text-xs text-muted-foreground">{item.detail}</p>
-                      </div>
-                    ))}
-                  </div>
+                  <p className="font-medium">Webhooks</p>
+                  <p className="mt-2">{business.twilioWebhookSyncedAt ? 'Synced' : 'Needs sync'}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {business.twilioWebhookSyncedAt
+                      ? `Last synced ${formatRelativeTime(business.twilioWebhookSyncedAt)}`
+                      : 'Voice, SMS, and status callback URLs still need to be pushed to the assigned number.'}
+                  </p>
                 </div>
+              </div>
+
+              <div className="space-y-3">
+                {checklist.map((item) => (
+                  <div key={item.key} className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="font-medium">{item.label}</span>
+                      <Badge variant={item.complete ? 'success' : 'outline'}>{item.complete ? 'Done' : 'Pending'}</Badge>
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">{item.detail}</p>
+                  </div>
+                ))}
               </div>
 
               <div className="flex flex-wrap gap-2">
@@ -500,69 +622,85 @@ export default async function AdminBusinessDetailPage({
               </div>
             </CardContent>
           </Card>
+
+          <Card className="bg-card/90">
+            <CardHeader>
+              <CardTitle>Owner account</CardTitle>
+              <CardDescription>Connect or re-invite the owner without leaving the operator page.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                <p className="font-medium">{ownerState.name || business.ownerName || 'Owner not named yet'}</p>
+                <p className="mt-1 text-muted-foreground">{ownerState.email || business.notificationSettings?.ownerEmail || 'Owner email missing'}</p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Badge variant={ownerState.connected ? 'success' : ownerState.pending ? 'outline' : 'destructive'}>
+                    {ownerState.connected ? 'Connected' : ownerState.pending ? 'Pending invite' : 'Needs connection'}
+                  </Badge>
+                  {ownerState.clerkUserId ? <Badge variant="outline">{ownerState.clerkUserId}</Badge> : null}
+                </div>
+                {ownerState.invitedAt ? <p className="mt-2 text-xs text-muted-foreground">Invite sent {formatDateTime(ownerState.invitedAt)}</p> : null}
+              </div>
+
+              <form action={connectBusinessOwnerAction} className="space-y-4">
+                <input type="hidden" name="businessId" value={business.id} />
+                <div className="space-y-2">
+                  <Label htmlFor="connectOwnerEmail">Owner email</Label>
+                  <Input id="connectOwnerEmail" name="ownerEmail" type="email" defaultValue={business.notificationSettings?.ownerEmail || ''} required />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="connectOwnerName">Owner name</Label>
+                  <Input id="connectOwnerName" name="ownerName" defaultValue={business.ownerName || ''} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="ownerClerkId">Existing Clerk user ID</Label>
+                  <Input id="ownerClerkId" name="ownerClerkId" defaultValue={ownerState.connected ? ownerState.clerkUserId || '' : ''} />
+                </div>
+                <Button type="submit" variant="outline">
+                  Connect or invite owner
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
         </div>
       </div>
 
       <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
         <Card className="bg-card/90">
           <CardHeader>
-            <CardTitle>Twilio configuration</CardTitle>
-            <CardDescription>Current subaccount, number, messaging service, and webhook health for this business.</CardDescription>
+            <CardTitle>Provisioning health</CardTitle>
+            <CardDescription>Technical truth without forcing the founder to hunt for it.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4 text-sm">
             <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
               <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Provisioning path</p>
-                <p className="mt-2 text-muted-foreground">
-                  {business.twilioPrimaryNumberSid ? 'Business number attached' : 'Choose the managed new-number path or use the admin-assisted existing-number path below.'}
-                </p>
-              </div>
-              <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Managed status</p>
-                <p className="mt-2 text-muted-foreground">{managedSummary.label}</p>
-                <p className="mt-2 text-xs text-muted-foreground">{managedSummary.description}</p>
-              </div>
-              <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Billing</p>
-                <p className="mt-2 text-muted-foreground">{billingAccess.billingActive ? 'Active' : business.subscriptionStatus.toLowerCase()}</p>
-              </div>
-              <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Subaccount SID</p>
+                <p className="font-medium">Subaccount</p>
                 <p className="mt-2 break-all text-muted-foreground">{business.twilioSubaccountSid || 'Not created yet'}</p>
               </div>
               <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Messaging Service SID</p>
+                <p className="font-medium">Messaging Service</p>
                 <p className="mt-2 break-all text-muted-foreground">{business.twilioMessagingServiceSid || 'Not created yet'}</p>
               </div>
               <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Primary texting line</p>
-                <p className="mt-2 text-muted-foreground">{formatPhoneForDisplay(getManagedTextingNumber(business))}</p>
+                <p className="font-medium">Assigned number</p>
+                <p className="mt-2 text-muted-foreground">{formatPhoneForDisplay(assignedNumber)}</p>
+                <p className="mt-2 text-xs text-muted-foreground">{business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid || 'Number SID missing'}</p>
               </div>
               <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Primary number SID</p>
-                <p className="mt-2 break-all text-muted-foreground">{business.twilioPrimaryNumberSid || 'Not assigned yet'}</p>
+                <p className="font-medium">Provisioning path</p>
+                <p className="mt-2 text-muted-foreground">{assignedNumber ? 'Number attached' : 'Choose new or existing number path below.'}</p>
               </div>
               <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">A2P registration</p>
-                <p className="mt-2 text-muted-foreground">{managedSummary.complianceReady ? 'Approved' : managedSummary.label}</p>
-                <p className="mt-2 text-xs text-muted-foreground">{managedSummary.nextStep}</p>
+                <p className="font-medium">Billing</p>
+                <p className="mt-2 text-muted-foreground">{billingAccess.billingActive ? 'Active' : business.subscriptionStatus.toLowerCase()}</p>
               </div>
               <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Voice webhook</p>
-                <p className="mt-2 text-muted-foreground">
-                  {webhookSnapshot?.voiceSynced ? 'Synced' : webhookSnapshot?.error ? 'Unable to verify' : 'Needs sync'}
-                </p>
-              </div>
-              <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">SMS webhook</p>
-                <p className="mt-2 text-muted-foreground">
-                  {webhookSnapshot?.smsSynced ? 'Synced' : webhookSnapshot?.error ? 'Unable to verify' : 'Needs sync'}
-                </p>
+                <p className="font-medium">Last update</p>
+                <p className="mt-2 text-muted-foreground">{formatDateTime(business.updatedAt)}</p>
               </div>
             </div>
 
             <div className="rounded-xl border bg-background/80 p-4">
-              <p className="font-medium text-foreground">Webhook status</p>
+              <p className="font-medium">Webhook status</p>
               {webhookSnapshot ? (
                 <div className="mt-3 grid gap-3 sm:grid-cols-3">
                   <div>
@@ -582,39 +720,12 @@ export default async function AdminBusinessDetailPage({
                   </div>
                 </div>
               ) : (
-                <p className="mt-2 text-muted-foreground">
-                  CallbackCloser will verify webhook drift after a number is attached and Twilio credentials are available.
-                </p>
+                <p className="mt-2 text-muted-foreground">Webhook verification becomes available once a number is attached and Twilio credentials are present.</p>
               )}
             </div>
 
             <div className="rounded-xl border bg-background/80 p-4">
-              <p className="font-medium text-foreground">A2P and messaging readiness</p>
-              <div className="mt-3 grid gap-3 sm:grid-cols-2">
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Current state</p>
-                  <p className="mt-1">{managedSummary.label}</p>
-                  <p className="mt-1 text-xs text-muted-foreground">{managedSummary.description}</p>
-                </div>
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Next operator step</p>
-                  <p className="mt-1">{managedSummary.nextStep}</p>
-                  {business.a2pApprovedAt ? <p className="mt-1 text-xs text-muted-foreground">Approved {formatDateTime(business.a2pApprovedAt)}</p> : null}
-                </div>
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Brand / campaign IDs</p>
-                  <p className="mt-1 break-all text-muted-foreground">{business.a2pBrandSid || 'Brand not recorded yet'}</p>
-                  <p className="mt-1 break-all text-muted-foreground">{business.a2pCampaignSid || 'Campaign not recorded yet'}</p>
-                </div>
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Attention note</p>
-                  <p className="mt-1 text-muted-foreground">{business.a2pFailureReason || 'No current compliance blocker recorded.'}</p>
-                </div>
-              </div>
-            </div>
-
-            <div className="rounded-xl border bg-background/80 p-4">
-              <p className="font-medium text-foreground">Available existing numbers</p>
+              <p className="font-medium">Available existing numbers</p>
               <p className="mt-2 text-muted-foreground">
                 {availableNumbers.error
                   ? availableNumbers.error
@@ -639,11 +750,67 @@ export default async function AdminBusinessDetailPage({
         <div className="space-y-6">
           <Card className="bg-card/90">
             <CardHeader>
-              <CardTitle>Provision business</CardTitle>
-              <CardDescription>
-                Use the new-number path when CallbackCloser should buy a line. Use the existing-number path when the Twilio number is already present on the
-                business account context.
-              </CardDescription>
+              <CardTitle>Messaging / A2P readiness</CardTitle>
+              <CardDescription>Explain clearly what is blocking live messaging, or whether no action is needed.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm">
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Current state</p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <Badge variant={managedSummary.messagingReady ? 'success' : managedSummary.attentionRequired ? 'destructive' : 'secondary'}>
+                    {managedSummary.label}
+                  </Badge>
+                  {managedSummary.complianceReady ? <Badge variant="success">Approved</Badge> : null}
+                </div>
+                <p className="mt-3 text-muted-foreground">{managedSummary.description}</p>
+                <p className="mt-2 text-xs text-muted-foreground">{managedSummary.nextStep}</p>
+                {business.a2pApprovedAt ? <p className="mt-2 text-xs text-muted-foreground">Approved {formatDateTime(business.a2pApprovedAt)}</p> : null}
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-xl border bg-background/80 p-4">
+                  <p className="font-medium">Brand / campaign IDs</p>
+                  <p className="mt-2 break-all text-muted-foreground">{business.a2pBrandSid || 'Brand not recorded yet'}</p>
+                  <p className="mt-2 break-all text-muted-foreground">{business.a2pCampaignSid || 'Campaign not recorded yet'}</p>
+                </div>
+                <div className="rounded-xl border bg-background/80 p-4">
+                  <p className="font-medium">Attention note</p>
+                  <p className="mt-2 text-muted-foreground">{business.a2pFailureReason || 'No current compliance blocker recorded.'}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-card/90">
+            <CardHeader>
+              <CardTitle>Commercial / account state</CardTitle>
+              <CardDescription>Plan, setup state, alert routing, and live launch context.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-3 sm:grid-cols-2 text-sm">
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Subscription</p>
+                <p className="mt-2 text-muted-foreground">{business.subscriptionStatus.toLowerCase()}</p>
+              </div>
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Billing access</p>
+                <p className="mt-2 text-muted-foreground">{billingAccess.billingActive ? 'Active' : 'Inactive'}</p>
+              </div>
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Owner alert destination</p>
+                <p className="mt-2 text-muted-foreground">
+                  {formatPhoneForDisplay(business.notificationSettings?.ownerPhone || business.notifyPhone)} · {business.notificationSettings?.ownerEmail || 'No owner email'}
+                </p>
+              </div>
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Customer-facing status</p>
+                <p className="mt-2 text-muted-foreground">{customerStatus.description}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-card/90">
+            <CardHeader>
+              <CardTitle>Provision / attach number</CardTitle>
+              <CardDescription>Use the new-number path for normal launches. Existing numbers stay admin-assisted.</CardDescription>
             </CardHeader>
             <CardContent className="space-y-6">
               <form action={provisionBusinessAction} className="space-y-4 rounded-xl border bg-background/80 p-4">
@@ -652,9 +819,8 @@ export default async function AdminBusinessDetailPage({
                 <div className="space-y-2">
                   <Label htmlFor="areaCode">Preferred area code</Label>
                   <Input id="areaCode" name="areaCode" placeholder="512" maxLength={3} />
-                  <p className="text-xs text-muted-foreground">Optional. Leave blank to let CallbackCloser choose the first available US local number.</p>
                 </div>
-                <Button type="submit">Provision business</Button>
+                <Button type="submit">Provision new number</Button>
               </form>
 
               <form action={provisionBusinessAction} className="space-y-4 rounded-xl border bg-background/80 p-4">
@@ -664,13 +830,12 @@ export default async function AdminBusinessDetailPage({
                   <Label htmlFor="existingNumberSidManual">Existing number SID</Label>
                   <Input id="existingNumberSidManual" name="existingNumberSidManual" placeholder="PN..." />
                   <p className="text-xs text-muted-foreground">
-                    This is an admin-assisted path only. The number must already exist in the target Twilio account context before you attach it here. If
-                    the customer is keeping a number from another account or carrier, handle that migration outside the self-serve product flow first.
+                    Keep-number launches are still admin-assisted. The number must already exist in the target Twilio account context first.
                   </p>
                 </div>
                 {availableNumbers.numbers.length > 0 ? (
                   <div className="space-y-2">
-                    <Label htmlFor="existingNumberSelect">Choose from loaded Twilio numbers</Label>
+                    <Label htmlFor="existingNumberSelect">Choose loaded number</Label>
                     <select
                       id="existingNumberSelect"
                       name="existingNumberSidSelect"
@@ -686,7 +851,9 @@ export default async function AdminBusinessDetailPage({
                     </select>
                   </div>
                 ) : null}
-                <Button type="submit" variant="outline">Attach existing number</Button>
+                <Button type="submit" variant="outline">
+                  Attach existing number
+                </Button>
               </form>
             </CardContent>
           </Card>
@@ -694,7 +861,7 @@ export default async function AdminBusinessDetailPage({
           <Card className="bg-card/90">
             <CardHeader>
               <CardTitle>Webhook tools</CardTitle>
-              <CardDescription>Re-sync voice, SMS, or all number webhooks when the app URL changes or Twilio drifts.</CardDescription>
+              <CardDescription>Keep recovery actions close to the thing they fix.</CardDescription>
             </CardHeader>
             <CardContent className="flex flex-wrap gap-2">
               <WebhookResyncButton businessId={business.id} target="VOICE" label="Re-sync voice webhook" />
@@ -702,37 +869,139 @@ export default async function AdminBusinessDetailPage({
               <WebhookResyncButton businessId={business.id} target="ALL" label="Re-sync all webhooks" />
             </CardContent>
           </Card>
-
-          <Card className="bg-card/90">
-            <CardHeader>
-              <CardTitle>Commercial + live state</CardTitle>
-              <CardDescription>Internal view of billing, go-live readiness, and any manual follow-up still needed.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm">
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="rounded-xl border bg-background/80 p-4">
-                  <p className="font-medium text-foreground">Subscription</p>
-                  <p className="mt-2 text-muted-foreground">{business.subscriptionStatus.toLowerCase()}</p>
-                </div>
-                <div className="rounded-xl border bg-background/80 p-4">
-                  <p className="font-medium text-foreground">Marked live</p>
-                  <p className="mt-2 text-muted-foreground">{business.provisioningStatus === 'LIVE' ? 'Yes' : 'No'}</p>
-                </div>
-                <div className="rounded-xl border bg-background/80 p-4">
-                  <p className="font-medium text-foreground">Owner alert destination</p>
-                  <p className="mt-2 text-muted-foreground">
-                    {formatPhoneForDisplay(business.notificationSettings?.ownerPhone || business.notifyPhone)} · {business.notificationSettings?.ownerEmail || 'No owner email'}
-                  </p>
-                </div>
-                <div className="rounded-xl border bg-background/80 p-4">
-                  <p className="font-medium text-foreground">Last updated</p>
-                  <p className="mt-2 text-muted-foreground">{formatDateTime(business.updatedAt)}</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
         </div>
       </div>
+
+      <Card className="bg-card/90" id="recent-events">
+        <CardHeader>
+          <CardTitle>Logs / recent events</CardTitle>
+          <CardDescription>Concise summaries first, details on demand, no secrets.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {recentEvents.length === 0 ? (
+            <div className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">No recent operator events are recorded for this business yet.</div>
+          ) : (
+            recentEvents.map((event) => (
+              <details key={event.id} className="rounded-xl border bg-background/80 p-4 text-sm">
+                <summary className="cursor-pointer list-none">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant={event.severity === 'error' ? 'destructive' : event.severity === 'warning' ? 'outline' : 'secondary'}>
+                          {event.label}
+                        </Badge>
+                        <span className="font-medium">{event.summary}</span>
+                      </div>
+                      <p className="mt-2 text-xs text-muted-foreground">{formatDateTime(event.at)}</p>
+                    </div>
+                    <span className="text-xs text-muted-foreground">Show detail</span>
+                  </div>
+                </summary>
+                <p className="mt-3 text-muted-foreground">{event.detail}</p>
+              </details>
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <Card className="bg-card/90">
+          <CardHeader>
+            <CardTitle>Support workspace access</CardTitle>
+            <CardDescription>Fast entry into a safe customer-style snapshot without risky impersonation.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <p className="text-muted-foreground">
+              The support workspace is read-only by design. It surfaces recent leads, recent alerts, and key settings for this business without weakening tenant isolation.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <Link className={buttonVariants({ variant: 'default' })} href={`/admin/${business.id}/workspace`}>
+                Open support workspace
+              </Link>
+              <Link className={buttonVariants({ variant: 'outline' })} href={`/admin/${business.id}/workspace#recent-leads`}>
+                Open recent leads
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-card/90">
+          <CardHeader>
+            <CardTitle>Archive / delete controls</CardTitle>
+            <CardDescription>Archive real businesses safely. Delete only archived test/demo workspaces.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            {isBusinessArchived(business) ? (
+              <form action={restoreBusinessAction} className="rounded-xl border bg-background/80 p-4">
+                <input type="hidden" name="businessId" value={business.id} />
+                <div className="space-y-2">
+                  <Label htmlFor="restoreName">Type business name to restore</Label>
+                  <Input id="restoreName" name="confirmationName" placeholder={business.name} />
+                </div>
+                <Button className="mt-3" type="submit">
+                  Restore business
+                </Button>
+              </form>
+            ) : (
+              <form action={archiveBusinessAction} className="rounded-xl border bg-background/80 p-4">
+                <input type="hidden" name="businessId" value={business.id} />
+                <div className="space-y-2">
+                  <Label htmlFor="archiveName">Type business name to archive</Label>
+                  <Input id="archiveName" name="confirmationName" placeholder={business.name} />
+                </div>
+                <Button className="mt-3" type="submit" variant="outline">
+                  Archive business safely
+                </Button>
+              </form>
+            )}
+
+            {canDeleteTestBusiness(business) ? (
+              <form action={deleteTestBusinessAction} className="rounded-xl border border-destructive/30 bg-destructive/5 p-4">
+                <input type="hidden" name="businessId" value={business.id} />
+                <div className="space-y-2">
+                  <Label htmlFor="deleteName">Type business name to delete this test workspace</Label>
+                  <Input id="deleteName" name="confirmationName" placeholder={business.name} />
+                </div>
+                <Button className="mt-3" type="submit" variant="destructive">
+                  Delete archived test business
+                </Button>
+              </form>
+            ) : (
+              <div className="rounded-xl border border-dashed p-4 text-muted-foreground">
+                Delete stays unavailable until this workspace is archived and marked as a test/demo business.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="bg-card/90" id="recent-leads">
+        <CardHeader>
+          <CardTitle>Recent leads snapshot</CardTitle>
+          <CardDescription>Useful context without forcing a jump into multiple customer pages.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {recentLeads.length === 0 ? (
+            <div className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">No recent leads yet.</div>
+          ) : (
+            recentLeads.map((lead) => (
+              <div key={lead.id} className="rounded-xl border bg-background/80 p-4 text-sm">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
+                  <Badge variant={lead.readiness === 'URGENT' ? 'destructive' : lead.readiness === 'QUALIFIED' ? 'secondary' : 'outline'}>
+                    {leadReadinessLabels[lead.readiness]}
+                  </Badge>
+                </div>
+                <p className="mt-3 font-medium">{getLeadCallbackState(lead)}</p>
+                <p className="mt-2 text-muted-foreground">{lead.summary || 'Lead details are still coming in.'}</p>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Last activity {formatRelativeTime(lead.lastInteractionAt || lead.createdAt)} · {lead.id}
+                </p>
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/app/admin/[businessId]/workspace/page.tsx
+++ b/app/admin/[businessId]/workspace/page.tsx
@@ -1,0 +1,210 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { buildAdminNextStep } from '@/lib/admin-dashboard';
+import { requireAdmin } from '@/lib/admin';
+import { Badge } from '@/components/ui/badge';
+import { buttonVariants } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { db } from '@/lib/db';
+import {
+  formatDateTime,
+  formatMessageStatus,
+  formatRelativeTime,
+  getLeadCallbackState,
+  getLeadStatusBadgeVariant,
+  leadReadinessLabels,
+  leadStatusLabels,
+} from '@/lib/lead-presenters';
+import { getManagedTwilioStatusSummary } from '@/lib/managed-twilio';
+import { formatPhoneForDisplay } from '@/lib/phone';
+import { getBusinessBillingAccessState } from '@/lib/subscription';
+
+export const dynamic = 'force-dynamic';
+
+function getNextStepBadgeVariant(tone: 'healthy' | 'pending' | 'attention' | 'paused') {
+  if (tone === 'healthy') return 'success' as const;
+  if (tone === 'attention') return 'destructive' as const;
+  if (tone === 'paused') return 'outline' as const;
+  return 'secondary' as const;
+}
+
+export default async function AdminBusinessWorkspacePage({ params }: { params: { businessId: string } }) {
+  await requireAdmin();
+
+  const [business, recentLeads, recentOwnerNotifications, recentMessages] = await Promise.all([
+    db.business.findUnique({
+      where: { id: params.businessId },
+      include: {
+        notificationSettings: true,
+      },
+    }),
+    db.lead.findMany({
+      where: { businessId: params.businessId },
+      orderBy: [{ lastInteractionAt: 'desc' }, { createdAt: 'desc' }],
+      take: 8,
+    }),
+    db.ownerNotification.findMany({
+      where: { businessId: params.businessId },
+      orderBy: { createdAt: 'desc' },
+      take: 8,
+    }),
+    db.message.findMany({
+      where: { businessId: params.businessId },
+      orderBy: { createdAt: 'desc' },
+      take: 8,
+    }),
+  ]);
+
+  if (!business) notFound();
+
+  const successfulLeadCount = recentLeads.filter((lead) => lead.ownerNotifiedAt || lead.notifiedAt).length;
+  const nextStep = buildAdminNextStep({
+    business,
+    notificationSettings: business.notificationSettings,
+    ownerConnected: !business.ownerClerkId.startsWith('pending_owner_'),
+  });
+  const managedSummary = getManagedTwilioStatusSummary(business);
+  const billingAccess = getBusinessBillingAccessState(business);
+
+  return (
+    <div className="container space-y-6 py-8">
+      <div className="space-y-2">
+        <Link className="text-sm text-muted-foreground underline underline-offset-4" href={`/admin/${business.id}`}>
+          Back to operator page
+        </Link>
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">{business.name} support workspace</h1>
+            <p className="text-sm text-muted-foreground">
+              Read-only snapshot of the customer-facing workspace so the founder can orient quickly without impersonation.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link className={buttonVariants({ variant: 'default' })} href={`/admin/${business.id}`}>
+              Open operator controls
+            </Link>
+            <Link className={buttonVariants({ variant: 'outline' })} href="/admin">
+              Back to board
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <Card className="border-primary/20 bg-primary/5">
+        <CardHeader>
+          <CardTitle>Support snapshot</CardTitle>
+          <CardDescription>What matters first when the founder needs to step into a customer’s world.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="rounded-xl border bg-background/80 p-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant={getNextStepBadgeVariant(nextStep.tone)}>{nextStep.title}</Badge>
+              <Badge variant={managedSummary.messagingReady ? 'success' : managedSummary.attentionRequired ? 'destructive' : 'secondary'}>
+                {managedSummary.label}
+              </Badge>
+            </div>
+            <p className="mt-3 text-sm text-muted-foreground">{nextStep.detail}</p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="rounded-xl border bg-background/80 p-4 text-sm">
+              <p className="font-medium">Lead handoffs</p>
+              <p className="mt-2 text-2xl font-semibold">{successfulLeadCount}</p>
+            </div>
+            <div className="rounded-xl border bg-background/80 p-4 text-sm">
+              <p className="font-medium">Billing</p>
+              <p className="mt-2 text-muted-foreground">{billingAccess.billingActive ? 'Active' : 'Inactive'}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+        <Card className="bg-card/90" id="recent-leads">
+          <CardHeader>
+            <CardTitle>Recent leads</CardTitle>
+            <CardDescription>Support-friendly snapshot of where the current inbox stands.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {recentLeads.length === 0 ? (
+              <div className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">No leads yet.</div>
+            ) : (
+              recentLeads.map((lead) => (
+                <div key={lead.id} className="rounded-xl border bg-background/80 p-4 text-sm">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
+                    <Badge variant={lead.readiness === 'URGENT' ? 'destructive' : lead.readiness === 'QUALIFIED' ? 'secondary' : 'outline'}>
+                      {leadReadinessLabels[lead.readiness]}
+                    </Badge>
+                  </div>
+                  <p className="mt-3 font-medium">{getLeadCallbackState(lead)}</p>
+                  <p className="mt-2 text-muted-foreground">{lead.summary || 'Lead summary not captured yet.'}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">{formatDateTime(lead.lastInteractionAt || lead.createdAt)}</p>
+                </div>
+              ))
+            )}
+          </CardContent>
+        </Card>
+
+        <div className="space-y-6">
+          <Card className="bg-card/90">
+            <CardHeader>
+              <CardTitle>Business settings snapshot</CardTitle>
+              <CardDescription>The customer context the founder usually has to hunt down.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-3 text-sm">
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Owner alerts</p>
+                <p className="mt-2 text-muted-foreground">
+                  {formatPhoneForDisplay(business.notificationSettings?.ownerPhone || business.notifyPhone)} · {business.notificationSettings?.ownerEmail || 'No owner email'}
+                </p>
+              </div>
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Forwarding number</p>
+                <p className="mt-2 text-muted-foreground">{formatPhoneForDisplay(business.forwardingNumber)}</p>
+              </div>
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Texting line</p>
+                <p className="mt-2 text-muted-foreground">
+                  {formatPhoneForDisplay(business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber)}
+                </p>
+              </div>
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Internal notes</p>
+                <p className="mt-2 text-muted-foreground">{business.internalNotes || 'No internal notes recorded.'}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-card/90">
+            <CardHeader>
+              <CardTitle>Recent notifications and SMS</CardTitle>
+              <CardDescription>Quick visibility into the latest customer-visible activity.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              {recentOwnerNotifications.slice(0, 4).map((notification) => (
+                <div key={notification.id} className="rounded-xl border bg-background/80 p-4">
+                  <p className="font-medium">
+                    Owner {notification.channel.toLowerCase()} alert · {notification.status.toLowerCase()}
+                  </p>
+                  <p className="mt-2 text-muted-foreground">{notification.error || notification.destination || 'No extra detail recorded.'}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">{formatRelativeTime(notification.createdAt)}</p>
+                </div>
+              ))}
+              {recentMessages.slice(0, 4).map((message) => (
+                <div key={message.id} className="rounded-xl border bg-background/80 p-4">
+                  <p className="font-medium">
+                    {message.participant === 'OWNER' ? 'Owner SMS' : 'Lead SMS'} · {message.direction.toLowerCase()}
+                    {message.status ? ` · ${formatMessageStatus(message.status)}` : ''}
+                  </p>
+                  <p className="mt-2 text-muted-foreground">{message.body}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">{formatRelativeTime(message.createdAt)}</p>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -12,11 +12,16 @@ import {
   updateBusinessProvisioningStatus,
 } from '@/lib/admin-provisioning';
 import { requireAdmin } from '@/lib/admin';
+import { canDeleteTestBusiness } from '@/lib/admin-dashboard';
 import { logAuditEvent } from '@/lib/audit-log';
 import { db } from '@/lib/db';
 import { maskPhoneForAudit, normalizePhoneNumber, normalizePhoneNumberToE164 } from '@/lib/phone';
+import { sendAndPersistOutboundMessage } from '@/lib/twilio-messaging';
 import {
+  adminArchiveBusinessSchema,
   adminBusinessDraftSchema,
+  adminDeleteBusinessSchema,
+  adminSendTestSmsSchema,
   adminBusinessUpdateSchema,
   adminConnectOwnerSchema,
   adminProvisionBusinessSchema,
@@ -52,6 +57,7 @@ function buildAdminBusinessRedirectPath(
 async function revalidateAdminPaths(businessId: string) {
   revalidatePath('/admin');
   revalidatePath(`/admin/${businessId}`);
+  revalidatePath(`/admin/${businessId}/workspace`);
 }
 
 function normalizeOptionalE164Phone(value: string | null | undefined, label: string) {
@@ -97,6 +103,15 @@ function buildChangedFieldMetadata(changes: Array<{ key: string; label: string; 
   }));
 }
 
+async function loadBusinessForLifecycleAction(businessId: string) {
+  return db.business.findUnique({
+    where: { id: businessId },
+    include: {
+      notificationSettings: true,
+    },
+  });
+}
+
 export async function createDemoBusinessAction(formData: FormData) {
   const admin = await requireAdmin();
   const ownerPhone = normalizePhoneNumber(getString(formData, 'ownerPhone')) || null;
@@ -111,6 +126,7 @@ export async function createDemoBusinessAction(formData: FormData) {
       ownerClerkId: DEMO_OWNER_CLERK_ID,
       ownerName: 'CallbackCloser Demo',
       name: DEFAULT_DEMO_NAME,
+      isTestBusiness: true,
       forwardingNumber,
       notifyPhone: ownerPhone,
       provisioningStatus: BusinessProvisioningStatus.DRAFT,
@@ -129,6 +145,8 @@ export async function createDemoBusinessAction(formData: FormData) {
     update: {
       ownerName: 'CallbackCloser Demo',
       name: DEFAULT_DEMO_NAME,
+      isTestBusiness: true,
+      archivedAt: null,
       forwardingNumber,
       notifyPhone: ownerPhone,
       provisioningStatus: BusinessProvisioningStatus.DRAFT,
@@ -182,6 +200,7 @@ export async function createAdminBusinessAction(formData: FormData) {
       ownerClerkId: buildPendingOwnerClerkId(),
       ownerName: data.ownerName || null,
       name: data.name,
+      isTestBusiness: data.isTestBusiness,
       forwardingNumber,
       notifyPhone: ownerPhone,
       provisioningStatus: BusinessProvisioningStatus.DRAFT,
@@ -307,6 +326,7 @@ export async function saveAdminBusinessProfileAction(formData: FormData) {
     existingBusiness.a2pBrandSid !== a2pBrandSid ||
     existingBusiness.a2pCampaignSid !== a2pCampaignSid ||
     existingBusiness.a2pFailureReason !== a2pFailureReason;
+  const testFlagChanged = existingBusiness.isTestBusiness !== data.isTestBusiness;
 
   const changedFields = [
     existingOwnerPhone !== ownerPhone
@@ -358,6 +378,14 @@ export async function saveAdminBusinessProfileAction(formData: FormData) {
           after: a2pFailureReason,
         }
       : null,
+    testFlagChanged
+      ? {
+          key: 'isTestBusiness',
+          label: 'test business flag',
+          before: existingBusiness.isTestBusiness ? 'true' : 'false',
+          after: data.isTestBusiness ? 'true' : 'false',
+        }
+      : null,
     managedTwilioStatusChanged
       ? {
           key: 'managedTwilioStatus',
@@ -373,6 +401,7 @@ export async function saveAdminBusinessProfileAction(formData: FormData) {
     data: {
       ownerName: data.ownerName || null,
       name: data.name,
+      isTestBusiness: data.isTestBusiness,
       forwardingNumber: normalizePhoneNumber(data.forwardingNumber),
       notifyPhone: ownerPhone,
       missedCallSeconds: data.missedCallSeconds,
@@ -590,4 +619,200 @@ export async function setBusinessProvisioningStatusAction(formData: FormData) {
   await updateBusinessProvisioningStatus(parsed.data.businessId, parsed.data.status as BusinessProvisioningStatus, null);
   await revalidateAdminPaths(parsed.data.businessId);
   redirect(buildAdminBusinessRedirectPath(parsed.data.businessId, { statusSaved: parsed.data.status.toLowerCase() }));
+}
+
+export async function sendBusinessTestSmsAction(formData: FormData) {
+  const admin = await requireAdmin();
+
+  const parsed = adminSendTestSmsSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    redirect(`/admin?error=${encodeURIComponent(parsed.error.issues[0]?.message || 'Invalid test SMS request.')}`);
+  }
+
+  const business = await loadBusinessForLifecycleAction(parsed.data.businessId);
+  if (!business) {
+    redirect(`/admin?error=${encodeURIComponent('Business not found.')}`);
+  }
+
+  const destinationPhone = normalizeOptionalE164Phone(parsed.data.destinationPhone, 'Test SMS destination');
+  const fromPhone = business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber;
+  if (!fromPhone) {
+    redirect(buildAdminBusinessRedirectPath(business.id, { error: 'A business texting number is required before sending a test SMS.' }));
+  }
+
+  try {
+    const result = await sendAndPersistOutboundMessage({
+      businessId: business.id,
+      fromPhone,
+      toPhone: destinationPhone!,
+      body: `CallbackCloser admin test: ${business.name} is using ${fromPhone} for live support verification.`,
+      participant: 'OWNER',
+      twilioSubaccountSid: business.twilioSubaccountSid,
+      messagingServiceSid: business.twilioMessagingServiceSid,
+      managedTwilioStatus: business.managedTwilioStatus,
+      a2pFailureReason: business.a2pFailureReason,
+    });
+
+    if (result.suppressed) {
+      redirect(
+        buildAdminBusinessRedirectPath(business.id, {
+          error: `Test SMS was suppressed: ${result.reason.replace(/_/g, ' ')}.`,
+        })
+      );
+    }
+
+    logAuditEvent({
+      event: 'admin_test_sms_sent',
+      actorType: 'user',
+      actorId: admin.userId,
+      businessId: business.id,
+      targetType: 'business',
+      targetId: business.id,
+      metadata: {
+        actorEmail: admin.email,
+        destinationPhone: maskPhoneForAudit(destinationPhone),
+        messageSid: result.sent.sid,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to send test SMS.';
+    redirect(buildAdminBusinessRedirectPath(business.id, { error: message }));
+  }
+
+  await revalidateAdminPaths(business.id);
+  redirect(buildAdminBusinessRedirectPath(business.id, { testSms: 1 }));
+}
+
+export async function archiveBusinessAction(formData: FormData) {
+  const admin = await requireAdmin();
+
+  const parsed = adminArchiveBusinessSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    redirect(`/admin?error=${encodeURIComponent(parsed.error.issues[0]?.message || 'Invalid archive request.')}`);
+  }
+
+  const business = await loadBusinessForLifecycleAction(parsed.data.businessId);
+  if (!business) {
+    redirect(`/admin?error=${encodeURIComponent('Business not found.')}`);
+  }
+
+  if (parsed.data.confirmationName !== business.name) {
+    redirect(buildAdminBusinessRedirectPath(business.id, { error: 'Type the exact business name to archive it.' }));
+  }
+
+  await db.business.update({
+    where: { id: business.id },
+    data: {
+      archivedAt: new Date(),
+      provisioningStatus: BusinessProvisioningStatus.PAUSED,
+      provisioningError: null,
+      provisioningLastRunAt: new Date(),
+    },
+  });
+
+  logAuditEvent({
+    event: 'admin_business_archived',
+    actorType: 'user',
+    actorId: admin.userId,
+    businessId: business.id,
+    targetType: 'business',
+    targetId: business.id,
+    metadata: {
+      actorEmail: admin.email,
+      businessName: business.name,
+      isTestBusiness: business.isTestBusiness,
+    },
+  });
+
+  await revalidateAdminPaths(business.id);
+  redirect(buildAdminBusinessRedirectPath(business.id, { archived: 1 }));
+}
+
+export async function restoreBusinessAction(formData: FormData) {
+  const admin = await requireAdmin();
+
+  const parsed = adminArchiveBusinessSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    redirect(`/admin?error=${encodeURIComponent(parsed.error.issues[0]?.message || 'Invalid restore request.')}`);
+  }
+
+  const business = await loadBusinessForLifecycleAction(parsed.data.businessId);
+  if (!business) {
+    redirect(`/admin?error=${encodeURIComponent('Business not found.')}`);
+  }
+
+  if (parsed.data.confirmationName !== business.name) {
+    redirect(buildAdminBusinessRedirectPath(business.id, { error: 'Type the exact business name to restore it.' }));
+  }
+
+  await db.business.update({
+    where: { id: business.id },
+    data: {
+      archivedAt: null,
+      provisioningStatus:
+        business.provisioningStatus === BusinessProvisioningStatus.PAUSED ? BusinessProvisioningStatus.ONBOARDING : business.provisioningStatus,
+      provisioningLastRunAt: new Date(),
+    },
+  });
+
+  logAuditEvent({
+    event: 'admin_business_restored',
+    actorType: 'user',
+    actorId: admin.userId,
+    businessId: business.id,
+    targetType: 'business',
+    targetId: business.id,
+    metadata: {
+      actorEmail: admin.email,
+      businessName: business.name,
+    },
+  });
+
+  await revalidateAdminPaths(business.id);
+  redirect(buildAdminBusinessRedirectPath(business.id, { restored: 1 }));
+}
+
+export async function deleteTestBusinessAction(formData: FormData) {
+  const admin = await requireAdmin();
+
+  const parsed = adminDeleteBusinessSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    redirect(`/admin?error=${encodeURIComponent(parsed.error.issues[0]?.message || 'Invalid delete request.')}`);
+  }
+
+  const business = await loadBusinessForLifecycleAction(parsed.data.businessId);
+  if (!business) {
+    redirect(`/admin?error=${encodeURIComponent('Business not found.')}`);
+  }
+
+  if (parsed.data.confirmationName !== business.name) {
+    redirect(buildAdminBusinessRedirectPath(business.id, { error: 'Type the exact business name to delete it.' }));
+  }
+
+  if (!canDeleteTestBusiness(business)) {
+    redirect(
+      buildAdminBusinessRedirectPath(business.id, {
+        error: 'Only archived test or demo businesses can be deleted from admin.',
+      })
+    );
+  }
+
+  await db.business.delete({ where: { id: business.id } });
+
+  logAuditEvent({
+    event: 'admin_test_business_deleted',
+    actorType: 'user',
+    actorId: admin.userId,
+    businessId: business.id,
+    targetType: 'business',
+    targetId: business.id,
+    metadata: {
+      actorEmail: admin.email,
+      businessName: business.name,
+      isTestBusiness: business.isTestBusiness,
+    },
+  });
+
+  revalidatePath('/admin');
+  redirect('/admin?deleted=1');
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -5,14 +5,23 @@ import {
   createDemoBusinessAction,
   provisionBusinessAction,
   resyncBusinessWebhooksAction,
+  restoreBusinessAction,
   setBusinessProvisioningStatusAction,
 } from '@/app/admin/actions';
+import {
+  adminBoardFilterOptions,
+  buildAdminNextStep,
+  getBusinessLifecycleLabel,
+  isBusinessArchived,
+  matchesAdminBoardFilter,
+  type AdminBoardFilter,
+} from '@/lib/admin-dashboard';
+import { requireAdmin } from '@/lib/admin';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { requireAdmin } from '@/lib/admin';
 import {
   adminProvisioningStatusLabels,
   getAdminProvisioningStatusVariant,
@@ -20,9 +29,10 @@ import {
 } from '@/lib/admin-provisioning';
 import { searchBusinessesForAdmin } from '@/lib/business';
 import { db } from '@/lib/db';
-import { formatDateTime } from '@/lib/lead-presenters';
+import { formatDateTime, formatRelativeTime } from '@/lib/lead-presenters';
 import { getManagedTextingNumber, getManagedTwilioStatusSummary } from '@/lib/managed-twilio';
 import { formatPhoneForDisplay } from '@/lib/phone';
+import { cn } from '@/lib/utils';
 
 export const dynamic = 'force-dynamic';
 
@@ -31,19 +41,37 @@ function getQueryValue(searchParams: Record<string, string | string[] | undefine
   return typeof value === 'string' ? value : null;
 }
 
+function maxDate(...values: Array<Date | null | undefined>) {
+  const timestamps = values
+    .filter((value): value is Date => value instanceof Date)
+    .map((value) => value.getTime());
+
+  if (timestamps.length === 0) return null;
+  return new Date(Math.max(...timestamps));
+}
+
+function getNextStepBadgeVariant(tone: 'healthy' | 'pending' | 'attention' | 'paused') {
+  if (tone === 'healthy') return 'success' as const;
+  if (tone === 'attention') return 'destructive' as const;
+  if (tone === 'paused') return 'outline' as const;
+  return 'secondary' as const;
+}
+
 export default async function AdminPage({ searchParams }: { searchParams?: Record<string, string | string[] | undefined> }) {
   const admin = await requireAdmin();
   const createdDemo = getQueryValue(searchParams, 'createdDemo') === '1';
   const createdBusinessId = getQueryValue(searchParams, 'businessId');
+  const deleted = getQueryValue(searchParams, 'deleted') === '1';
   const error = getQueryValue(searchParams, 'error');
   const query = getQueryValue(searchParams, 'q')?.trim() || '';
+  const view = (getQueryValue(searchParams, 'view') as AdminBoardFilter | null) || 'all';
   const adminBusiness = await db.business.findUnique({ where: { ownerClerkId: admin.userId } });
 
-  const [businesses, leadCounts] = await Promise.all([
+  const [businesses, leadCounts, leadActivity, callActivity, messageActivity, notificationFailures] = await Promise.all([
     query
       ? searchBusinessesForAdmin(query)
       : db.business.findMany({
-          orderBy: { updatedAt: 'desc' },
+          orderBy: [{ archivedAt: 'asc' }, { updatedAt: 'desc' }],
           include: {
             notificationSettings: true,
           },
@@ -51,38 +79,138 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
     db.lead.groupBy({
       by: ['businessId'],
       _count: { _all: true },
+      _max: { lastInteractionAt: true, createdAt: true },
+    }),
+    db.lead.groupBy({
+      by: ['businessId'],
+      _max: { lastInteractionAt: true, createdAt: true },
+    }),
+    db.call.groupBy({
+      by: ['businessId'],
+      _max: { createdAt: true },
+    }),
+    db.message.groupBy({
+      by: ['businessId'],
+      _max: { createdAt: true },
+    }),
+    db.ownerNotification.findMany({
+      where: {
+        status: { in: ['FAILED', 'SKIPPED'] },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        businessId: true,
+        status: true,
+        error: true,
+        createdAt: true,
+      },
+      take: 200,
     }),
   ]);
 
   const leadCountMap = new Map(leadCounts.map((item) => [item.businessId, item._count._all]));
+  const leadActivityMap = new Map(
+    leadActivity.map((item) => [item.businessId, maxDate(item._max.lastInteractionAt, item._max.createdAt)])
+  );
+  const callActivityMap = new Map(callActivity.map((item) => [item.businessId, item._max.createdAt]));
+  const messageActivityMap = new Map(messageActivity.map((item) => [item.businessId, item._max.createdAt]));
+  const notificationFailureMap = new Map<string, { status: string; error: string | null; createdAt: Date }>();
+
+  for (const failure of notificationFailures) {
+    if (!notificationFailureMap.has(failure.businessId)) {
+      notificationFailureMap.set(failure.businessId, failure);
+    }
+  }
+
+  const businessRows = businesses.map((business) => {
+    const managedSummary = getManagedTwilioStatusSummary(business);
+    const ownerPending = isPendingOwnerClerkId(business.ownerClerkId);
+    const ownerConnected = !ownerPending;
+    const nextStep = buildAdminNextStep({
+      business,
+      notificationSettings: business.notificationSettings,
+      ownerConnected,
+    });
+    const lastActivityAt = maxDate(
+      business.updatedAt,
+      leadActivityMap.get(business.id),
+      callActivityMap.get(business.id),
+      messageActivityMap.get(business.id)
+    );
+    const latestFailure = notificationFailureMap.get(business.id);
+
+    return {
+      business,
+      ownerPending,
+      ownerConnected,
+      managedSummary,
+      nextStep,
+      leadCount: leadCountMap.get(business.id) ?? 0,
+      assignedNumber: getManagedTextingNumber(business),
+      lastActivityAt,
+      latestFailure,
+    };
+  });
+
+  const filterCounts = new Map(
+    adminBoardFilterOptions.map((option) => [
+      option.key,
+      businessRows.filter((item) =>
+        matchesAdminBoardFilter(item.business, item.business.notificationSettings, item.ownerConnected, option.key)
+      ).length,
+    ])
+  );
+
+  const visibleRows = businessRows.filter((item) =>
+    matchesAdminBoardFilter(item.business, item.business.notificationSettings, item.ownerConnected, view)
+  );
+
+  const summaryStats = [
+    { label: 'Needs attention', value: filterCounts.get('needs_attention') ?? 0 },
+    { label: 'Live', value: filterCounts.get('live') ?? 0 },
+    { label: 'Pending A2P', value: filterCounts.get('pending_a2p') ?? 0 },
+    { label: 'Archived', value: filterCounts.get('archived') ?? 0 },
+  ];
 
   return (
     <div className="container space-y-6 py-8">
-      <div className="space-y-2">
+      <div className="space-y-3">
         <Badge variant="outline">Internal Admin</Badge>
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Business provisioning dashboard</h1>
-          <p className="text-sm text-muted-foreground">
-            Create business workspaces, connect owners, provision Twilio, and fix webhook drift without touching the customer dashboard.
-          </p>
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold tracking-tight">Operator triage board</h1>
+            <p className="max-w-3xl text-sm text-muted-foreground">
+              Open admin and immediately see which businesses are healthy, which ones need help, and the next safe action to take.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-4">
+            {summaryStats.map((item) => (
+              <Card key={item.label} className="bg-card/90">
+                <CardHeader className="pb-2">
+                  <CardDescription>{item.label}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-2xl font-semibold">{item.value}</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
         </div>
       </div>
 
       {error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{error}</div> : null}
+      {deleted ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Archived test business deleted.</div> : null}
       {createdDemo && createdBusinessId ? (
         <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">
           Demo business ready. Use <code className="rounded bg-background px-1 py-0.5">{createdBusinessId}</code> as `SIMULATOR_BUSINESS_ID`, or open the
-          workspace below.
+          support workspace below.
         </div>
       ) : null}
 
       <Card className="bg-card/90">
         <CardHeader>
-          <CardTitle>Internal database lookup</CardTitle>
-          <CardDescription>
-            Search by business name, owner email, Twilio number, Twilio number SID, or business ID. This tool is internal-only and stays behind the admin
-            dashboard guard.
-          </CardDescription>
+          <CardTitle>Find any business fast</CardTitle>
+          <CardDescription>Search by business name, owner email, business ID, Twilio number, or Twilio SID.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <form className="grid gap-3 md:grid-cols-[1fr_auto_auto]">
@@ -92,34 +220,44 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
               name="q"
               placeholder="Search name, owner email, +18777480449, PN..., or business ID"
             />
+            <input type="hidden" name="view" value={view} />
             <Button type="submit" variant="outline">
               Search
             </Button>
             {query ? (
-              <Link className={buttonVariants({ variant: 'ghost' })} href="/admin">
+              <Link className={buttonVariants({ variant: 'ghost' })} href={`/admin?view=${encodeURIComponent(view)}`}>
                 Clear
               </Link>
             ) : null}
           </form>
-          <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground">
-            {query ? (
-              <>
-                Showing {businesses.length} result{businesses.length === 1 ? '' : 's'} for <span className="font-medium text-foreground">{query}</span>.
-              </>
-            ) : (
-              <>Search is empty, so the full business list is shown below.</>
-            )}
+          <div className="flex flex-wrap gap-2">
+            {adminBoardFilterOptions.map((option) => {
+              const href = query
+                ? `/admin?view=${encodeURIComponent(option.key)}&q=${encodeURIComponent(query)}`
+                : `/admin?view=${encodeURIComponent(option.key)}`;
+              return (
+                <Link
+                  key={option.key}
+                  className={cn(
+                    buttonVariants({ variant: option.key === view ? 'default' : 'outline', size: 'sm' }),
+                    option.key === view && 'pointer-events-none'
+                  )}
+                  href={href}
+                >
+                  {option.label} ({filterCounts.get(option.key) ?? 0})
+                </Link>
+              );
+            })}
           </div>
         </CardContent>
       </Card>
 
-      <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
         <Card className="border-primary/20 bg-primary/5">
           <CardHeader>
             <CardTitle>Create customer business</CardTitle>
             <CardDescription>
-              Save the business workspace, owner contact details, and default routing in one pass. CallbackCloser will connect an existing Clerk owner by
-              email when possible, or send an owner invite and keep the workspace in a pending-owner state.
+              Save the business workspace, owner details, test flag, and default routing in one pass so provisioning can start immediately.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -164,6 +302,10 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                 <Label htmlFor="serviceLabel3">Tertiary service label</Label>
                 <Input id="serviceLabel3" name="serviceLabel3" defaultValue="Maintenance" />
               </div>
+              <label className="md:col-span-2 flex items-start gap-2 rounded-xl border bg-background/80 p-3 text-sm">
+                <input name="isTestBusiness" type="checkbox" value="true" />
+                <span>Mark this as a test/demo business so it can be safely archived and deleted later.</span>
+              </label>
               <div className="md:col-span-2 flex flex-wrap items-center gap-3">
                 <Button type="submit">Create business workspace</Button>
                 <p className="text-sm text-muted-foreground">If the owner already exists in Clerk, CallbackCloser will connect that account automatically.</p>
@@ -175,9 +317,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
         <Card className="bg-card/90">
           <CardHeader>
             <CardTitle>Create dedicated simulator workspace</CardTitle>
-            <CardDescription>
-              Keeps public simulator traffic isolated from real customer accounts while still using the same missed-call workflow.
-            </CardDescription>
+            <CardDescription>Keep simulator traffic isolated from real customers while still using the real operator controls.</CardDescription>
           </CardHeader>
           <CardContent>
             <form action={createDemoBusinessAction} className="space-y-4">
@@ -211,129 +351,151 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                   placeholder="+1 555 000 0001"
                 />
               </div>
-              <Button type="submit">Create Demo Business</Button>
+              <Button type="submit">Create demo workspace</Button>
             </form>
           </CardContent>
         </Card>
       </div>
 
-      <Card className="bg-card/90">
-        <CardHeader>
-          <CardTitle>{query ? 'Search results' : 'All businesses'}</CardTitle>
-          <CardDescription>Operational view of owner state, provisioning progress, Twilio setup, and live readiness.</CardDescription>
-        </CardHeader>
-        <CardContent className="overflow-x-auto">
-          {businesses.length === 0 ? (
-            <div className="rounded-xl border border-dashed p-6 text-sm text-muted-foreground">
-              No businesses matched this lookup. Try the exact business ID, owner email, or normalized Twilio number.
-            </div>
-          ) : (
-            <table className="min-w-full text-sm">
-              <thead>
-                <tr className="border-b text-left text-muted-foreground">
-                  <th className="px-3 py-3 font-medium">Business</th>
-                  <th className="px-3 py-3 font-medium">Owner</th>
-                  <th className="px-3 py-3 font-medium">Business status</th>
-                  <th className="px-3 py-3 font-medium">Provisioning</th>
-                  <th className="px-3 py-3 font-medium">Twilio</th>
-                  <th className="px-3 py-3 font-medium">Phone + webhooks</th>
-                  <th className="px-3 py-3 font-medium">Messaging</th>
-                  <th className="px-3 py-3 font-medium">Live</th>
-                  <th className="px-3 py-3 font-medium">Updated</th>
-                  <th className="px-3 py-3 font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {businesses.map((business) => {
-                const managedSummary = getManagedTwilioStatusSummary(business);
-                const ownerEmail = business.notificationSettings?.ownerEmail || 'Owner email missing';
-                const leadCount = leadCountMap.get(business.id) ?? 0;
-                const hasNumber = Boolean(getManagedTextingNumber(business));
-                const ownerPending = isPendingOwnerClerkId(business.ownerClerkId);
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-semibold tracking-tight">Businesses</h2>
+            <p className="text-sm text-muted-foreground">
+              {query ? `Showing ${visibleRows.length} result${visibleRows.length === 1 ? '' : 's'} for ${query}.` : 'Use this board as the founder control center.'}
+            </p>
+          </div>
+        </div>
 
-                return (
-                  <tr key={business.id} className="border-b align-top last:border-0 hover:bg-muted/20">
-                    <td className="px-3 py-3">
-                      <Link className="font-medium hover:underline" href={`/admin/${business.id}`}>
+        {visibleRows.length === 0 ? (
+          <Card className="bg-card/90">
+            <CardContent className="p-6 text-sm text-muted-foreground">
+              No businesses matched this view. Try a different filter or search for the exact business ID, owner email, or Twilio number.
+            </CardContent>
+          </Card>
+        ) : (
+          visibleRows.map(({ business, ownerPending, managedSummary, nextStep, leadCount, assignedNumber, lastActivityAt, latestFailure }) => (
+            <Card key={business.id} className="bg-card/90">
+              <CardContent className="space-y-5 p-5">
+                <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Link className="text-lg font-semibold hover:underline" href={`/admin/${business.id}`}>
                         {business.name}
                       </Link>
-                      <div className="text-xs text-muted-foreground">{business.id}</div>
-                      <div className="mt-1 text-xs text-muted-foreground">{leadCount} lead{leadCount === 1 ? '' : 's'}</div>
-                    </td>
-                    <td className="px-3 py-3">
-                      <div className="font-medium">{business.ownerName || 'Owner name missing'}</div>
-                      <div className="text-xs text-muted-foreground">{ownerEmail}</div>
-                      <div className="mt-1">
-                        <Badge variant={ownerPending ? 'outline' : 'secondary'}>{ownerPending ? 'Pending owner' : 'Owner linked'}</Badge>
-                      </div>
-                    </td>
-                    <td className="px-3 py-3">
+                      {business.isTestBusiness ? <Badge variant="outline">Test</Badge> : null}
+                      {isBusinessArchived(business) ? <Badge variant="outline">Archived</Badge> : null}
+                      <Badge variant={getNextStepBadgeVariant(nextStep.tone)}>{nextStep.title}</Badge>
+                    </div>
+                    <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                      <span>{business.id}</span>
+                      <span>Owner: {business.ownerName || 'Missing owner name'}</span>
+                      <span>{business.notificationSettings?.ownerEmail || 'Missing owner email'}</span>
+                      {ownerPending ? <span>Owner invite pending</span> : <span>Owner linked</span>}
+                    </div>
+                    <p className="max-w-3xl text-sm text-muted-foreground">{nextStep.detail}</p>
+                    {latestFailure ? (
+                      <p className="text-sm text-destructive">
+                        Latest attention item: {latestFailure.error || `${latestFailure.status.toLowerCase()} owner notification`} on{' '}
+                        {formatDateTime(latestFailure.createdAt)}.
+                      </p>
+                    ) : null}
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <Link className={buttonVariants({ variant: 'default' })} href={`/admin/${business.id}`}>
+                      Open operator page
+                    </Link>
+                    <Link className={buttonVariants({ variant: 'outline' })} href={`/admin/${business.id}/workspace`}>
+                      Open support workspace
+                    </Link>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+                  <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <p className="font-medium text-foreground">Lifecycle</p>
+                    <div className="mt-2 flex flex-wrap gap-2">
                       <Badge variant={getAdminProvisioningStatusVariant(business.provisioningStatus)}>
                         {adminProvisioningStatusLabels[business.provisioningStatus]}
                       </Badge>
-                    </td>
-                    <td className="px-3 py-3">
-                      <div className="font-medium">{managedSummary.label}</div>
-                      <div className="mt-1 text-xs text-muted-foreground">{managedSummary.nextStep}</div>
-                      {business.provisioningError ? <div className="mt-1 text-xs text-destructive">{business.provisioningError}</div> : null}
-                    </td>
-                    <td className="px-3 py-3">
-                      <Badge variant={business.twilioSubaccountSid ? 'success' : 'outline'}>
-                        {business.twilioSubaccountSid ? 'Subaccount ready' : 'Subaccount missing'}
+                      <Badge variant={managedSummary.messagingReady ? 'success' : managedSummary.attentionRequired ? 'destructive' : 'secondary'}>
+                        {managedSummary.messagingReady ? 'Healthy' : managedSummary.attentionRequired ? 'Needs attention' : 'Pending'}
                       </Badge>
-                    </td>
-                    <td className="px-3 py-3">
-                      <div className="font-medium">{hasNumber ? formatPhoneForDisplay(getManagedTextingNumber(business)) : 'No number assigned'}</div>
-                      <div className="text-xs text-muted-foreground">
-                        {business.twilioWebhookSyncedAt ? `Synced ${formatDateTime(business.twilioWebhookSyncedAt)}` : 'Webhook sync needed'}
-                      </div>
-                    </td>
-                    <td className="px-3 py-3">
-                      <Badge variant={managedSummary.messagingReady ? 'success' : managedSummary.onboardingReady ? 'secondary' : 'outline'}>
-                        {managedSummary.messagingReady ? 'Approved' : managedSummary.onboardingReady ? 'A2P pending' : 'Setup pending'}
-                      </Badge>
-                    </td>
-                    <td className="px-3 py-3">
-                      <Badge variant={business.provisioningStatus === 'LIVE' ? 'success' : 'outline'}>
-                        {business.provisioningStatus === 'LIVE' ? 'Yes' : 'No'}
-                      </Badge>
-                    </td>
-                    <td className="px-3 py-3 text-muted-foreground">{formatDateTime(business.updatedAt)}</td>
-                    <td className="px-3 py-3">
-                      <div className="flex flex-col gap-2">
-                        <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`/admin/${business.id}`}>
-                          Open
-                        </Link>
-                        {!hasNumber ? (
-                          <form action={provisionBusinessAction}>
-                            <input type="hidden" name="businessId" value={business.id} />
-                            <input type="hidden" name="mode" value="NEW_NUMBER" />
-                            <Button size="sm" type="submit">Provision</Button>
-                          </form>
-                        ) : (
-                          <form action={resyncBusinessWebhooksAction}>
-                            <input type="hidden" name="businessId" value={business.id} />
-                            <input type="hidden" name="target" value="ALL" />
-                            <Button size="sm" type="submit" variant="outline">Re-sync webhooks</Button>
-                          </form>
-                        )}
-                        <form action={setBusinessProvisioningStatusAction}>
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">{getBusinessLifecycleLabel(business)}</p>
+                  </div>
+
+                  <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <p className="font-medium text-foreground">Twilio readiness</p>
+                    <p className="mt-2">{managedSummary.label}</p>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {assignedNumber ? `Number ${formatPhoneForDisplay(assignedNumber)}` : 'No number assigned yet'}
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <p className="font-medium text-foreground">A2P + webhooks</p>
+                    <p className="mt-2">
+                      {managedSummary.complianceReady ? 'Approved' : managedSummary.complianceStarted ? 'Pending review' : 'Not started'}
+                    </p>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {business.twilioWebhookSyncedAt ? `Webhook sync ${formatRelativeTime(business.twilioWebhookSyncedAt)}` : 'Webhook sync still needed'}
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <p className="font-medium text-foreground">Activity</p>
+                    <p className="mt-2">{leadCount} lead{leadCount === 1 ? '' : 's'}</p>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {lastActivityAt ? `Last activity ${formatRelativeTime(lastActivityAt)}` : 'No activity yet'}
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <p className="font-medium text-foreground">Quick recovery</p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {isBusinessArchived(business) ? (
+                        <form action={restoreBusinessAction}>
                           <input type="hidden" name="businessId" value={business.id} />
-                          <input type="hidden" name="status" value={business.provisioningStatus === 'PAUSED' ? 'ONBOARDING' : 'PAUSED'} />
-                          <Button size="sm" type="submit" variant="ghost">
-                            {business.provisioningStatus === 'PAUSED' ? 'Resume' : 'Pause'}
+                          <input type="hidden" name="confirmationName" value={business.name} />
+                          <Button size="sm" type="submit" variant="outline">
+                            Restore
                           </Button>
                         </form>
-                      </div>
-                    </td>
-                  </tr>
-                );
-                })}
-              </tbody>
-            </table>
-          )}
-        </CardContent>
-      </Card>
+                      ) : !assignedNumber ? (
+                        <form action={provisionBusinessAction}>
+                          <input type="hidden" name="businessId" value={business.id} />
+                          <input type="hidden" name="mode" value="NEW_NUMBER" />
+                          <Button size="sm" type="submit">
+                            Provision
+                          </Button>
+                        </form>
+                      ) : (
+                        <form action={resyncBusinessWebhooksAction}>
+                          <input type="hidden" name="businessId" value={business.id} />
+                          <input type="hidden" name="target" value="ALL" />
+                          <Button size="sm" type="submit" variant="outline">
+                            Re-sync webhooks
+                          </Button>
+                        </form>
+                      )}
+
+                      <form action={setBusinessProvisioningStatusAction}>
+                        <input type="hidden" name="businessId" value={business.id} />
+                        <input type="hidden" name="status" value={business.provisioningStatus === 'PAUSED' ? 'ONBOARDING' : 'PAUSED'} />
+                        <Button size="sm" type="submit" variant="ghost">
+                          {business.provisioningStatus === 'PAUSED' ? 'Resume' : 'Pause'}
+                        </Button>
+                      </form>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
     </div>
   );
 }

--- a/app/simulator/actions.ts
+++ b/app/simulator/actions.ts
@@ -101,6 +101,8 @@ export async function replyToSimulatorRunAction(formData: FormData) {
       ownerClerkId: 'simulator',
       notifyPhone: null,
       subscriptionStatus: SubscriptionStatus.ACTIVE,
+      provisioningStatus: 'LIVE',
+      archivedAt: null,
     },
     leadId: run.leadId,
     body,

--- a/lib/admin-dashboard.ts
+++ b/lib/admin-dashboard.ts
@@ -1,0 +1,429 @@
+import {
+  BusinessProvisioningStatus,
+  ManagedTwilioStatus,
+  OwnerNotificationStatus,
+  type Business,
+  type BusinessNotificationSettings,
+  type Call,
+  type Lead,
+  type Message,
+  type OwnerNotification,
+} from '@prisma/client';
+
+import { getManagedTextingNumber, getManagedTwilioStatusSummary } from '@/lib/managed-twilio-status';
+import { formatMessageStatus, isMessageDeliveryIssueStatus } from '@/lib/lead-presenters';
+
+type DashboardBusiness = Pick<
+  Business,
+  | 'id'
+  | 'name'
+  | 'ownerClerkId'
+  | 'ownerName'
+  | 'isTestBusiness'
+  | 'archivedAt'
+  | 'provisioningStatus'
+  | 'provisioningError'
+  | 'provisioningLastRunAt'
+  | 'forwardingNumber'
+  | 'notifyPhone'
+  | 'twilioSubaccountSid'
+  | 'twilioMessagingServiceSid'
+  | 'twilioPrimaryNumberSid'
+  | 'twilioPhoneNumberSid'
+  | 'twilioPrimaryPhoneNumber'
+  | 'twilioPhoneNumber'
+  | 'twilioWebhookSyncedAt'
+  | 'managedTwilioStatus'
+  | 'a2pCustomerProfileSid'
+  | 'a2pBrandSid'
+  | 'a2pCampaignSid'
+  | 'a2pFailureReason'
+  | 'a2pApprovedAt'
+  | 'subscriptionStatus'
+  | 'stripePriceId'
+  | 'updatedAt'
+>;
+
+type DashboardNotificationSettings = Pick<
+  BusinessNotificationSettings,
+  'ownerPhone' | 'ownerEmail' | 'notifySms' | 'notifyEmail' | 'notifyInApp' | 'urgentOnly'
+>;
+
+type EventMessage = Pick<Message, 'id' | 'leadId' | 'participant' | 'direction' | 'status' | 'body' | 'createdAt'>;
+type EventOwnerNotification = Pick<OwnerNotification, 'id' | 'channel' | 'status' | 'error' | 'createdAt' | 'destination'>;
+type EventLead = Pick<Lead, 'id' | 'status' | 'readiness' | 'billingRequired' | 'smsState' | 'summary' | 'createdAt' | 'lastInteractionAt'>;
+type EventCall = Pick<Call, 'id' | 'status' | 'missed' | 'answered' | 'dialCallStatus' | 'createdAt'>;
+
+export type AdminBoardFilter =
+  | 'all'
+  | 'needs_attention'
+  | 'pending_a2p'
+  | 'not_fully_provisioned'
+  | 'live'
+  | 'paused'
+  | 'archived';
+
+export type AdminBoardFilterOption = {
+  key: AdminBoardFilter;
+  label: string;
+};
+
+export type AdminNextStep = {
+  title: string;
+  detail: string;
+  tone: 'healthy' | 'pending' | 'attention' | 'paused';
+  actionLabel: string;
+};
+
+export type AdminBusinessEvent = {
+  id: string;
+  at: Date;
+  severity: 'info' | 'warning' | 'error';
+  label: string;
+  summary: string;
+  detail: string;
+};
+
+export const adminBoardFilterOptions: AdminBoardFilterOption[] = [
+  { key: 'all', label: 'All' },
+  { key: 'needs_attention', label: 'Needs attention' },
+  { key: 'pending_a2p', label: 'Pending A2P' },
+  { key: 'not_fully_provisioned', label: 'Not fully provisioned' },
+  { key: 'live', label: 'Live' },
+  { key: 'paused', label: 'Paused' },
+  { key: 'archived', label: 'Archived' },
+];
+
+const DEMO_OWNER_CLERK_ID = 'simulator_demo_callbackcloser';
+
+export function isBusinessArchived(business: Pick<DashboardBusiness, 'archivedAt'>) {
+  return Boolean(business.archivedAt);
+}
+
+export function isBusinessAutomationPaused(
+  business: Pick<DashboardBusiness, 'provisioningStatus' | 'archivedAt'>
+) {
+  return business.provisioningStatus === BusinessProvisioningStatus.PAUSED || isBusinessArchived(business);
+}
+
+export function canDeleteTestBusiness(
+  business: Pick<DashboardBusiness, 'isTestBusiness' | 'ownerClerkId' | 'archivedAt'>
+) {
+  return isBusinessArchived(business) && (business.isTestBusiness || business.ownerClerkId === DEMO_OWNER_CLERK_ID);
+}
+
+export function getBusinessLifecycleLabel(
+  business: Pick<DashboardBusiness, 'archivedAt' | 'provisioningStatus'>
+) {
+  if (isBusinessArchived(business)) return 'Archived';
+  if (business.provisioningStatus === BusinessProvisioningStatus.PAUSED) return 'Paused';
+  if (business.provisioningStatus === BusinessProvisioningStatus.LIVE) return 'Live';
+  return 'Active';
+}
+
+export function getBusinessCommercialPlanLabel(
+  business: Pick<DashboardBusiness, 'stripePriceId' | 'subscriptionStatus'>
+) {
+  if (business.stripePriceId) {
+    const compact = business.stripePriceId.replace(/^price_/, '');
+    return compact.length > 18 ? `${compact.slice(0, 18)}…` : compact;
+  }
+
+  return business.subscriptionStatus.toLowerCase();
+}
+
+export function buildAdminNextStep(params: {
+  business: DashboardBusiness;
+  notificationSettings: DashboardNotificationSettings | null;
+  ownerConnected: boolean;
+}): AdminNextStep {
+  const { business, notificationSettings, ownerConnected } = params;
+  const managedSummary = getManagedTwilioStatusSummary(business);
+  const ownerEmail = notificationSettings?.ownerEmail?.trim() || null;
+  const ownerPhone = notificationSettings?.ownerPhone?.trim() || business.notifyPhone || null;
+  const hasTextingNumber = Boolean(getManagedTextingNumber(business) && (business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid));
+
+  if (isBusinessArchived(business)) {
+    return {
+      title: 'Business archived',
+      detail: 'Automation is off and the workspace is hidden from normal triage. Restore it only if this customer should become active again.',
+      tone: 'paused',
+      actionLabel: 'Restore business',
+    };
+  }
+
+  if (business.provisioningStatus === BusinessProvisioningStatus.PAUSED) {
+    return {
+      title: 'Automation is paused',
+      detail: 'New missed calls are preserved, but automation should stay off until you resume this business.',
+      tone: 'paused',
+      actionLabel: 'Resume automation',
+    };
+  }
+
+  if (business.provisioningError) {
+    return {
+      title: 'Provisioning needs attention',
+      detail: business.provisioningError,
+      tone: 'attention',
+      actionLabel: hasTextingNumber ? 'Re-run provisioning' : 'Finish provisioning',
+    };
+  }
+
+  if (!ownerEmail && !ownerPhone) {
+    return {
+      title: 'Owner contact info is missing',
+      detail: 'Add the owner email or alert phone so CallbackCloser can route invites and alerts without manual digging.',
+      tone: 'attention',
+      actionLabel: 'Save owner contact info',
+    };
+  }
+
+  if (!ownerConnected) {
+    return {
+      title: 'Owner account still needs connection',
+      detail: ownerEmail
+        ? 'The business is saved, but the Clerk owner is not attached yet. Re-run the owner connection flow from admin.'
+        : 'Add the owner email first, then connect or invite the owner.',
+      tone: 'attention',
+      actionLabel: 'Connect owner',
+    };
+  }
+
+  if (!business.twilioSubaccountSid) {
+    return {
+      title: 'Twilio subaccount is missing',
+      detail: 'Managed provisioning cannot finish until the business has a Twilio subaccount attached.',
+      tone: 'attention',
+      actionLabel: 'Re-run provisioning',
+    };
+  }
+
+  if (!hasTextingNumber) {
+    return {
+      title: 'No texting number is assigned',
+      detail: 'Provision a new number or attach the approved existing number so missed-call SMS can start.',
+      tone: 'attention',
+      actionLabel: 'Provision number',
+    };
+  }
+
+  if (!business.twilioMessagingServiceSid) {
+    return {
+      title: 'Messaging service is missing',
+      detail: 'The business has a number, but Twilio messaging still needs a Messaging Service for compliant delivery.',
+      tone: 'attention',
+      actionLabel: 'Re-run provisioning',
+    };
+  }
+
+  if (!business.twilioWebhookSyncedAt) {
+    return {
+      title: 'Webhook sync is missing',
+      detail: 'The assigned number still needs the current voice, SMS, and status callback URLs synced from admin.',
+      tone: 'attention',
+      actionLabel: 'Re-sync webhooks',
+    };
+  }
+
+  if (business.managedTwilioStatus === ManagedTwilioStatus.AWAITING_BUSINESS_VERIFICATION) {
+    return {
+      title: 'Business verification still needed',
+      detail: 'Messaging is wired up, but the A2P business details still need to be completed before compliant live texting can launch.',
+      tone: 'pending',
+      actionLabel: 'Review A2P readiness',
+    };
+  }
+
+  if (business.managedTwilioStatus === ManagedTwilioStatus.BRAND_SUBMITTED) {
+    return {
+      title: 'A2P brand submitted',
+      detail: 'Brand review is in progress. No action is needed unless Twilio requests changes.',
+      tone: 'pending',
+      actionLabel: 'Watch for review updates',
+    };
+  }
+
+  if (business.managedTwilioStatus === ManagedTwilioStatus.CAMPAIGN_SUBMITTED) {
+    return {
+      title: 'A2P campaign still pending',
+      detail: 'The campaign is waiting on Twilio or carrier review. No action is needed yet.',
+      tone: 'pending',
+      actionLabel: 'Wait for approval',
+    };
+  }
+
+  if (managedSummary.attentionRequired) {
+    return {
+      title: 'Compliance review needs attention',
+      detail: business.a2pFailureReason || managedSummary.nextStep,
+      tone: 'attention',
+      actionLabel: 'Review compliance notes',
+    };
+  }
+
+  if (managedSummary.messagingReady && business.provisioningStatus !== BusinessProvisioningStatus.LIVE) {
+    return {
+      title: 'Ready to go live',
+      detail: 'Infrastructure and compliance look ready. Mark the business live when you want automation active.',
+      tone: 'pending',
+      actionLabel: 'Mark live',
+    };
+  }
+
+  if (managedSummary.messagingReady && business.provisioningStatus === BusinessProvisioningStatus.LIVE) {
+    return {
+      title: 'Business is live and healthy',
+      detail: 'Twilio, webhooks, alerts, and rollout status all look ready for normal operator monitoring.',
+      tone: 'healthy',
+      actionLabel: 'Open support workspace',
+    };
+  }
+
+  return {
+    title: 'Finish onboarding',
+    detail: managedSummary.nextStep,
+    tone: 'pending',
+    actionLabel: 'Review provisioning health',
+  };
+}
+
+export function matchesAdminBoardFilter(
+  business: DashboardBusiness,
+  notificationSettings: DashboardNotificationSettings | null,
+  ownerConnected: boolean,
+  filter: AdminBoardFilter
+) {
+  if (filter === 'all') return true;
+
+  const managedSummary = getManagedTwilioStatusSummary(business);
+  const nextStep = buildAdminNextStep({ business, notificationSettings, ownerConnected });
+  const archived = isBusinessArchived(business);
+  const paused = isBusinessAutomationPaused(business) && !archived;
+
+  if (filter === 'archived') return archived;
+  if (archived) return false;
+
+  if (filter === 'paused') {
+    return paused || business.managedTwilioStatus === ManagedTwilioStatus.PAUSED_NONCOMPLIANT;
+  }
+
+  if (filter === 'live') {
+    return business.provisioningStatus === BusinessProvisioningStatus.LIVE && managedSummary.messagingReady;
+  }
+
+  if (filter === 'pending_a2p') {
+    return (
+      business.managedTwilioStatus === ManagedTwilioStatus.AWAITING_BUSINESS_VERIFICATION ||
+      business.managedTwilioStatus === ManagedTwilioStatus.BRAND_SUBMITTED ||
+      business.managedTwilioStatus === ManagedTwilioStatus.CAMPAIGN_SUBMITTED
+    );
+  }
+
+  if (filter === 'not_fully_provisioned') {
+    return !managedSummary.onboardingReady || !ownerConnected;
+  }
+
+  if (filter === 'needs_attention') {
+    return nextStep.tone === 'attention';
+  }
+
+  return true;
+}
+
+function compactBody(value: string, maxLength = 120) {
+  const trimmed = value.trim();
+  if (!trimmed) return 'No extra detail recorded.';
+  if (trimmed.length <= maxLength) return trimmed;
+  return `${trimmed.slice(0, maxLength - 1)}…`;
+}
+
+export function buildAdminBusinessEvents(params: {
+  business: DashboardBusiness;
+  messages: EventMessage[];
+  ownerNotifications: EventOwnerNotification[];
+  leads: EventLead[];
+  calls: EventCall[];
+}) {
+  const events: AdminBusinessEvent[] = [];
+
+  if (params.business.provisioningLastRunAt) {
+    events.push({
+      id: 'provisioning-run',
+      at: params.business.provisioningLastRunAt,
+      severity: params.business.provisioningError ? 'error' : 'info',
+      label: 'Provisioning',
+      summary: params.business.provisioningError ? 'Latest provisioning run failed' : 'Latest provisioning run completed',
+      detail: params.business.provisioningError || 'The most recent admin provisioning run completed without a stored error.',
+    });
+  }
+
+  if (getManagedTextingNumber(params.business) && !params.business.twilioWebhookSyncedAt) {
+    events.push({
+      id: 'webhook-sync-missing',
+      at: params.business.updatedAt,
+      severity: 'warning',
+      label: 'Webhook sync',
+      summary: 'Assigned number still needs webhook sync',
+      detail: 'The business has a number assigned, but admin has not recorded a webhook sync yet.',
+    });
+  }
+
+  for (const notification of params.ownerNotifications) {
+    const severity =
+      notification.status === OwnerNotificationStatus.FAILED
+        ? 'error'
+        : notification.status === OwnerNotificationStatus.SKIPPED
+          ? 'warning'
+          : 'info';
+    events.push({
+      id: `notification-${notification.id}`,
+      at: notification.createdAt,
+      severity,
+      label: `Owner ${notification.channel.toLowerCase()} alert`,
+      summary:
+        notification.status === OwnerNotificationStatus.FAILED
+          ? 'Owner alert failed'
+          : notification.status === OwnerNotificationStatus.SKIPPED
+            ? 'Owner alert skipped'
+            : 'Owner alert sent',
+      detail: notification.error || notification.destination || 'Owner notification recorded.',
+    });
+  }
+
+  for (const message of params.messages) {
+    const issue = isMessageDeliveryIssueStatus(message.status);
+    events.push({
+      id: `message-${message.id}`,
+      at: message.createdAt,
+      severity: issue ? 'error' : 'info',
+      label: message.participant === 'OWNER' ? 'Owner SMS' : 'Lead SMS',
+      summary: `${message.direction === 'OUTBOUND' ? 'Outbound' : 'Inbound'} message${message.status ? ` · ${formatMessageStatus(message.status)}` : ''}`,
+      detail: compactBody(message.body),
+    });
+  }
+
+  for (const lead of params.leads) {
+    events.push({
+      id: `lead-${lead.id}`,
+      at: lead.lastInteractionAt || lead.createdAt,
+      severity: lead.billingRequired ? 'warning' : 'info',
+      label: 'Lead activity',
+      summary: `${lead.status.toLowerCase()} lead · ${lead.readiness.toLowerCase()}`,
+      detail: lead.summary || `SMS state: ${lead.smsState.toLowerCase().replace(/_/g, ' ')}.`,
+    });
+  }
+
+  for (const call of params.calls) {
+    events.push({
+      id: `call-${call.id}`,
+      at: call.createdAt,
+      severity: call.missed ? 'warning' : 'info',
+      label: 'Call event',
+      summary: call.missed ? 'Missed call captured' : call.answered ? 'Answered call recorded' : 'Call status recorded',
+      detail: call.dialCallStatus || call.status,
+    });
+  }
+
+  return events.sort((left, right) => right.at.getTime() - left.at.getTime());
+}

--- a/lib/missed-call-flow.ts
+++ b/lib/missed-call-flow.ts
@@ -1,5 +1,6 @@
 import { LeadStatus, SmsConversationState, type Business, type Lead } from '@prisma/client';
 
+import { isBusinessAutomationPaused } from '@/lib/admin-dashboard';
 import { db } from '@/lib/db';
 import { buildLeadSummary, getLeadReadiness, getQualifiedLeadStatus, isLeadQualified } from '@/lib/lead-qualification';
 import { notifyQualifiedLeadIfNeeded } from '@/lib/owner-notifications';
@@ -21,6 +22,8 @@ type LeadFlowBusiness = Pick<
   | 'managedTwilioStatus'
   | 'a2pFailureReason'
   | 'subscriptionStatus'
+  | 'provisioningStatus'
+  | 'archivedAt'
   | 'serviceLabel1'
   | 'serviceLabel2'
   | 'serviceLabel3'
@@ -147,6 +150,14 @@ export async function startMissedCallRecovery(params: StartRecoveryParams) {
     });
   }
 
+  if (isBusinessAutomationPaused(params.business)) {
+    return {
+      lead,
+      started: false as const,
+      reason: 'automation_paused' as const,
+    };
+  }
+
   const fromPhone = getBusinessTextingNumber(params.business);
   if (!fromPhone || lead.smsStartedAt || (!params.forceAutomation && lead.billingRequired)) {
     return {
@@ -255,7 +266,7 @@ export async function processLeadInboundReply(params: ProcessReplyParams) {
   }
 
   const fromPhone = getBusinessTextingNumber(params.business);
-  if (!fromPhone) {
+  if (!fromPhone || isBusinessAutomationPaused(params.business)) {
     return { lead: updatedLead, transition, duplicate: false as const, notificationResult };
   }
 

--- a/lib/owner-notifications.ts
+++ b/lib/owner-notifications.ts
@@ -1,6 +1,7 @@
 import { LeadReadiness, LeadStatus, OwnerNotificationChannel, OwnerNotificationStatus, type Business, type Lead } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 
+import { isBusinessAutomationPaused } from '@/lib/admin-dashboard';
 import { getEffectiveBusinessNotificationSettings } from '@/lib/business-notification-settings';
 import { db } from '@/lib/db';
 import { sendTransactionalEmail } from '@/lib/email';
@@ -137,6 +138,8 @@ async function getLeadForOwnerNotifications(leadId: string) {
           twilioPhoneNumber: true,
           managedTwilioStatus: true,
           a2pFailureReason: true,
+          provisioningStatus: true,
+          archivedAt: true,
         },
       },
     },
@@ -310,6 +313,9 @@ export async function notifyQualifiedLeadIfNeeded(leadId: string) {
   if (!lead) return { notified: false, reason: 'lead_not_found' as const };
   if (!isLeadQualified(lead)) return { notified: false, reason: 'lead_not_qualified' as const };
   if (lead.notifiedAt) return { notified: false, reason: 'already_notified' as const };
+  if (isBusinessAutomationPaused(lead.business)) {
+    return { notified: false, reason: 'business_paused' as const };
+  }
 
   const settings = await getEffectiveBusinessNotificationSettings(lead.business);
   if (settings.urgentOnly && lead.readiness !== LeadReadiness.URGENT) {

--- a/lib/portfolio-demo.ts
+++ b/lib/portfolio-demo.ts
@@ -35,6 +35,8 @@ const demoBusiness: Business = {
   ownerClerkId: DEMO_USER_ID,
   name: 'Northside HVAC & Plumbing (Demo)',
   ownerName: 'Jordan Smith',
+  isTestBusiness: false,
+  archivedAt: null,
   forwardingNumber: '+15125550111',
   notifyPhone: '+15125550199',
   provisioningStatus: BusinessProvisioningStatus.LIVE,

--- a/lib/simulator.ts
+++ b/lib/simulator.ts
@@ -52,6 +52,8 @@ export async function getSimulatorBusiness() {
       managedTwilioStatus: true,
       a2pFailureReason: true,
       subscriptionStatus: true,
+      provisioningStatus: true,
+      archivedAt: true,
       serviceLabel1: true,
       serviceLabel2: true,
       serviceLabel3: true,
@@ -84,6 +86,8 @@ export async function getSimulatorRun(publicId: string) {
           twilioPrimaryPhoneNumber: true,
           managedTwilioStatus: true,
           a2pFailureReason: true,
+          provisioningStatus: true,
+          archivedAt: true,
           serviceLabel1: true,
           serviceLabel2: true,
           serviceLabel3: true,
@@ -105,6 +109,8 @@ export type SimulatorRunRecord = SimulatorRun & {
     | 'twilioPrimaryPhoneNumber'
     | 'managedTwilioStatus'
     | 'a2pFailureReason'
+    | 'provisioningStatus'
+    | 'archivedAt'
     | 'serviceLabel1'
     | 'serviceLabel2'
     | 'serviceLabel3'

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -42,6 +42,7 @@ export const adminBusinessDraftSchema = z.object({
   ownerName: z.string().trim().max(120).optional().or(z.literal('')),
   ownerEmail: z.string().trim().email(),
   ownerPhone: z.string().max(30).optional().or(z.literal('')),
+  isTestBusiness: z.coerce.boolean().optional().default(false),
   forwardingNumber: z.string().min(7).max(30),
   timezone: z.string().min(2).max(100).default('America/New_York'),
   missedCallSeconds: z.coerce.number().int().min(5).max(90).default(20),
@@ -122,6 +123,21 @@ export const adminWebhookSyncSchema = z.object({
 export const adminProvisioningStatusSchema = z.object({
   businessId: z.string().min(1),
   status: z.enum(['DRAFT', 'ONBOARDING', 'NEEDS_ATTENTION', 'LIVE', 'PAUSED']),
+});
+
+export const adminSendTestSmsSchema = z.object({
+  businessId: z.string().min(1),
+  destinationPhone: z.string().trim().min(7).max(30),
+});
+
+export const adminArchiveBusinessSchema = z.object({
+  businessId: z.string().min(1),
+  confirmationName: z.string().trim().min(1),
+});
+
+export const adminDeleteBusinessSchema = z.object({
+  businessId: z.string().min(1),
+  confirmationName: z.string().trim().min(1),
 });
 
 export const businessTwilioAdminOverrideSchema = z.object({

--- a/prisma/migrations/20260417173000_add_admin_business_lifecycle_flags/migration.sql
+++ b/prisma/migrations/20260417173000_add_admin_business_lifecycle_flags/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "Business"
+ADD COLUMN "archivedAt" TIMESTAMP(3),
+ADD COLUMN "isTestBusiness" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE INDEX "Business_archivedAt_idx" ON "Business"("archivedAt");
+
+-- CreateIndex
+CREATE INDEX "Business_isTestBusiness_idx" ON "Business"("isTestBusiness");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,8 @@ model Business {
   ownerClerkId                String             @unique
   name                        String
   ownerName                   String?
+  isTestBusiness              Boolean            @default(false)
+  archivedAt                  DateTime?
   forwardingNumber            String
   notifyPhone                 String?
   provisioningStatus          BusinessProvisioningStatus @default(DRAFT)
@@ -58,6 +60,8 @@ model Business {
   smsConsents                 SmsConsent[]
 
   @@index([subscriptionStatus])
+  @@index([archivedAt])
+  @@index([isTestBusiness])
 }
 
 model Call {

--- a/tests/admin-dashboard.test.ts
+++ b/tests/admin-dashboard.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { BusinessProvisioningStatus, ManagedTwilioStatus, SubscriptionStatus } from '@prisma/client';
+
+import {
+  buildAdminBusinessEvents,
+  buildAdminNextStep,
+  canDeleteTestBusiness,
+  matchesAdminBoardFilter,
+} from '../lib/admin-dashboard.ts';
+
+function createBusiness(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'biz_123',
+    name: 'Acme Plumbing',
+    ownerClerkId: 'user_123',
+    ownerName: 'Casey Owner',
+    isTestBusiness: false,
+    archivedAt: null,
+    forwardingNumber: '+15557654321',
+    notifyPhone: '+15551234567',
+    provisioningStatus: BusinessProvisioningStatus.ONBOARDING,
+    provisioningLastRunAt: new Date('2026-04-15T00:00:00.000Z'),
+    provisioningError: null,
+    twilioSubaccountSid: 'AC_TEST_SUBACCOUNT',
+    twilioMessagingServiceSid: 'MG_TEST_SERVICE',
+    twilioPrimaryNumberSid: 'PN_TEST_PRIMARY',
+    twilioPhoneNumberSid: 'PN_TEST_PRIMARY',
+    twilioPrimaryPhoneNumber: '+15550001111',
+    twilioPhoneNumber: '+15550001111',
+    twilioWebhookSyncedAt: new Date('2026-04-15T00:00:00.000Z'),
+    managedTwilioStatus: ManagedTwilioStatus.CAMPAIGN_SUBMITTED,
+    a2pCustomerProfileSid: 'BU_TEST_PROFILE',
+    a2pBrandSid: 'BN_TEST_BRAND',
+    a2pCampaignSid: 'QE_TEST_CAMPAIGN',
+    a2pFailureReason: null,
+    a2pApprovedAt: null,
+    subscriptionStatus: SubscriptionStatus.ACTIVE,
+    stripePriceId: 'price_callbackcloser_pro',
+    updatedAt: new Date('2026-04-15T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createNotificationSettings(overrides: Record<string, unknown> = {}) {
+  return {
+    ownerPhone: '+15551234567',
+    ownerEmail: 'owner@example.com',
+    notifySms: true,
+    notifyEmail: true,
+    notifyInApp: true,
+    urgentOnly: false,
+    ...overrides,
+  };
+}
+
+test('next-step guidance calls out webhook recovery and live health clearly', () => {
+  const webhookMissing = buildAdminNextStep({
+    business: createBusiness({ twilioWebhookSyncedAt: null, managedTwilioStatus: ManagedTwilioStatus.AWAITING_BUSINESS_VERIFICATION }),
+    notificationSettings: createNotificationSettings(),
+    ownerConnected: true,
+  });
+
+  assert.equal(webhookMissing.title, 'Webhook sync is missing');
+  assert.match(webhookMissing.detail, /status callback URLs/i);
+
+  const healthy = buildAdminNextStep({
+    business: createBusiness({
+      provisioningStatus: BusinessProvisioningStatus.LIVE,
+      managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+      a2pApprovedAt: new Date('2026-04-15T00:00:00.000Z'),
+    }),
+    notificationSettings: createNotificationSettings(),
+    ownerConnected: true,
+  });
+
+  assert.equal(healthy.title, 'Business is live and healthy');
+  assert.equal(healthy.tone, 'healthy');
+});
+
+test('board filters and delete guard stay conservative', () => {
+  const pausedTestBusiness = createBusiness({
+    isTestBusiness: true,
+    archivedAt: new Date('2026-04-16T00:00:00.000Z'),
+    provisioningStatus: BusinessProvisioningStatus.PAUSED,
+  });
+
+  assert.equal(canDeleteTestBusiness(pausedTestBusiness), true);
+  assert.equal(
+    matchesAdminBoardFilter(pausedTestBusiness, createNotificationSettings(), true, 'archived'),
+    true
+  );
+  assert.equal(
+    matchesAdminBoardFilter(createBusiness(), createNotificationSettings(), true, 'pending_a2p'),
+    true
+  );
+  assert.equal(
+    canDeleteTestBusiness(createBusiness({ isTestBusiness: false, archivedAt: new Date('2026-04-16T00:00:00.000Z') })),
+    false
+  );
+});
+
+test('recent event synthesis prioritizes provisioning failures and owner alert failures', () => {
+  const events = buildAdminBusinessEvents({
+    business: createBusiness({
+      provisioningError: 'Messaging service missing after attach.',
+      provisioningLastRunAt: new Date('2026-04-17T10:00:00.000Z'),
+      twilioWebhookSyncedAt: null,
+    }),
+    messages: [
+      {
+        id: 'msg_1',
+        leadId: 'lead_1',
+        participant: 'LEAD',
+        direction: 'OUTBOUND',
+        status: 'failed',
+        body: 'CallbackCloser: We missed your call.',
+        createdAt: new Date('2026-04-17T09:58:00.000Z'),
+      },
+    ],
+    ownerNotifications: [
+      {
+        id: 'notify_1',
+        channel: 'SMS',
+        status: 'FAILED',
+        error: 'Owner SMS failed',
+        createdAt: new Date('2026-04-17T09:59:00.000Z'),
+        destination: '+15551234567',
+      },
+    ],
+    leads: [],
+    calls: [],
+  });
+
+  assert.equal(events[0]?.label, 'Provisioning');
+  assert.equal(events.some((event) => event.label === 'Owner sms alert' && event.severity === 'error'), true);
+  assert.equal(events.some((event) => event.label === 'Lead SMS' && event.severity === 'error'), true);
+});

--- a/tests/admin-operator-routes.test.ts
+++ b/tests/admin-operator-routes.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+function read(path: string) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+test('admin routes expose support workspace and safe lifecycle controls', () => {
+  const adminHome = read('app/admin/page.tsx');
+  const adminDetail = read('app/admin/[businessId]/page.tsx');
+  const supportWorkspace = read('app/admin/[businessId]/workspace/page.tsx');
+
+  assert.match(adminHome, /Operator triage board/);
+  assert.match(adminHome, /Open support workspace/);
+  assert.match(adminDetail, /What should I do next\?/);
+  assert.match(adminDetail, /Archive \/ delete controls/);
+  assert.match(adminDetail, /Send test SMS/);
+  assert.match(supportWorkspace, /support workspace/);
+  assert.match(supportWorkspace, /Read-only snapshot/);
+});


### PR DESCRIPTION
## Summary
- replace the raw provisioning table with an owner-first operator triage board and business health filters
- reorganize the business detail page around next-step guidance, grouped operational status, quick actions, support workspace access, and recent events
- add safe archive/delete test-business controls, lifecycle flags, support workspace routing, and focused admin dashboard tests

## Validation
- npm install
- npm run env:check
- npm run preflight:providers
- npm run typecheck
- npm run lint
- npm run test
- npm run build
- npx prisma migrate deploy
- npx prisma migrate status