### PR TITLE
Fix public SMS consent disclosure wording

### DIFF
--- a/app/app/settings/page.tsx
+++ b/app/app/settings/page.tsx
@@ -474,7 +474,9 @@ export default async function SettingsPage({ searchParams }: { searchParams?: Re
                 <div className="rounded-xl border bg-muted/20 p-4">
                   <p className="font-medium">Message disclaimer preview</p>
                   <p className="mt-2 text-muted-foreground">
-                    By replying, callers consent to text messages related to their missed call. Message frequency varies. Message and data rates may apply. Reply STOP to opt out, HELP for help.
+                    By providing a phone number and agreeing to receive messages, callers consent to SMS from CallbackCloser related
+                    to callback coordination, customer support, service updates, and account or service notifications tied to their
+                    request. Message frequency varies. Message and data rates may apply. Reply STOP to opt out or HELP for help.
                   </p>
                 </div>
               </CardContent>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -28,16 +28,16 @@ export default function PrivacyPage() {
           <section className="space-y-2">
             <h2 className="text-xl font-semibold">How We Use Data</h2>
             <p className="text-sm text-muted-foreground">
-              Data is used to deliver missed-call follow-up, surface leads in the dashboard, support customer care, send account
-              notifications, deliver service updates, maintain service reliability, and support account operations.
+              Data is used to support callback coordination, customer support, service updates, account or service notifications,
+              lead visibility in the dashboard, service reliability, and account operations.
             </p>
           </section>
 
           <section className="space-y-2">
             <h2 className="text-xl font-semibold">SMS And Customer Communications</h2>
             <p className="text-sm text-muted-foreground">
-              CallbackCloser may process phone numbers, missed-call records, and SMS conversation content to provide customer care,
-              account notifications, missed call follow-up, and service updates tied to the CallbackCloser workflow.
+              CallbackCloser may process phone numbers, missed-call records, and SMS conversation content to provide callback
+              coordination, customer support, service updates, and account or service notifications related to a user&apos;s request.
             </p>
             <p className="text-sm text-muted-foreground">
               Message frequency varies by conversation. Message and data rates may apply. Recipients can reply STOP to opt out or HELP

--- a/app/sms-consent/page.tsx
+++ b/app/sms-consent/page.tsx
@@ -11,15 +11,16 @@ const EFFECTIVE_DATE = 'April 5, 2026';
 export const metadata: Metadata = {
   title: 'SMS Consent | CallbackCloser',
   description:
-    'Review the SMS consent disclosure language CallbackCloser uses for missed call follow-up, callback coordination, customer care, and account updates.',
+    'CallbackCloser uses SMS messaging to respond to customer inquiries and provide service-related updates.',
 };
 
-const messageTypes = ['Missed call follow-up', 'Callback coordination', 'Service updates', 'Customer care', 'Account notifications'];
-const messageDetails = [
+const messageExamples = ['Callback coordination', 'Customer support', 'Service-related questions', 'Status updates', 'Account or service notifications'];
+const requiredDisclosures = [
   'Message frequency varies.',
   'Message and data rates may apply.',
   'Reply STOP to opt out.',
   'Reply HELP for help.',
+  'Contact: support@callbackcloser.com',
 ];
 
 export default function SmsConsentPage() {
@@ -29,12 +30,11 @@ export default function SmsConsentPage() {
 
       <main className="container py-12">
         <article className="mx-auto max-w-4xl space-y-8">
-          <header className="max-w-2xl space-y-3">
+          <header className="max-w-3xl space-y-3">
             <h1 className="text-4xl font-semibold tracking-tight">SMS Consent</h1>
             <p className="text-sm text-muted-foreground">Effective date: {EFFECTIVE_DATE}</p>
             <p className="text-base text-muted-foreground">
-              Review the disclosure language CallbackCloser uses in live SMS opt-in flows for missed call follow-up, callback
-              coordination, service updates, customer care, and account notifications.
+              CallbackCloser uses SMS messaging to respond to customer inquiries and provide service-related updates.
             </p>
           </header>
 
@@ -44,62 +44,58 @@ export default function SmsConsentPage() {
             <div className="space-y-6">
               <Card>
                 <CardHeader>
-                  <CardTitle>What to expect</CardTitle>
-                  <CardDescription>CallbackCloser uses text messages to keep service conversations moving after a missed call.</CardDescription>
+                  <CardTitle>Consent explanation</CardTitle>
+                  <CardDescription>
+                    By providing a phone number and agreeing to the disclosure, the user consents to receive SMS messages from
+                    CallbackCloser related to callback coordination, customer support, service updates, and account or service
+                    notifications related to the user&apos;s request.
+                  </CardDescription>
                 </CardHeader>
-                <CardContent className="space-y-3 text-sm text-muted-foreground">
-                  <div className="grid gap-2 sm:grid-cols-2">
-                    {messageTypes.map((type) => (
-                      <div key={type} className="rounded-lg border bg-muted/30 px-4 py-3">
-                        <p className="font-medium text-foreground">{type}</p>
-                      </div>
-                    ))}
-                  </div>
+                <CardContent className="text-sm text-muted-foreground">
+                  Consent to receive SMS messages is not a condition of purchase.
                 </CardContent>
               </Card>
 
               <Card>
                 <CardHeader>
-                  <CardTitle>Message details</CardTitle>
-                  <CardDescription>Live opt-in flows must show these terms before consent is captured.</CardDescription>
+                  <CardTitle>These messages may include</CardTitle>
+                  <CardDescription>CallbackCloser uses SMS for coordination, support, and service-related communication tied to a request.</CardDescription>
                 </CardHeader>
-                <CardContent className="space-y-2 text-sm text-muted-foreground">
-                  {messageDetails.map((item) => (
-                    <p key={item}>- {item}</p>
+                <CardContent className="grid gap-2 sm:grid-cols-2">
+                  {messageExamples.map((item) => (
+                    <div key={item} className="rounded-lg border bg-muted/30 px-4 py-3 text-sm">
+                      <p className="font-medium text-foreground">{item}</p>
+                    </div>
                   ))}
                 </CardContent>
               </Card>
 
               <Card>
                 <CardHeader>
-                  <CardTitle>Related trust pages</CardTitle>
-                  <CardDescription>Review the policies connected to CallbackCloser messaging and service use.</CardDescription>
+                  <CardTitle>Required disclosures</CardTitle>
+                  <CardDescription>These terms apply to service-related SMS messages sent by CallbackCloser.</CardDescription>
                 </CardHeader>
-                <CardContent className="flex flex-wrap gap-3 text-sm">
-                  <Link className="underline underline-offset-4" href="/privacy">
-                    Privacy Policy
-                  </Link>
-                  <Link className="underline underline-offset-4" href="/terms">
-                    Terms &amp; Conditions
-                  </Link>
-                  <Link className="underline underline-offset-4" href="/contact">
-                    Contact
-                  </Link>
+                <CardContent className="space-y-2 text-sm text-muted-foreground">
+                  {requiredDisclosures.map((item) => (
+                    <p key={item}>- {item}</p>
+                  ))}
                 </CardContent>
               </Card>
 
-              <p className="text-sm text-muted-foreground">
-                This page is a public compliance reference. CallbackCloser records consent inside the actual signup, intake, or customer
-                messaging flow, not on this page.
-              </p>
-
-              <p className="text-sm text-muted-foreground">
-                Need help? Email{' '}
-                <a className="underline underline-offset-4" href="mailto:support@callbackcloser.com">
-                  support@callbackcloser.com
-                </a>
-                .
-              </p>
+              <div className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground">
+                <p className="font-medium text-foreground">Related policies</p>
+                <p className="mt-2">
+                  Review our{' '}
+                  <Link className="underline underline-offset-4" href="/privacy">
+                    Privacy Policy
+                  </Link>{' '}
+                  and{' '}
+                  <Link className="underline underline-offset-4" href="/terms">
+                    Terms &amp; Conditions
+                  </Link>
+                  .
+                </p>
+              </div>
             </div>
           </section>
         </article>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -34,8 +34,8 @@ export default function TermsPage() {
           <section className="space-y-2">
             <h2 className="text-xl font-semibold">SMS Messaging</h2>
             <p className="text-sm text-muted-foreground">
-              CallbackCloser currently uses SMS for customer care, account notifications, missed call follow-up, and service updates.
-              CallbackCloser is not presented on the public website as a promotional SMS marketing program.
+              CallbackCloser uses SMS for callback coordination, customer support, service updates, and account or service
+              notifications related to a user&apos;s request.
             </p>
             <p className="text-sm text-muted-foreground">
               Public opt-in language is described on the{' '}
@@ -43,7 +43,7 @@ export default function TermsPage() {
                 SMS Consent
               </Link>{' '}
               page. Recipients can use STOP to opt out and HELP for help where messaging is active. Message frequency varies and
-              message and data rates may apply.
+              message and data rates may apply. Consent to receive SMS messages is not a condition of purchase.
             </p>
           </section>
 

--- a/components/public-sms-consent-form.tsx
+++ b/components/public-sms-consent-form.tsx
@@ -1,39 +1,31 @@
 import Link from 'next/link';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 
 export function PublicSmsConsentForm() {
   return (
     <Card className="border-primary/20 bg-card/95">
       <CardHeader>
-        <CardTitle>Consent language reference</CardTitle>
+        <CardTitle>Consent disclosure</CardTitle>
         <CardDescription>
-          This page documents the disclosure language CallbackCloser uses for SMS opt-in flows. It does not submit or store phone numbers.
+          By providing a phone number and agreeing to this disclosure, a user consents to receive SMS messages from CallbackCloser
+          related to callback coordination, customer support, service updates, and account or service notifications related to the
+          user&apos;s request.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="space-y-2">
-          <Label htmlFor="sms-consent-phone">Example mobile number field</Label>
-          <Input defaultValue="+1 555 123 4567" disabled id="sms-consent-phone" inputMode="tel" name="phone" type="tel" />
-          <p className="text-xs text-muted-foreground">Use a real phone field in your live signup or intake flow before recording consent.</p>
-        </div>
-
         <div className="rounded-lg border bg-muted/30 p-4">
           <div className="flex items-start gap-3 text-sm text-muted-foreground">
             <input
-              checked={false}
+              defaultChecked={false}
               className="mt-1 h-4 w-4 rounded border"
-              disabled
               id="sms-consent-checkbox"
               name="consent"
-              readOnly
               type="checkbox"
             />
             <span>
-              By checking this box, you agree to receive SMS messages from CallbackCloser related to customer care and account
-              notifications. Message frequency varies. Message and data rates may apply. Reply STOP to opt out or HELP for help. See our{' '}
+              I agree to receive SMS messages from CallbackCloser related to my request. Message frequency varies. Message &amp; data
+              rates may apply. Reply STOP to opt out or HELP for help. See our{' '}
               <Link className="underline underline-offset-4" href="/privacy">
                 Privacy Policy
               </Link>{' '}
@@ -44,14 +36,14 @@ export function PublicSmsConsentForm() {
               .
             </span>
           </div>
-          <p className="mt-3 text-xs text-muted-foreground">
-            In production, your real consent flow should require an unchecked checkbox and a phone number before submission.
-          </p>
+          <p className="mt-3 text-xs text-muted-foreground">Consent to receive SMS messages is not a condition of purchase.</p>
         </div>
 
         <div className="rounded-lg border bg-background/80 p-4 text-sm text-muted-foreground">
-          This public page is a compliance reference for buyers, carriers, and reviewers. It does not create a subscription, submit
-          consent, or capture any phone number data by itself.
+          Support contact:{' '}
+          <a className="underline underline-offset-4" href="mailto:support@callbackcloser.com">
+            support@callbackcloser.com
+          </a>
         </div>
       </CardContent>
     </Card>

--- a/tests/legal-pages.test.ts
+++ b/tests/legal-pages.test.ts
@@ -30,25 +30,30 @@ test('sms consent page includes required disclosures and trust links', () => {
   const terms = read('app/terms/page.tsx');
   const contact = read('app/contact/page.tsx');
 
-  assert.match(smsConsent, /missed call follow-up/i);
-  assert.match(smsConsent, /customer care/i);
+  assert.match(smsConsent, /respond to customer inquiries/i);
+  assert.match(smsConsent, /callback coordination/i);
+  assert.match(smsConsent, /customer support/i);
   assert.match(smsConsent, /service updates/i);
-  assert.match(smsConsent, /account notifications/i);
+  assert.match(smsConsent, /account or service notifications/i);
+  assert.match(smsConsent, /Consent to receive SMS messages is not a condition of purchase/i);
   assert.match(smsConsent, /Message and data rates may apply/i);
   assert.match(smsConsent, /Reply STOP/i);
   assert.match(smsConsent, /HELP/i);
+  assert.match(smsConsent, /support@callbackcloser\.com/i);
   assert.match(smsConsent, /href="\/privacy"/);
   assert.match(smsConsent, /href="\/terms"/);
-  assert.match(smsConsent, /href="\/contact"/);
   assert.match(
     smsConsentForm,
-    /By checking this box, you agree to receive SMS messages from CallbackCloser related to customer care and account[\s\S]*notifications\./
+    /I agree to receive SMS messages from CallbackCloser related to my request\./
   );
-  assert.match(smsConsentForm, /does not submit or store phone numbers/i);
-  assert.match(smsConsentForm, /compliance reference/i);
-  assert.match(smsConsent, /records consent inside the actual signup, intake, or customer[\s\S]*messaging flow/i);
+  assert.match(smsConsentForm, /defaultChecked=\{false\}/);
+  assert.match(smsConsentForm, /Consent to receive SMS messages is not a condition of purchase/i);
+  assert.doesNotMatch(smsConsent, /visual-only|Twilio review only|pilot reference|demo|public compliance reference/i);
+  assert.doesNotMatch(smsConsentForm, /does not submit or store phone numbers|compliance reference|buyers, carriers, and reviewers/i);
   assert.match(privacy, /does not sell mobile numbers/i);
+  assert.match(privacy, /callback coordination/i);
   assert.match(terms, /SMS Consent/);
+  assert.match(terms, /callback coordination/i);
   assert.match(contact, /support@callbackcloser\.com/);
 });
 


### PR DESCRIPTION
## Summary
- rewrite the public sms-consent page so it reads like a real SMS consent disclosure instead of a review/reference artifact
- align the checkbox copy and public trust pages with the Twilio submission framing for callback coordination, customer support, service updates, and account or service notifications
- tighten legal-page coverage so fake/demo/reference wording cannot slip back in

## Validation
- npm install
- npm run typecheck
- npm run lint
- node --test tests/legal-pages.test.ts
- npm run test
- npm run build