### PR TITLE
[codex] Simplify customer dashboard and leads UX

### DIFF
--- a/app/admin/[businessId]/page.tsx
+++ b/app/admin/[businessId]/page.tsx
@@ -2,12 +2,22 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 import {
+  archiveBusinessAction,
   connectBusinessOwnerAction,
+  deleteTestBusinessAction,
   provisionBusinessAction,
   resyncBusinessWebhooksAction,
+  restoreBusinessAction,
   saveAdminBusinessProfileAction,
+  sendBusinessTestSmsAction,
   setBusinessProvisioningStatusAction,
 } from '@/app/admin/actions';
+import {
+  buildAdminBusinessEvents,
+  buildAdminNextStep,
+  canDeleteTestBusiness,
+  isBusinessArchived,
+} from '@/lib/admin-dashboard';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -25,7 +35,15 @@ import {
   listAdminTwilioNumbers,
 } from '@/lib/admin-provisioning';
 import { db } from '@/lib/db';
-import { formatDateTime } from '@/lib/lead-presenters';
+import {
+  formatDateTime,
+  formatRelativeTime,
+  formatMessageStatus,
+  getLeadCallbackState,
+  getLeadStatusBadgeVariant,
+  leadReadinessLabels,
+  leadStatusLabels,
+} from '@/lib/lead-presenters';
 import { getManagedTextingNumber, getManagedTwilioStatusSummary, managedTwilioStatusLabels } from '@/lib/managed-twilio';
 import { formatPhoneForDisplay } from '@/lib/phone';
 import { getBusinessBillingAccessState } from '@/lib/subscription';
@@ -43,11 +61,19 @@ const changedFieldLabels: Record<string, string> = {
   a2pCampaignSid: 'A2P campaign SID',
   a2pFailureReason: 'A2P failure reason',
   managedTwilioStatus: 'managed Twilio status',
+  isTestBusiness: 'test business flag',
 };
 
 function getQueryValue(searchParams: Record<string, string | string[] | undefined> | undefined, key: string) {
   const value = searchParams?.[key];
   return typeof value === 'string' ? value : null;
+}
+
+function getNextStepBadgeVariant(tone: 'healthy' | 'pending' | 'attention' | 'paused') {
+  if (tone === 'healthy') return 'success' as const;
+  if (tone === 'attention') return 'destructive' as const;
+  if (tone === 'paused') return 'outline' as const;
+  return 'secondary' as const;
 }
 
 function StatusButton({
@@ -85,7 +111,7 @@ function WebhookResyncButton({
     <form action={resyncBusinessWebhooksAction}>
       <input type="hidden" name="businessId" value={businessId} />
       <input type="hidden" name="target" value={target} />
-      <Button type="submit" variant="outline">
+      <Button type="submit" size="sm" variant="outline">
         {label}
       </Button>
     </form>
@@ -101,37 +127,85 @@ export default async function AdminBusinessDetailPage({
 }) {
   await requireAdmin();
 
-  const [
-    business,
-    successfulLeadCount,
-    leadCount,
-    callCount,
-    messageCount,
-  ] = await Promise.all([
-    db.business.findUnique({
-      where: { id: params.businessId },
-      include: {
-        notificationSettings: true,
-      },
-    }),
-    db.lead.count({
-      where: {
-        businessId: params.businessId,
-        OR: [{ ownerNotifiedAt: { not: null } }, { notifiedAt: { not: null } }],
-      },
-    }),
-    db.lead.count({ where: { businessId: params.businessId } }),
-    db.call.count({ where: { businessId: params.businessId } }),
-    db.message.count({ where: { businessId: params.businessId } }),
-  ]);
+  const [business, successfulLeadCount, leadCount, callCount, messageCount, recentLeads, recentCalls, recentMessages, recentOwnerNotifications] =
+    await Promise.all([
+      db.business.findUnique({
+        where: { id: params.businessId },
+        include: {
+          notificationSettings: true,
+        },
+      }),
+      db.lead.count({
+        where: {
+          businessId: params.businessId,
+          OR: [{ ownerNotifiedAt: { not: null } }, { notifiedAt: { not: null } }],
+        },
+      }),
+      db.lead.count({ where: { businessId: params.businessId } }),
+      db.call.count({ where: { businessId: params.businessId } }),
+      db.message.count({ where: { businessId: params.businessId } }),
+      db.lead.findMany({
+        where: { businessId: params.businessId },
+        orderBy: [{ lastInteractionAt: 'desc' }, { createdAt: 'desc' }],
+        take: 6,
+        select: {
+          id: true,
+          status: true,
+          readiness: true,
+          billingRequired: true,
+          smsState: true,
+          summary: true,
+          notifiedAt: true,
+          ownerNotifiedAt: true,
+          createdAt: true,
+          lastInteractionAt: true,
+        },
+      }),
+      db.call.findMany({
+        where: { businessId: params.businessId },
+        orderBy: { createdAt: 'desc' },
+        take: 6,
+        select: {
+          id: true,
+          status: true,
+          missed: true,
+          answered: true,
+          dialCallStatus: true,
+          createdAt: true,
+        },
+      }),
+      db.message.findMany({
+        where: { businessId: params.businessId, direction: 'OUTBOUND' },
+        orderBy: { createdAt: 'desc' },
+        take: 8,
+        select: {
+          id: true,
+          leadId: true,
+          participant: true,
+          direction: true,
+          status: true,
+          body: true,
+          createdAt: true,
+        },
+      }),
+      db.ownerNotification.findMany({
+        where: { businessId: params.businessId },
+        orderBy: { createdAt: 'desc' },
+        take: 8,
+        select: {
+          id: true,
+          channel: true,
+          status: true,
+          error: true,
+          createdAt: true,
+          destination: true,
+        },
+      }),
+    ]);
 
   if (!business) notFound();
 
-  const [
-    ownerState,
-    webhookSnapshot,
-    availableNumbers,
-  ] = await Promise.all([
+  const [ownerState, webhookSnapshot, availableNumbers] = await Promise.all([
     getAdminOwnerState(business, business.notificationSettings),
     getTwilioWebhookSnapshot(business),
     listAdminTwilioNumbers(business),
@@ -147,6 +221,19 @@ export default async function AdminBusinessDetailPage({
     ownerConnected: ownerState.connected,
     webhookSnapshot,
   });
+  const nextStep = buildAdminNextStep({
+    business,
+    notificationSettings: business.notificationSettings,
+    ownerConnected: ownerState.connected,
+  });
+  const recentEvents = buildAdminBusinessEvents({
+    business,
+    messages: recentMessages,
+    ownerNotifications: recentOwnerNotifications,
+    leads: recentLeads,
+    calls: recentCalls,
+  }).slice(0, 10);
+  const assignedNumber = getManagedTextingNumber(business);
 
   const created = getQueryValue(searchParams, 'created') === '1';
   const saved = getQueryValue(searchParams, 'saved') === '1';
@@ -154,6 +241,9 @@ export default async function AdminBusinessDetailPage({
   const provisioned = getQueryValue(searchParams, 'provisioned') === '1';
   const synced = getQueryValue(searchParams, 'synced');
   const statusSaved = getQueryValue(searchParams, 'statusSaved');
+  const testSms = getQueryValue(searchParams, 'testSms') === '1';
+  const archived = getQueryValue(searchParams, 'archived') === '1';
+  const restored = getQueryValue(searchParams, 'restored') === '1';
   const error = getQueryValue(searchParams, 'error');
   const changed = (getQueryValue(searchParams, 'changed') || '')
     .split(',')
@@ -165,22 +255,35 @@ export default async function AdminBusinessDetailPage({
     <div className="container space-y-6 py-8">
       <div className="space-y-2">
         <Link className="text-sm text-muted-foreground underline underline-offset-4" href="/admin">
-          Back to admin dashboard
+          Back to operator board
         </Link>
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <h1 className="text-2xl font-semibold tracking-tight">{business.name}</h1>
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-3xl font-semibold tracking-tight">{business.name}</h1>
+              {business.isTestBusiness ? <Badge variant="outline">Test</Badge> : null}
+              {isBusinessArchived(business) ? <Badge variant="outline">Archived</Badge> : null}
+            </div>
             <p className="text-sm text-muted-foreground">
-              Internal provisioning console for owner setup, Twilio configuration, webhook sync, and go-live status.
+              One page for business health, recovery actions, safe editing, support workspace access, and recent operator context.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Badge variant={getAdminProvisioningStatusVariant(business.provisioningStatus)}>
-              {adminProvisioningStatusLabels[business.provisioningStatus]}
-            </Badge>
-            <Badge variant={rolloutStatus.badgeVariant}>{rolloutStatus.label}</Badge>
-            <Badge variant={customerStatus.badgeVariant}>{customerStatus.label}</Badge>
+            <Link className={buttonVariants({ variant: 'default' })} href={`/admin/${business.id}/workspace`}>
+              Open support workspace
+            </Link>
+            <Link className={buttonVariants({ variant: 'outline' })} href="/admin">
+              Back to board
+            </Link>
           </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant={getAdminProvisioningStatusVariant(business.provisioningStatus)}>
+            {adminProvisioningStatusLabels[business.provisioningStatus]}
+          </Badge>
+          <Badge variant={rolloutStatus.badgeVariant}>{rolloutStatus.label}</Badge>
+          <Badge variant={customerStatus.badgeVariant}>{customerStatus.label}</Badge>
+          <Badge variant={getNextStepBadgeVariant(nextStep.tone)}>{nextStep.title}</Badge>
         </div>
       </div>
 
@@ -199,35 +302,106 @@ export default async function AdminBusinessDetailPage({
               : 'Owner state updated.'}
         </div>
       ) : null}
-      {provisioned ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Provisioning finished. Review the checklist and mark the business live when ready.</div> : null}
+      {provisioned ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Provisioning finished. Review the health sections below.</div> : null}
       {synced ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Webhook sync complete for {synced.toLowerCase()}.</div> : null}
       {statusSaved ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business status updated to {statusSaved.replace(/_/g, ' ')}.</div> : null}
+      {testSms ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Admin test SMS sent.</div> : null}
+      {archived ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business archived safely. Automation is paused.</div> : null}
+      {restored ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business restored and ready for review.</div> : null}
       {error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{error}</div> : null}
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
-        {[
-          { label: 'Leads', value: leadCount },
-          { label: 'Calls', value: callCount },
-          { label: 'Messages', value: messageCount },
-          { label: 'Qualified alerts', value: successfulLeadCount },
-          { label: 'Billing', value: billingAccess.billingActive ? 'Active' : business.subscriptionStatus.toLowerCase() },
-        ].map((item) => (
-          <Card key={item.label} className="bg-card/90">
-            <CardHeader className="pb-2">
-              <CardDescription>{item.label}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <p className="text-xl font-semibold">{item.value}</p>
-            </CardContent>
-          </Card>
-        ))}
+      <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
+        <Card className="border-primary/20 bg-primary/5">
+          <CardHeader>
+            <CardTitle>What should I do next?</CardTitle>
+            <CardDescription>Plain-English guidance to keep the founder out of the weeds.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="rounded-xl border bg-background/80 p-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-lg font-semibold">{nextStep.title}</p>
+                  <p className="mt-2 max-w-3xl text-sm text-muted-foreground">{nextStep.detail}</p>
+                </div>
+                <Badge variant={getNextStepBadgeVariant(nextStep.tone)}>{nextStep.actionLabel}</Badge>
+              </div>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              {[
+                { label: 'Leads', value: leadCount },
+                { label: 'Calls', value: callCount },
+                { label: 'Messages', value: messageCount },
+                { label: 'Qualified alerts', value: successfulLeadCount },
+              ].map((item) => (
+                <div key={item.label} className="rounded-xl border bg-background/80 p-4">
+                  <p className="text-sm text-muted-foreground">{item.label}</p>
+                  <p className="mt-2 text-2xl font-semibold">{item.value}</p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-card/90">
+          <CardHeader>
+            <CardTitle>Quick actions</CardTitle>
+            <CardDescription>Common fixes and shortcuts should be one click away.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap gap-2">
+              <form action={provisionBusinessAction}>
+                <input type="hidden" name="businessId" value={business.id} />
+                <input type="hidden" name="mode" value="NEW_NUMBER" />
+                <Button size="sm" type="submit">
+                  Re-run provisioning
+                </Button>
+              </form>
+              <WebhookResyncButton businessId={business.id} target="ALL" label="Re-sync webhooks" />
+              {business.provisioningStatus === 'PAUSED' ? (
+                <StatusButton businessId={business.id} status="ONBOARDING" label="Resume automation" />
+              ) : (
+                <StatusButton businessId={business.id} status="PAUSED" label="Pause automation" variant="outline" />
+              )}
+              {business.provisioningStatus === 'LIVE' ? null : <StatusButton businessId={business.id} status="LIVE" label="Mark live" variant="secondary" />}
+            </div>
+
+            <form action={sendBusinessTestSmsAction} className="rounded-xl border bg-background/80 p-4">
+              <input type="hidden" name="businessId" value={business.id} />
+              <div className="space-y-2">
+                <Label htmlFor="destinationPhone">Send test SMS</Label>
+                <Input
+                  id="destinationPhone"
+                  name="destinationPhone"
+                  type="tel"
+                  defaultValue={business.notificationSettings?.ownerPhone || business.notifyPhone || ''}
+                  placeholder="+1 555 123 4567"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Sends a short admin verification message from the assigned business line to the destination above.
+                </p>
+              </div>
+              <Button className="mt-3" size="sm" type="submit" variant="outline">
+                Send test SMS
+              </Button>
+            </form>
+
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`/admin/${business.id}/workspace`}>
+                Open support workspace
+              </Link>
+              <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`#recent-events`}>
+                Open recent events
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
       <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
         <Card className="bg-card/90">
           <CardHeader>
-            <CardTitle>Business identity</CardTitle>
-            <CardDescription>Save the customer profile, routing defaults, owner alerts, internal notes, and admin-only Twilio mapping fields.</CardDescription>
+            <CardTitle>Business info</CardTitle>
+            <CardDescription>Edit the business, owner contact settings, internal notes, and admin-only Twilio mapping safely from one place.</CardDescription>
           </CardHeader>
           <CardContent>
             <form action={saveAdminBusinessProfileAction} className="grid gap-4 md:grid-cols-2">
@@ -238,18 +412,11 @@ export default async function AdminBusinessDetailPage({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="ownerName">Owner name</Label>
-                <Input id="ownerName" name="ownerName" defaultValue={business.ownerName || ''} placeholder="Casey Owner" />
+                <Input id="ownerName" name="ownerName" defaultValue={business.ownerName || ''} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="ownerEmail">Owner email</Label>
-                <Input
-                  id="ownerEmail"
-                  name="ownerEmail"
-                  type="email"
-                  defaultValue={business.notificationSettings?.ownerEmail || ''}
-                  placeholder="owner@business.com"
-                  required
-                />
+                <Input id="ownerEmail" name="ownerEmail" type="email" defaultValue={business.notificationSettings?.ownerEmail || ''} required />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="ownerPhone">Owner alert phone</Label>
@@ -258,7 +425,6 @@ export default async function AdminBusinessDetailPage({
                   name="ownerPhone"
                   type="tel"
                   defaultValue={business.notificationSettings?.ownerPhone || business.notifyPhone || ''}
-                  placeholder="+1 555 123 4567"
                 />
               </div>
               <div className="space-y-2">
@@ -271,14 +437,7 @@ export default async function AdminBusinessDetailPage({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="missedCallSeconds">Missed-call timeout</Label>
-                <Input
-                  id="missedCallSeconds"
-                  name="missedCallSeconds"
-                  type="number"
-                  min={5}
-                  max={90}
-                  defaultValue={business.missedCallSeconds}
-                />
+                <Input id="missedCallSeconds" name="missedCallSeconds" type="number" min={5} max={90} defaultValue={business.missedCallSeconds} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="serviceLabel1">Primary service label</Label>
@@ -292,88 +451,74 @@ export default async function AdminBusinessDetailPage({
                 <Label htmlFor="serviceLabel3">Tertiary service label</Label>
                 <Input id="serviceLabel3" name="serviceLabel3" defaultValue={business.serviceLabel3} />
               </div>
+              <label className="md:col-span-2 flex items-start gap-2 rounded-xl border bg-background/80 p-3 text-sm">
+                <input defaultChecked={business.isTestBusiness} name="isTestBusiness" type="checkbox" value="true" />
+                <span>Test/demo business. Required for safe destructive delete after archive.</span>
+              </label>
               <div className="space-y-3 md:col-span-2">
                 <Label htmlFor="internalNotes">Internal notes</Label>
                 <Textarea
                   id="internalNotes"
                   name="internalNotes"
                   defaultValue={business.internalNotes || ''}
-                  placeholder="Store launch notes, customer preferences, or any follow-up needed for this rollout."
                   rows={5}
+                  placeholder="Store launch notes, handoff context, or anything the founder should not have to remember."
                 />
               </div>
+
               <div className="md:col-span-2 space-y-3 rounded-xl border bg-background/80 p-4">
                 <div>
-                  <p className="text-sm font-medium">Owner notifications</p>
-                  <p className="text-xs text-muted-foreground">These control the owner alerts CallbackCloser sends when a lead is qualified.</p>
+                  <p className="text-sm font-medium">Automation settings</p>
+                  <p className="text-xs text-muted-foreground">Critical owner alert toggles and operational state.</p>
                 </div>
-                <div className="flex flex-wrap gap-4 text-sm">
-                  <label className="flex items-center gap-2">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <label className="flex items-center gap-2 text-sm">
                     <input type="checkbox" name="notifySms" defaultChecked={business.notificationSettings?.notifySms ?? true} />
-                    SMS alerts
+                    Owner SMS alerts
                   </label>
-                  <label className="flex items-center gap-2">
+                  <label className="flex items-center gap-2 text-sm">
                     <input type="checkbox" name="notifyEmail" defaultChecked={business.notificationSettings?.notifyEmail ?? true} />
-                    Email alerts
+                    Owner email alerts
                   </label>
-                  <label className="flex items-center gap-2">
+                  <label className="flex items-center gap-2 text-sm">
                     <input type="checkbox" name="notifyInApp" defaultChecked={business.notificationSettings?.notifyInApp ?? true} />
                     In-app alerts
                   </label>
-                  <label className="flex items-center gap-2">
+                  <label className="flex items-center gap-2 text-sm">
                     <input type="checkbox" name="urgentOnly" defaultChecked={business.notificationSettings?.urgentOnly ?? false} />
                     Urgent leads only
                   </label>
                 </div>
               </div>
+
               <div className="md:col-span-2 space-y-4 rounded-xl border border-primary/20 bg-primary/5 p-4">
                 <div>
-                  <p className="text-sm font-medium">Internal database editor</p>
+                  <p className="text-sm font-medium">Admin Twilio editor</p>
                   <p className="text-xs text-muted-foreground">
-                    Internal admin-only. Twilio numbers are normalized to E.164 on save, the primary and legacy lookup fields are updated together, and
-                    manual mapping changes clear the last webhook sync timestamp until the next resync confirms the assignment.
+                    Use this for safe business corrections, manual provisioning repair, or A2P tracking without leaving admin.
                   </p>
                 </div>
                 <div className="grid gap-4 md:grid-cols-2">
                   <div className="space-y-2">
-                    <Label htmlFor="twilioPhoneNumber">Twilio number</Label>
+                    <Label htmlFor="twilioPhoneNumber">Assigned number</Label>
                     <Input
                       id="twilioPhoneNumber"
                       name="twilioPhoneNumber"
                       type="tel"
                       defaultValue={business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber || ''}
-                      placeholder="+18777480449"
                     />
                   </div>
                   <div className="space-y-2">
-                    <Label htmlFor="twilioPhoneNumberSid">Twilio number SID</Label>
+                    <Label htmlFor="twilioPhoneNumberSid">Number SID</Label>
                     <Input
                       id="twilioPhoneNumberSid"
                       name="twilioPhoneNumberSid"
                       defaultValue={business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid || ''}
-                      placeholder="PN..."
                     />
                   </div>
                   <div className="space-y-2">
-                    <Label htmlFor="twilioMessagingServiceSid">Messaging service SID</Label>
-                    <Input
-                      id="twilioMessagingServiceSid"
-                      name="twilioMessagingServiceSid"
-                      defaultValue={business.twilioMessagingServiceSid || ''}
-                      placeholder="MG..."
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="a2pCustomerProfileSid">A2P customer profile SID</Label>
-                    <Input id="a2pCustomerProfileSid" name="a2pCustomerProfileSid" defaultValue={business.a2pCustomerProfileSid || ''} placeholder="BU..." />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="a2pBrandSid">A2P brand SID</Label>
-                    <Input id="a2pBrandSid" name="a2pBrandSid" defaultValue={business.a2pBrandSid || ''} placeholder="BN..." />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="a2pCampaignSid">A2P campaign SID</Label>
-                    <Input id="a2pCampaignSid" name="a2pCampaignSid" defaultValue={business.a2pCampaignSid || ''} placeholder="QE..." />
+                    <Label htmlFor="twilioMessagingServiceSid">Messaging Service SID</Label>
+                    <Input id="twilioMessagingServiceSid" name="twilioMessagingServiceSid" defaultValue={business.twilioMessagingServiceSid || ''} />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="managedTwilioStatus">Managed Twilio status</Label>
@@ -385,24 +530,37 @@ export default async function AdminBusinessDetailPage({
                       ))}
                     </Select>
                   </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="a2pCustomerProfileSid">Customer profile SID</Label>
+                    <Input id="a2pCustomerProfileSid" name="a2pCustomerProfileSid" defaultValue={business.a2pCustomerProfileSid || ''} />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="a2pBrandSid">Brand SID</Label>
+                    <Input id="a2pBrandSid" name="a2pBrandSid" defaultValue={business.a2pBrandSid || ''} />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="a2pCampaignSid">Campaign SID</Label>
+                    <Input id="a2pCampaignSid" name="a2pCampaignSid" defaultValue={business.a2pCampaignSid || ''} />
+                  </div>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="a2pFailureReason">A2P failure or attention note</Label>
+                  <Label htmlFor="a2pFailureReason">A2P or launch attention note</Label>
                   <Textarea
                     id="a2pFailureReason"
                     name="a2pFailureReason"
                     defaultValue={business.a2pFailureReason || ''}
-                    placeholder="Use this for rejection reasons, carrier requests, or the exact next operator action needed."
                     rows={3}
+                    placeholder="Record exactly what is blocking live messaging or what manual action is still needed."
                   />
                 </div>
                 <label className="flex items-start gap-2 rounded-lg border bg-background/80 p-3 text-sm">
                   <input className="mt-1" type="checkbox" name="confirmCriticalFieldClears" value="true" />
-                  <span>I understand this may clear a live Twilio mapping or owner alert destination and should only be used for internal corrections.</span>
+                  <span>I understand this can clear live Twilio mappings or alert routing and should only be used for deliberate internal corrections.</span>
                 </label>
               </div>
+
               <div className="md:col-span-2">
-                <Button type="submit">Save business details</Button>
+                <Button type="submit">Save business settings</Button>
               </div>
             </form>
           </CardContent>
@@ -411,81 +569,45 @@ export default async function AdminBusinessDetailPage({
         <div className="space-y-6">
           <Card className="bg-card/90">
             <CardHeader>
-              <CardTitle>Owner account</CardTitle>
-              <CardDescription>Connect an existing Clerk user by ID or email. If the owner has not signed up yet, CallbackCloser will send an invite.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="rounded-xl border bg-background/80 p-4 text-sm">
-                <p className="font-medium">{ownerState.name || business.ownerName || 'Owner not named yet'}</p>
-                <p className="mt-1 text-muted-foreground">{ownerState.email || business.notificationSettings?.ownerEmail || 'Owner email missing'}</p>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <Badge variant={ownerState.connected ? 'success' : ownerState.pending ? 'outline' : 'destructive'}>
-                    {ownerState.connected ? 'Connected' : ownerState.pending ? 'Pending invite' : 'Needs connection'}
-                  </Badge>
-                  {ownerState.clerkUserId ? <Badge variant="outline">{ownerState.clerkUserId}</Badge> : null}
-                </div>
-                {ownerState.invitedAt ? <p className="mt-2 text-xs text-muted-foreground">Invite sent {formatDateTime(ownerState.invitedAt)}</p> : null}
-              </div>
-              <form action={connectBusinessOwnerAction} className="space-y-4">
-                <input type="hidden" name="businessId" value={business.id} />
-                <div className="space-y-2">
-                  <Label htmlFor="connectOwnerEmail">Owner email</Label>
-                  <Input
-                    id="connectOwnerEmail"
-                    name="ownerEmail"
-                    type="email"
-                    defaultValue={business.notificationSettings?.ownerEmail || ''}
-                    placeholder="owner@business.com"
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="connectOwnerName">Owner name</Label>
-                  <Input id="connectOwnerName" name="ownerName" defaultValue={business.ownerName || ''} placeholder="Casey Owner" />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="ownerClerkId">Existing Clerk user ID</Label>
-                  <Input id="ownerClerkId" name="ownerClerkId" defaultValue={ownerState.connected ? ownerState.clerkUserId || '' : ''} placeholder="user_..." />
-                </div>
-                <Button type="submit">Create or connect owner</Button>
-              </form>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-card/90">
-            <CardHeader>
-              <CardTitle>Provisioning status</CardTitle>
-              <CardDescription>Internal rollout state plus the exact setup steps still blocking go-live.</CardDescription>
+              <CardTitle>Provisioning health</CardTitle>
+              <CardDescription>Checklist-style visibility into subaccount, number, webhooks, and readiness.</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid gap-3 sm:grid-cols-2">
                 <div className="rounded-xl border bg-background/80 p-4 text-sm">
-                  <p className="font-medium text-foreground">Current status</p>
+                  <p className="font-medium">Current status</p>
                   <div className="mt-2 flex flex-wrap gap-2">
                     <Badge variant={getAdminProvisioningStatusVariant(business.provisioningStatus)}>
                       {adminProvisioningStatusLabels[business.provisioningStatus]}
                     </Badge>
-                    <Badge variant={managedSummary.messagingReady ? 'success' : managedSummary.onboardingReady ? 'secondary' : 'outline'}>
-                      {managedSummary.messagingReady ? 'Approved' : managedSummary.onboardingReady ? 'A2P pending' : 'Setup pending'}
+                    <Badge variant={managedSummary.messagingReady ? 'success' : managedSummary.attentionRequired ? 'destructive' : 'secondary'}>
+                      {managedSummary.messagingReady ? 'Healthy' : managedSummary.attentionRequired ? 'Needs attention' : 'Pending'}
                     </Badge>
                   </div>
-                  <p className="mt-3 text-muted-foreground">Last run: {formatDateTime(business.provisioningLastRunAt)}</p>
-                  {business.provisioningError ? <p className="mt-2 text-destructive">{business.provisioningError}</p> : null}
+                  <p className="mt-3 text-xs text-muted-foreground">Last provisioning run: {formatDateTime(business.provisioningLastRunAt)}</p>
+                  {business.provisioningError ? <p className="mt-2 text-sm text-destructive">{business.provisioningError}</p> : null}
                 </div>
                 <div className="rounded-xl border bg-background/80 p-4 text-sm">
-                  <p className="font-medium text-foreground">Checklist</p>
-                  <div className="mt-3 space-y-3">
-                    {checklist.map((item) => (
-                      <div key={item.key} className="rounded-lg border bg-card p-3">
-                        <div className="flex items-center justify-between gap-3">
-                          <span className="font-medium">{item.label}</span>
-                          <Badge variant={item.complete ? 'success' : 'outline'}>{item.complete ? 'Done' : 'Pending'}</Badge>
-                        </div>
-                        <p className="mt-2 text-xs text-muted-foreground">{item.detail}</p>
-                      </div>
-                    ))}
-                  </div>
+                  <p className="font-medium">Webhooks</p>
+                  <p className="mt-2">{business.twilioWebhookSyncedAt ? 'Synced' : 'Needs sync'}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {business.twilioWebhookSyncedAt
+                      ? `Last synced ${formatRelativeTime(business.twilioWebhookSyncedAt)}`
+                      : 'Voice, SMS, and status callback URLs still need to be pushed to the assigned number.'}
+                  </p>
                 </div>
+              </div>
+
+              <div className="space-y-3">
+                {checklist.map((item) => (
+                  <div key={item.key} className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="font-medium">{item.label}</span>
+                      <Badge variant={item.complete ? 'success' : 'outline'}>{item.complete ? 'Done' : 'Pending'}</Badge>
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">{item.detail}</p>
+                  </div>
+                ))}
               </div>
 
               <div className="flex flex-wrap gap-2">
@@ -500,69 +622,85 @@ export default async function AdminBusinessDetailPage({
               </div>
             </CardContent>
           </Card>
+
+          <Card className="bg-card/90">
+            <CardHeader>
+              <CardTitle>Owner account</CardTitle>
+              <CardDescription>Connect or re-invite the owner without leaving the operator page.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                <p className="font-medium">{ownerState.name || business.ownerName || 'Owner not named yet'}</p>
+                <p className="mt-1 text-muted-foreground">{ownerState.email || business.notificationSettings?.ownerEmail || 'Owner email missing'}</p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Badge variant={ownerState.connected ? 'success' : ownerState.pending ? 'outline' : 'destructive'}>
+                    {ownerState.connected ? 'Connected' : ownerState.pending ? 'Pending invite' : 'Needs connection'}
+                  </Badge>
+                  {ownerState.clerkUserId ? <Badge variant="outline">{ownerState.clerkUserId}</Badge> : null}
+                </div>
+                {ownerState.invitedAt ? <p className="mt-2 text-xs text-muted-foreground">Invite sent {formatDateTime(ownerState.invitedAt)}</p> : null}
+              </div>
+
+              <form action={connectBusinessOwnerAction} className="space-y-4">
+                <input type="hidden" name="businessId" value={business.id} />
+                <div className="space-y-2">
+                  <Label htmlFor="connectOwnerEmail">Owner email</Label>
+                  <Input id="connectOwnerEmail" name="ownerEmail" type="email" defaultValue={business.notificationSettings?.ownerEmail || ''} required />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="connectOwnerName">Owner name</Label>
+                  <Input id="connectOwnerName" name="ownerName" defaultValue={business.ownerName || ''} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="ownerClerkId">Existing Clerk user ID</Label>
+                  <Input id="ownerClerkId" name="ownerClerkId" defaultValue={ownerState.connected ? ownerState.clerkUserId || '' : ''} />
+                </div>
+                <Button type="submit" variant="outline">
+                  Connect or invite owner
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
         </div>
       </div>
 
       <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
         <Card className="bg-card/90">
           <CardHeader>
-            <CardTitle>Twilio configuration</CardTitle>
-            <CardDescription>Current subaccount, number, messaging service, and webhook health for this business.</CardDescription>
+            <CardTitle>Provisioning health</CardTitle>
+            <CardDescription>Technical truth without forcing the founder to hunt for it.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4 text-sm">
             <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
               <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Provisioning path</p>
-                <p className="mt-2 text-muted-foreground">
-                  {business.twilioPrimaryNumberSid ? 'Business number attached' : 'Choose the managed new-number path or use the admin-assisted existing-number path below.'}
-                </p>
-              </div>
-              <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Managed status</p>
-                <p className="mt-2 text-muted-foreground">{managedSummary.label}</p>
-                <p className="mt-2 text-xs text-muted-foreground">{managedSummary.description}</p>
-              </div>
-              <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Billing</p>
-                <p className="mt-2 text-muted-foreground">{billingAccess.billingActive ? 'Active' : business.subscriptionStatus.toLowerCase()}</p>
-              </div>
-              <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Subaccount SID</p>
+                <p className="font-medium">Subaccount</p>
                 <p className="mt-2 break-all text-muted-foreground">{business.twilioSubaccountSid || 'Not created yet'}</p>
               </div>
               <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Messaging Service SID</p>
+                <p className="font-medium">Messaging Service</p>
                 <p className="mt-2 break-all text-muted-foreground">{business.twilioMessagingServiceSid || 'Not created yet'}</p>
               </div>
               <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Primary texting line</p>
-                <p className="mt-2 text-muted-foreground">{formatPhoneForDisplay(getManagedTextingNumber(business))}</p>
+                <p className="font-medium">Assigned number</p>
+                <p className="mt-2 text-muted-foreground">{formatPhoneForDisplay(assignedNumber)}</p>
+                <p className="mt-2 text-xs text-muted-foreground">{business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid || 'Number SID missing'}</p>
               </div>
               <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Primary number SID</p>
-                <p className="mt-2 break-all text-muted-foreground">{business.twilioPrimaryNumberSid || 'Not assigned yet'}</p>
+                <p className="font-medium">Provisioning path</p>
+                <p className="mt-2 text-muted-foreground">{assignedNumber ? 'Number attached' : 'Choose new or existing number path below.'}</p>
               </div>
               <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">A2P registration</p>
-                <p className="mt-2 text-muted-foreground">{managedSummary.complianceReady ? 'Approved' : managedSummary.label}</p>
-                <p className="mt-2 text-xs text-muted-foreground">{managedSummary.nextStep}</p>
+                <p className="font-medium">Billing</p>
+                <p className="mt-2 text-muted-foreground">{billingAccess.billingActive ? 'Active' : business.subscriptionStatus.toLowerCase()}</p>
               </div>
               <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">Voice webhook</p>
-                <p className="mt-2 text-muted-foreground">
-                  {webhookSnapshot?.voiceSynced ? 'Synced' : webhookSnapshot?.error ? 'Unable to verify' : 'Needs sync'}
-                </p>
-              </div>
-              <div className="rounded-xl border bg-background/80 p-4">
-                <p className="font-medium text-foreground">SMS webhook</p>
-                <p className="mt-2 text-muted-foreground">
-                  {webhookSnapshot?.smsSynced ? 'Synced' : webhookSnapshot?.error ? 'Unable to verify' : 'Needs sync'}
-                </p>
+                <p className="font-medium">Last update</p>
+                <p className="mt-2 text-muted-foreground">{formatDateTime(business.updatedAt)}</p>
               </div>
             </div>
 
             <div className="rounded-xl border bg-background/80 p-4">
-              <p className="font-medium text-foreground">Webhook status</p>
+              <p className="font-medium">Webhook status</p>
               {webhookSnapshot ? (
                 <div className="mt-3 grid gap-3 sm:grid-cols-3">
                   <div>
@@ -582,39 +720,12 @@ export default async function AdminBusinessDetailPage({
                   </div>
                 </div>
               ) : (
-                <p className="mt-2 text-muted-foreground">
-                  CallbackCloser will verify webhook drift after a number is attached and Twilio credentials are available.
-                </p>
+                <p className="mt-2 text-muted-foreground">Webhook verification becomes available once a number is attached and Twilio credentials are present.</p>
               )}
             </div>
 
             <div className="rounded-xl border bg-background/80 p-4">
-              <p className="font-medium text-foreground">A2P and messaging readiness</p>
-              <div className="mt-3 grid gap-3 sm:grid-cols-2">
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Current state</p>
-                  <p className="mt-1">{managedSummary.label}</p>
-                  <p className="mt-1 text-xs text-muted-foreground">{managedSummary.description}</p>
-                </div>
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Next operator step</p>
-                  <p className="mt-1">{managedSummary.nextStep}</p>
-                  {business.a2pApprovedAt ? <p className="mt-1 text-xs text-muted-foreground">Approved {formatDateTime(business.a2pApprovedAt)}</p> : null}
-                </div>
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Brand / campaign IDs</p>
-                  <p className="mt-1 break-all text-muted-foreground">{business.a2pBrandSid || 'Brand not recorded yet'}</p>
-                  <p className="mt-1 break-all text-muted-foreground">{business.a2pCampaignSid || 'Campaign not recorded yet'}</p>
-                </div>
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Attention note</p>
-                  <p className="mt-1 text-muted-foreground">{business.a2pFailureReason || 'No current compliance blocker recorded.'}</p>
-                </div>
-              </div>
-            </div>
-
-            <div className="rounded-xl border bg-background/80 p-4">
-              <p className="font-medium text-foreground">Available existing numbers</p>
+              <p className="font-medium">Available existing numbers</p>
               <p className="mt-2 text-muted-foreground">
                 {availableNumbers.error
                   ? availableNumbers.error
@@ -639,11 +750,67 @@ export default async function AdminBusinessDetailPage({
         <div className="space-y-6">
           <Card className="bg-card/90">
             <CardHeader>
-              <CardTitle>Provision business</CardTitle>
-              <CardDescription>
-                Use the new-number path when CallbackCloser should buy a line. Use the existing-number path when the Twilio number is already present on the
-                business account context.
-              </CardDescription>
+              <CardTitle>Messaging / A2P readiness</CardTitle>
+              <CardDescription>Explain clearly what is blocking live messaging, or whether no action is needed.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm">
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Current state</p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <Badge variant={managedSummary.messagingReady ? 'success' : managedSummary.attentionRequired ? 'destructive' : 'secondary'}>
+                    {managedSummary.label}
+                  </Badge>
+                  {managedSummary.complianceReady ? <Badge variant="success">Approved</Badge> : null}
+                </div>
+                <p className="mt-3 text-muted-foreground">{managedSummary.description}</p>
+                <p className="mt-2 text-xs text-muted-foreground">{managedSummary.nextStep}</p>
+                {business.a2pApprovedAt ? <p className="mt-2 text-xs text-muted-foreground">Approved {formatDateTime(business.a2pApprovedAt)}</p> : null}
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-xl border bg-background/80 p-4">
+                  <p className="font-medium">Brand / campaign IDs</p>
+                  <p className="mt-2 break-all text-muted-foreground">{business.a2pBrandSid || 'Brand not recorded yet'}</p>
+                  <p className="mt-2 break-all text-muted-foreground">{business.a2pCampaignSid || 'Campaign not recorded yet'}</p>
+                </div>
+                <div className="rounded-xl border bg-background/80 p-4">
+                  <p className="font-medium">Attention note</p>
+                  <p className="mt-2 text-muted-foreground">{business.a2pFailureReason || 'No current compliance blocker recorded.'}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-card/90">
+            <CardHeader>
+              <CardTitle>Commercial / account state</CardTitle>
+              <CardDescription>Plan, setup state, alert routing, and live launch context.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-3 sm:grid-cols-2 text-sm">
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Subscription</p>
+                <p className="mt-2 text-muted-foreground">{business.subscriptionStatus.toLowerCase()}</p>
+              </div>
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Billing access</p>
+                <p className="mt-2 text-muted-foreground">{billingAccess.billingActive ? 'Active' : 'Inactive'}</p>
+              </div>
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Owner alert destination</p>
+                <p className="mt-2 text-muted-foreground">
+                  {formatPhoneForDisplay(business.notificationSettings?.ownerPhone || business.notifyPhone)} · {business.notificationSettings?.ownerEmail || 'No owner email'}
+                </p>
+              </div>
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Customer-facing status</p>
+                <p className="mt-2 text-muted-foreground">{customerStatus.description}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-card/90">
+            <CardHeader>
+              <CardTitle>Provision / attach number</CardTitle>
+              <CardDescription>Use the new-number path for normal launches. Existing numbers stay admin-assisted.</CardDescription>
             </CardHeader>
             <CardContent className="space-y-6">
               <form action={provisionBusinessAction} className="space-y-4 rounded-xl border bg-background/80 p-4">
@@ -652,9 +819,8 @@ export default async function AdminBusinessDetailPage({
                 <div className="space-y-2">
                   <Label htmlFor="areaCode">Preferred area code</Label>
                   <Input id="areaCode" name="areaCode" placeholder="512" maxLength={3} />
-                  <p className="text-xs text-muted-foreground">Optional. Leave blank to let CallbackCloser choose the first available US local number.</p>
                 </div>
-                <Button type="submit">Provision business</Button>
+                <Button type="submit">Provision new number</Button>
               </form>
 
               <form action={provisionBusinessAction} className="space-y-4 rounded-xl border bg-background/80 p-4">
@@ -664,13 +830,12 @@ export default async function AdminBusinessDetailPage({
                   <Label htmlFor="existingNumberSidManual">Existing number SID</Label>
                   <Input id="existingNumberSidManual" name="existingNumberSidManual" placeholder="PN..." />
                   <p className="text-xs text-muted-foreground">
-                    This is an admin-assisted path only. The number must already exist in the target Twilio account context before you attach it here. If
-                    the customer is keeping a number from another account or carrier, handle that migration outside the self-serve product flow first.
+                    Keep-number launches are still admin-assisted. The number must already exist in the target Twilio account context first.
                   </p>
                 </div>
                 {availableNumbers.numbers.length > 0 ? (
                   <div className="space-y-2">
-                    <Label htmlFor="existingNumberSelect">Choose from loaded Twilio numbers</Label>
+                    <Label htmlFor="existingNumberSelect">Choose loaded number</Label>
                     <select
                       id="existingNumberSelect"
                       name="existingNumberSidSelect"
@@ -686,7 +851,9 @@ export default async function AdminBusinessDetailPage({
                     </select>
                   </div>
                 ) : null}
-                <Button type="submit" variant="outline">Attach existing number</Button>
+                <Button type="submit" variant="outline">
+                  Attach existing number
+                </Button>
               </form>
             </CardContent>
           </Card>
@@ -694,7 +861,7 @@ export default async function AdminBusinessDetailPage({
           <Card className="bg-card/90">
             <CardHeader>
               <CardTitle>Webhook tools</CardTitle>
-              <CardDescription>Re-sync voice, SMS, or all number webhooks when the app URL changes or Twilio drifts.</CardDescription>
+              <CardDescription>Keep recovery actions close to the thing they fix.</CardDescription>
             </CardHeader>
             <CardContent className="flex flex-wrap gap-2">
               <WebhookResyncButton businessId={business.id} target="VOICE" label="Re-sync voice webhook" />
@@ -702,37 +869,139 @@ export default async function AdminBusinessDetailPage({
               <WebhookResyncButton businessId={business.id} target="ALL" label="Re-sync all webhooks" />
             </CardContent>
           </Card>
-
-          <Card className="bg-card/90">
-            <CardHeader>
-              <CardTitle>Commercial + live state</CardTitle>
-              <CardDescription>Internal view of billing, go-live readiness, and any manual follow-up still needed.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm">
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="rounded-xl border bg-background/80 p-4">
-                  <p className="font-medium text-foreground">Subscription</p>
-                  <p className="mt-2 text-muted-foreground">{business.subscriptionStatus.toLowerCase()}</p>
-                </div>
-                <div className="rounded-xl border bg-background/80 p-4">
-                  <p className="font-medium text-foreground">Marked live</p>
-                  <p className="mt-2 text-muted-foreground">{business.provisioningStatus === 'LIVE' ? 'Yes' : 'No'}</p>
-                </div>
-                <div className="rounded-xl border bg-background/80 p-4">
-                  <p className="font-medium text-foreground">Owner alert destination</p>
-                  <p className="mt-2 text-muted-foreground">
-                    {formatPhoneForDisplay(business.notificationSettings?.ownerPhone || business.notifyPhone)} · {business.notificationSettings?.ownerEmail || 'No owner email'}
-                  </p>
-                </div>
-                <div className="rounded-xl border bg-background/80 p-4">
-                  <p className="font-medium text-foreground">Last updated</p>
-                  <p className="mt-2 text-muted-foreground">{formatDateTime(business.updatedAt)}</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
         </div>
       </div>
+
+      <Card className="bg-card/90" id="recent-events">
+        <CardHeader>
+          <CardTitle>Logs / recent events</CardTitle>
+          <CardDescription>Concise summaries first, details on demand, no secrets.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {recentEvents.length === 0 ? (
+            <div className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">No recent operator events are recorded for this business yet.</div>
+          ) : (
+            recentEvents.map((event) => (
+              <details key={event.id} className="rounded-xl border bg-background/80 p-4 text-sm">
+                <summary className="cursor-pointer list-none">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant={event.severity === 'error' ? 'destructive' : event.severity === 'warning' ? 'outline' : 'secondary'}>
+                          {event.label}
+                        </Badge>
+                        <span className="font-medium">{event.summary}</span>
+                      </div>
+                      <p className="mt-2 text-xs text-muted-foreground">{formatDateTime(event.at)}</p>
+                    </div>
+                    <span className="text-xs text-muted-foreground">Show detail</span>
+                  </div>
+                </summary>
+                <p className="mt-3 text-muted-foreground">{event.detail}</p>
+              </details>
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <Card className="bg-card/90">
+          <CardHeader>
+            <CardTitle>Support workspace access</CardTitle>
+            <CardDescription>Fast entry into a safe customer-style snapshot without risky impersonation.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <p className="text-muted-foreground">
+              The support workspace is read-only by design. It surfaces recent leads, recent alerts, and key settings for this business without weakening tenant isolation.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <Link className={buttonVariants({ variant: 'default' })} href={`/admin/${business.id}/workspace`}>
+                Open support workspace
+              </Link>
+              <Link className={buttonVariants({ variant: 'outline' })} href={`/admin/${business.id}/workspace#recent-leads`}>
+                Open recent leads
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-card/90">
+          <CardHeader>
+            <CardTitle>Archive / delete controls</CardTitle>
+            <CardDescription>Archive real businesses safely. Delete only archived test/demo workspaces.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            {isBusinessArchived(business) ? (
+              <form action={restoreBusinessAction} className="rounded-xl border bg-background/80 p-4">
+                <input type="hidden" name="businessId" value={business.id} />
+                <div className="space-y-2">
+                  <Label htmlFor="restoreName">Type business name to restore</Label>
+                  <Input id="restoreName" name="confirmationName" placeholder={business.name} />
+                </div>
+                <Button className="mt-3" type="submit">
+                  Restore business
+                </Button>
+              </form>
+            ) : (
+              <form action={archiveBusinessAction} className="rounded-xl border bg-background/80 p-4">
+                <input type="hidden" name="businessId" value={business.id} />
+                <div className="space-y-2">
+                  <Label htmlFor="archiveName">Type business name to archive</Label>
+                  <Input id="archiveName" name="confirmationName" placeholder={business.name} />
+                </div>
+                <Button className="mt-3" type="submit" variant="outline">
+                  Archive business safely
+                </Button>
+              </form>
+            )}
+
+            {canDeleteTestBusiness(business) ? (
+              <form action={deleteTestBusinessAction} className="rounded-xl border border-destructive/30 bg-destructive/5 p-4">
+                <input type="hidden" name="businessId" value={business.id} />
+                <div className="space-y-2">
+                  <Label htmlFor="deleteName">Type business name to delete this test workspace</Label>
+                  <Input id="deleteName" name="confirmationName" placeholder={business.name} />
+                </div>
+                <Button className="mt-3" type="submit" variant="destructive">
+                  Delete archived test business
+                </Button>
+              </form>
+            ) : (
+              <div className="rounded-xl border border-dashed p-4 text-muted-foreground">
+                Delete stays unavailable until this workspace is archived and marked as a test/demo business.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="bg-card/90" id="recent-leads">
+        <CardHeader>
+          <CardTitle>Recent leads snapshot</CardTitle>
+          <CardDescription>Useful context without forcing a jump into multiple customer pages.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {recentLeads.length === 0 ? (
+            <div className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">No recent leads yet.</div>
+          ) : (
+            recentLeads.map((lead) => (
+              <div key={lead.id} className="rounded-xl border bg-background/80 p-4 text-sm">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
+                  <Badge variant={lead.readiness === 'URGENT' ? 'destructive' : lead.readiness === 'QUALIFIED' ? 'secondary' : 'outline'}>
+                    {leadReadinessLabels[lead.readiness]}
+                  </Badge>
+                </div>
+                <p className="mt-3 font-medium">{getLeadCallbackState(lead)}</p>
+                <p className="mt-2 text-muted-foreground">{lead.summary || 'Lead details are still coming in.'}</p>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Last activity {formatRelativeTime(lead.lastInteractionAt || lead.createdAt)} · {lead.id}
+                </p>
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/app/admin/[businessId]/workspace/page.tsx
+++ b/app/admin/[businessId]/workspace/page.tsx
@@ -1,0 +1,210 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { buildAdminNextStep } from '@/lib/admin-dashboard';
+import { requireAdmin } from '@/lib/admin';
+import { Badge } from '@/components/ui/badge';
+import { buttonVariants } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { db } from '@/lib/db';
+import {
+  formatDateTime,
+  formatMessageStatus,
+  formatRelativeTime,
+  getLeadCallbackState,
+  getLeadStatusBadgeVariant,
+  leadReadinessLabels,
+  leadStatusLabels,
+} from '@/lib/lead-presenters';
+import { getManagedTwilioStatusSummary } from '@/lib/managed-twilio';
+import { formatPhoneForDisplay } from '@/lib/phone';
+import { getBusinessBillingAccessState } from '@/lib/subscription';
+
+export const dynamic = 'force-dynamic';
+
+function getNextStepBadgeVariant(tone: 'healthy' | 'pending' | 'attention' | 'paused') {
+  if (tone === 'healthy') return 'success' as const;
+  if (tone === 'attention') return 'destructive' as const;
+  if (tone === 'paused') return 'outline' as const;
+  return 'secondary' as const;
+}
+
+export default async function AdminBusinessWorkspacePage({ params }: { params: { businessId: string } }) {
+  await requireAdmin();
+
+  const [business, recentLeads, recentOwnerNotifications, recentMessages] = await Promise.all([
+    db.business.findUnique({
+      where: { id: params.businessId },
+      include: {
+        notificationSettings: true,
+      },
+    }),
+    db.lead.findMany({
+      where: { businessId: params.businessId },
+      orderBy: [{ lastInteractionAt: 'desc' }, { createdAt: 'desc' }],
+      take: 8,
+    }),
+    db.ownerNotification.findMany({
+      where: { businessId: params.businessId },
+      orderBy: { createdAt: 'desc' },
+      take: 8,
+    }),
+    db.message.findMany({
+      where: { businessId: params.businessId },
+      orderBy: { createdAt: 'desc' },
+      take: 8,
+    }),
+  ]);
+
+  if (!business) notFound();
+
+  const successfulLeadCount = recentLeads.filter((lead) => lead.ownerNotifiedAt || lead.notifiedAt).length;
+  const nextStep = buildAdminNextStep({
+    business,
+    notificationSettings: business.notificationSettings,
+    ownerConnected: !business.ownerClerkId.startsWith('pending_owner_'),
+  });
+  const managedSummary = getManagedTwilioStatusSummary(business);
+  const billingAccess = getBusinessBillingAccessState(business);
+
+  return (
+    <div className="container space-y-6 py-8">
+      <div className="space-y-2">
+        <Link className="text-sm text-muted-foreground underline underline-offset-4" href={`/admin/${business.id}`}>
+          Back to operator page
+        </Link>
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">{business.name} support workspace</h1>
+            <p className="text-sm text-muted-foreground">
+              Read-only snapshot of the customer-facing workspace so the founder can orient quickly without impersonation.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link className={buttonVariants({ variant: 'default' })} href={`/admin/${business.id}`}>
+              Open operator controls
+            </Link>
+            <Link className={buttonVariants({ variant: 'outline' })} href="/admin">
+              Back to board
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <Card className="border-primary/20 bg-primary/5">
+        <CardHeader>
+          <CardTitle>Support snapshot</CardTitle>
+          <CardDescription>What matters first when the founder needs to step into a customer’s world.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="rounded-xl border bg-background/80 p-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant={getNextStepBadgeVariant(nextStep.tone)}>{nextStep.title}</Badge>
+              <Badge variant={managedSummary.messagingReady ? 'success' : managedSummary.attentionRequired ? 'destructive' : 'secondary'}>
+                {managedSummary.label}
+              </Badge>
+            </div>
+            <p className="mt-3 text-sm text-muted-foreground">{nextStep.detail}</p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="rounded-xl border bg-background/80 p-4 text-sm">
+              <p className="font-medium">Lead handoffs</p>
+              <p className="mt-2 text-2xl font-semibold">{successfulLeadCount}</p>
+            </div>
+            <div className="rounded-xl border bg-background/80 p-4 text-sm">
+              <p className="font-medium">Billing</p>
+              <p className="mt-2 text-muted-foreground">{billingAccess.billingActive ? 'Active' : 'Inactive'}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+        <Card className="bg-card/90" id="recent-leads">
+          <CardHeader>
+            <CardTitle>Recent leads</CardTitle>
+            <CardDescription>Support-friendly snapshot of where the current inbox stands.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {recentLeads.length === 0 ? (
+              <div className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">No leads yet.</div>
+            ) : (
+              recentLeads.map((lead) => (
+                <div key={lead.id} className="rounded-xl border bg-background/80 p-4 text-sm">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
+                    <Badge variant={lead.readiness === 'URGENT' ? 'destructive' : lead.readiness === 'QUALIFIED' ? 'secondary' : 'outline'}>
+                      {leadReadinessLabels[lead.readiness]}
+                    </Badge>
+                  </div>
+                  <p className="mt-3 font-medium">{getLeadCallbackState(lead)}</p>
+                  <p className="mt-2 text-muted-foreground">{lead.summary || 'Lead summary not captured yet.'}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">{formatDateTime(lead.lastInteractionAt || lead.createdAt)}</p>
+                </div>
+              ))
+            )}
+          </CardContent>
+        </Card>
+
+        <div className="space-y-6">
+          <Card className="bg-card/90">
+            <CardHeader>
+              <CardTitle>Business settings snapshot</CardTitle>
+              <CardDescription>The customer context the founder usually has to hunt down.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-3 text-sm">
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Owner alerts</p>
+                <p className="mt-2 text-muted-foreground">
+                  {formatPhoneForDisplay(business.notificationSettings?.ownerPhone || business.notifyPhone)} · {business.notificationSettings?.ownerEmail || 'No owner email'}
+                </p>
+              </div>
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Forwarding number</p>
+                <p className="mt-2 text-muted-foreground">{formatPhoneForDisplay(business.forwardingNumber)}</p>
+              </div>
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Texting line</p>
+                <p className="mt-2 text-muted-foreground">
+                  {formatPhoneForDisplay(business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber)}
+                </p>
+              </div>
+              <div className="rounded-xl border bg-background/80 p-4">
+                <p className="font-medium">Internal notes</p>
+                <p className="mt-2 text-muted-foreground">{business.internalNotes || 'No internal notes recorded.'}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-card/90">
+            <CardHeader>
+              <CardTitle>Recent notifications and SMS</CardTitle>
+              <CardDescription>Quick visibility into the latest customer-visible activity.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              {recentOwnerNotifications.slice(0, 4).map((notification) => (
+                <div key={notification.id} className="rounded-xl border bg-background/80 p-4">
+                  <p className="font-medium">
+                    Owner {notification.channel.toLowerCase()} alert · {notification.status.toLowerCase()}
+                  </p>
+                  <p className="mt-2 text-muted-foreground">{notification.error || notification.destination || 'No extra detail recorded.'}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">{formatRelativeTime(notification.createdAt)}</p>
+                </div>
+              ))}
+              {recentMessages.slice(0, 4).map((message) => (
+                <div key={message.id} className="rounded-xl border bg-background/80 p-4">
+                  <p className="font-medium">
+                    {message.participant === 'OWNER' ? 'Owner SMS' : 'Lead SMS'} · {message.direction.toLowerCase()}
+                    {message.status ? ` · ${formatMessageStatus(message.status)}` : ''}
+                  </p>
+                  <p className="mt-2 text-muted-foreground">{message.body}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">{formatRelativeTime(message.createdAt)}</p>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -12,11 +12,16 @@ import {
   updateBusinessProvisioningStatus,
 } from '@/lib/admin-provisioning';
 import { requireAdmin } from '@/lib/admin';
+import { canDeleteTestBusiness } from '@/lib/admin-dashboard';
 import { logAuditEvent } from '@/lib/audit-log';
 import { db } from '@/lib/db';
 import { maskPhoneForAudit, normalizePhoneNumber, normalizePhoneNumberToE164 } from '@/lib/phone';
+import { sendAndPersistOutboundMessage } from '@/lib/twilio-messaging';
 import {
+  adminArchiveBusinessSchema,
   adminBusinessDraftSchema,
+  adminDeleteBusinessSchema,
+  adminSendTestSmsSchema,
   adminBusinessUpdateSchema,
   adminConnectOwnerSchema,
   adminProvisionBusinessSchema,
@@ -52,6 +57,7 @@ function buildAdminBusinessRedirectPath(
 async function revalidateAdminPaths(businessId: string) {
   revalidatePath('/admin');
   revalidatePath(`/admin/${businessId}`);
+  revalidatePath(`/admin/${businessId}/workspace`);
 }
 
 function normalizeOptionalE164Phone(value: string | null | undefined, label: string) {
@@ -97,6 +103,15 @@ function buildChangedFieldMetadata(changes: Array<{ key: string; label: string; 
   }));
 }
 
+async function loadBusinessForLifecycleAction(businessId: string) {
+  return db.business.findUnique({
+    where: { id: businessId },
+    include: {
+      notificationSettings: true,
+    },
+  });
+}
+
 export async function createDemoBusinessAction(formData: FormData) {
   const admin = await requireAdmin();
   const ownerPhone = normalizePhoneNumber(getString(formData, 'ownerPhone')) || null;
@@ -111,6 +126,7 @@ export async function createDemoBusinessAction(formData: FormData) {
       ownerClerkId: DEMO_OWNER_CLERK_ID,
       ownerName: 'CallbackCloser Demo',
       name: DEFAULT_DEMO_NAME,
+      isTestBusiness: true,
       forwardingNumber,
       notifyPhone: ownerPhone,
       provisioningStatus: BusinessProvisioningStatus.DRAFT,
@@ -129,6 +145,8 @@ export async function createDemoBusinessAction(formData: FormData) {
     update: {
       ownerName: 'CallbackCloser Demo',
       name: DEFAULT_DEMO_NAME,
+      isTestBusiness: true,
+      archivedAt: null,
       forwardingNumber,
       notifyPhone: ownerPhone,
       provisioningStatus: BusinessProvisioningStatus.DRAFT,
@@ -182,6 +200,7 @@ export async function createAdminBusinessAction(formData: FormData) {
       ownerClerkId: buildPendingOwnerClerkId(),
       ownerName: data.ownerName || null,
       name: data.name,
+      isTestBusiness: data.isTestBusiness,
       forwardingNumber,
       notifyPhone: ownerPhone,
       provisioningStatus: BusinessProvisioningStatus.DRAFT,
@@ -307,6 +326,7 @@ export async function saveAdminBusinessProfileAction(formData: FormData) {
     existingBusiness.a2pBrandSid !== a2pBrandSid ||
     existingBusiness.a2pCampaignSid !== a2pCampaignSid ||
     existingBusiness.a2pFailureReason !== a2pFailureReason;
+  const testFlagChanged = existingBusiness.isTestBusiness !== data.isTestBusiness;
 
   const changedFields = [
     existingOwnerPhone !== ownerPhone
@@ -358,6 +378,14 @@ export async function saveAdminBusinessProfileAction(formData: FormData) {
           after: a2pFailureReason,
         }
       : null,
+    testFlagChanged
+      ? {
+          key: 'isTestBusiness',
+          label: 'test business flag',
+          before: existingBusiness.isTestBusiness ? 'true' : 'false',
+          after: data.isTestBusiness ? 'true' : 'false',
+        }
+      : null,
     managedTwilioStatusChanged
       ? {
           key: 'managedTwilioStatus',
@@ -373,6 +401,7 @@ export async function saveAdminBusinessProfileAction(formData: FormData) {
     data: {
       ownerName: data.ownerName || null,
       name: data.name,
+      isTestBusiness: data.isTestBusiness,
       forwardingNumber: normalizePhoneNumber(data.forwardingNumber),
       notifyPhone: ownerPhone,
       missedCallSeconds: data.missedCallSeconds,
@@ -590,4 +619,200 @@ export async function setBusinessProvisioningStatusAction(formData: FormData) {
   await updateBusinessProvisioningStatus(parsed.data.businessId, parsed.data.status as BusinessProvisioningStatus, null);
   await revalidateAdminPaths(parsed.data.businessId);
   redirect(buildAdminBusinessRedirectPath(parsed.data.businessId, { statusSaved: parsed.data.status.toLowerCase() }));
+}
+
+export async function sendBusinessTestSmsAction(formData: FormData) {
+  const admin = await requireAdmin();
+
+  const parsed = adminSendTestSmsSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    redirect(`/admin?error=${encodeURIComponent(parsed.error.issues[0]?.message || 'Invalid test SMS request.')}`);
+  }
+
+  const business = await loadBusinessForLifecycleAction(parsed.data.businessId);
+  if (!business) {
+    redirect(`/admin?error=${encodeURIComponent('Business not found.')}`);
+  }
+
+  const destinationPhone = normalizeOptionalE164Phone(parsed.data.destinationPhone, 'Test SMS destination');
+  const fromPhone = business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber;
+  if (!fromPhone) {
+    redirect(buildAdminBusinessRedirectPath(business.id, { error: 'A business texting number is required before sending a test SMS.' }));
+  }
+
+  try {
+    const result = await sendAndPersistOutboundMessage({
+      businessId: business.id,
+      fromPhone,
+      toPhone: destinationPhone!,
+      body: `CallbackCloser admin test: ${business.name} is using ${fromPhone} for live support verification.`,
+      participant: 'OWNER',
+      twilioSubaccountSid: business.twilioSubaccountSid,
+      messagingServiceSid: business.twilioMessagingServiceSid,
+      managedTwilioStatus: business.managedTwilioStatus,
+      a2pFailureReason: business.a2pFailureReason,
+    });
+
+    if (result.suppressed) {
+      redirect(
+        buildAdminBusinessRedirectPath(business.id, {
+          error: `Test SMS was suppressed: ${result.reason.replace(/_/g, ' ')}.`,
+        })
+      );
+    }
+
+    logAuditEvent({
+      event: 'admin_test_sms_sent',
+      actorType: 'user',
+      actorId: admin.userId,
+      businessId: business.id,
+      targetType: 'business',
+      targetId: business.id,
+      metadata: {
+        actorEmail: admin.email,
+        destinationPhone: maskPhoneForAudit(destinationPhone),
+        messageSid: result.sent.sid,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to send test SMS.';
+    redirect(buildAdminBusinessRedirectPath(business.id, { error: message }));
+  }
+
+  await revalidateAdminPaths(business.id);
+  redirect(buildAdminBusinessRedirectPath(business.id, { testSms: 1 }));
+}
+
+export async function archiveBusinessAction(formData: FormData) {
+  const admin = await requireAdmin();
+
+  const parsed = adminArchiveBusinessSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    redirect(`/admin?error=${encodeURIComponent(parsed.error.issues[0]?.message || 'Invalid archive request.')}`);
+  }
+
+  const business = await loadBusinessForLifecycleAction(parsed.data.businessId);
+  if (!business) {
+    redirect(`/admin?error=${encodeURIComponent('Business not found.')}`);
+  }
+
+  if (parsed.data.confirmationName !== business.name) {
+    redirect(buildAdminBusinessRedirectPath(business.id, { error: 'Type the exact business name to archive it.' }));
+  }
+
+  await db.business.update({
+    where: { id: business.id },
+    data: {
+      archivedAt: new Date(),
+      provisioningStatus: BusinessProvisioningStatus.PAUSED,
+      provisioningError: null,
+      provisioningLastRunAt: new Date(),
+    },
+  });
+
+  logAuditEvent({
+    event: 'admin_business_archived',
+    actorType: 'user',
+    actorId: admin.userId,
+    businessId: business.id,
+    targetType: 'business',
+    targetId: business.id,
+    metadata: {
+      actorEmail: admin.email,
+      businessName: business.name,
+      isTestBusiness: business.isTestBusiness,
+    },
+  });
+
+  await revalidateAdminPaths(business.id);
+  redirect(buildAdminBusinessRedirectPath(business.id, { archived: 1 }));
+}
+
+export async function restoreBusinessAction(formData: FormData) {
+  const admin = await requireAdmin();
+
+  const parsed = adminArchiveBusinessSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    redirect(`/admin?error=${encodeURIComponent(parsed.error.issues[0]?.message || 'Invalid restore request.')}`);
+  }
+
+  const business = await loadBusinessForLifecycleAction(parsed.data.businessId);
+  if (!business) {
+    redirect(`/admin?error=${encodeURIComponent('Business not found.')}`);
+  }
+
+  if (parsed.data.confirmationName !== business.name) {
+    redirect(buildAdminBusinessRedirectPath(business.id, { error: 'Type the exact business name to restore it.' }));
+  }
+
+  await db.business.update({
+    where: { id: business.id },
+    data: {
+      archivedAt: null,
+      provisioningStatus:
+        business.provisioningStatus === BusinessProvisioningStatus.PAUSED ? BusinessProvisioningStatus.ONBOARDING : business.provisioningStatus,
+      provisioningLastRunAt: new Date(),
+    },
+  });
+
+  logAuditEvent({
+    event: 'admin_business_restored',
+    actorType: 'user',
+    actorId: admin.userId,
+    businessId: business.id,
+    targetType: 'business',
+    targetId: business.id,
+    metadata: {
+      actorEmail: admin.email,
+      businessName: business.name,
+    },
+  });
+
+  await revalidateAdminPaths(business.id);
+  redirect(buildAdminBusinessRedirectPath(business.id, { restored: 1 }));
+}
+
+export async function deleteTestBusinessAction(formData: FormData) {
+  const admin = await requireAdmin();
+
+  const parsed = adminDeleteBusinessSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    redirect(`/admin?error=${encodeURIComponent(parsed.error.issues[0]?.message || 'Invalid delete request.')}`);
+  }
+
+  const business = await loadBusinessForLifecycleAction(parsed.data.businessId);
+  if (!business) {
+    redirect(`/admin?error=${encodeURIComponent('Business not found.')}`);
+  }
+
+  if (parsed.data.confirmationName !== business.name) {
+    redirect(buildAdminBusinessRedirectPath(business.id, { error: 'Type the exact business name to delete it.' }));
+  }
+
+  if (!canDeleteTestBusiness(business)) {
+    redirect(
+      buildAdminBusinessRedirectPath(business.id, {
+        error: 'Only archived test or demo businesses can be deleted from admin.',
+      })
+    );
+  }
+
+  await db.business.delete({ where: { id: business.id } });
+
+  logAuditEvent({
+    event: 'admin_test_business_deleted',
+    actorType: 'user',
+    actorId: admin.userId,
+    businessId: business.id,
+    targetType: 'business',
+    targetId: business.id,
+    metadata: {
+      actorEmail: admin.email,
+      businessName: business.name,
+      isTestBusiness: business.isTestBusiness,
+    },
+  });
+
+  revalidatePath('/admin');
+  redirect('/admin?deleted=1');
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -5,14 +5,23 @@ import {
   createDemoBusinessAction,
   provisionBusinessAction,
   resyncBusinessWebhooksAction,
+  restoreBusinessAction,
   setBusinessProvisioningStatusAction,
 } from '@/app/admin/actions';
+import {
+  adminBoardFilterOptions,
+  buildAdminNextStep,
+  getBusinessLifecycleLabel,
+  isBusinessArchived,
+  matchesAdminBoardFilter,
+  type AdminBoardFilter,
+} from '@/lib/admin-dashboard';
+import { requireAdmin } from '@/lib/admin';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { requireAdmin } from '@/lib/admin';
 import {
   adminProvisioningStatusLabels,
   getAdminProvisioningStatusVariant,
@@ -20,9 +29,10 @@ import {
 } from '@/lib/admin-provisioning';
 import { searchBusinessesForAdmin } from '@/lib/business';
 import { db } from '@/lib/db';
-import { formatDateTime } from '@/lib/lead-presenters';
+import { formatDateTime, formatRelativeTime } from '@/lib/lead-presenters';
 import { getManagedTextingNumber, getManagedTwilioStatusSummary } from '@/lib/managed-twilio';
 import { formatPhoneForDisplay } from '@/lib/phone';
+import { cn } from '@/lib/utils';
 
 export const dynamic = 'force-dynamic';
 
@@ -31,19 +41,37 @@ function getQueryValue(searchParams: Record<string, string | string[] | undefine
   return typeof value === 'string' ? value : null;
 }
 
+function maxDate(...values: Array<Date | null | undefined>) {
+  const timestamps = values
+    .filter((value): value is Date => value instanceof Date)
+    .map((value) => value.getTime());
+
+  if (timestamps.length === 0) return null;
+  return new Date(Math.max(...timestamps));
+}
+
+function getNextStepBadgeVariant(tone: 'healthy' | 'pending' | 'attention' | 'paused') {
+  if (tone === 'healthy') return 'success' as const;
+  if (tone === 'attention') return 'destructive' as const;
+  if (tone === 'paused') return 'outline' as const;
+  return 'secondary' as const;
+}
+
 export default async function AdminPage({ searchParams }: { searchParams?: Record<string, string | string[] | undefined> }) {
   const admin = await requireAdmin();
   const createdDemo = getQueryValue(searchParams, 'createdDemo') === '1';
   const createdBusinessId = getQueryValue(searchParams, 'businessId');
+  const deleted = getQueryValue(searchParams, 'deleted') === '1';
   const error = getQueryValue(searchParams, 'error');
   const query = getQueryValue(searchParams, 'q')?.trim() || '';
+  const view = (getQueryValue(searchParams, 'view') as AdminBoardFilter | null) || 'all';
   const adminBusiness = await db.business.findUnique({ where: { ownerClerkId: admin.userId } });
 
-  const [businesses, leadCounts] = await Promise.all([
+  const [businesses, leadCounts, leadActivity, callActivity, messageActivity, notificationFailures] = await Promise.all([
     query
       ? searchBusinessesForAdmin(query)
       : db.business.findMany({
-          orderBy: { updatedAt: 'desc' },
+          orderBy: [{ archivedAt: 'asc' }, { updatedAt: 'desc' }],
           include: {
             notificationSettings: true,
           },
@@ -51,38 +79,138 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
     db.lead.groupBy({
       by: ['businessId'],
       _count: { _all: true },
+      _max: { lastInteractionAt: true, createdAt: true },
+    }),
+    db.lead.groupBy({
+      by: ['businessId'],
+      _max: { lastInteractionAt: true, createdAt: true },
+    }),
+    db.call.groupBy({
+      by: ['businessId'],
+      _max: { createdAt: true },
+    }),
+    db.message.groupBy({
+      by: ['businessId'],
+      _max: { createdAt: true },
+    }),
+    db.ownerNotification.findMany({
+      where: {
+        status: { in: ['FAILED', 'SKIPPED'] },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        businessId: true,
+        status: true,
+        error: true,
+        createdAt: true,
+      },
+      take: 200,
     }),
   ]);
 
   const leadCountMap = new Map(leadCounts.map((item) => [item.businessId, item._count._all]));
+  const leadActivityMap = new Map(
+    leadActivity.map((item) => [item.businessId, maxDate(item._max.lastInteractionAt, item._max.createdAt)])
+  );
+  const callActivityMap = new Map(callActivity.map((item) => [item.businessId, item._max.createdAt]));
+  const messageActivityMap = new Map(messageActivity.map((item) => [item.businessId, item._max.createdAt]));
+  const notificationFailureMap = new Map<string, { status: string; error: string | null; createdAt: Date }>();
+
+  for (const failure of notificationFailures) {
+    if (!notificationFailureMap.has(failure.businessId)) {
+      notificationFailureMap.set(failure.businessId, failure);
+    }
+  }
+
+  const businessRows = businesses.map((business) => {
+    const managedSummary = getManagedTwilioStatusSummary(business);
+    const ownerPending = isPendingOwnerClerkId(business.ownerClerkId);
+    const ownerConnected = !ownerPending;
+    const nextStep = buildAdminNextStep({
+      business,
+      notificationSettings: business.notificationSettings,
+      ownerConnected,
+    });
+    const lastActivityAt = maxDate(
+      business.updatedAt,
+      leadActivityMap.get(business.id),
+      callActivityMap.get(business.id),
+      messageActivityMap.get(business.id)
+    );
+    const latestFailure = notificationFailureMap.get(business.id);
+
+    return {
+      business,
+      ownerPending,
+      ownerConnected,
+      managedSummary,
+      nextStep,
+      leadCount: leadCountMap.get(business.id) ?? 0,
+      assignedNumber: getManagedTextingNumber(business),
+      lastActivityAt,
+      latestFailure,
+    };
+  });
+
+  const filterCounts = new Map(
+    adminBoardFilterOptions.map((option) => [
+      option.key,
+      businessRows.filter((item) =>
+        matchesAdminBoardFilter(item.business, item.business.notificationSettings, item.ownerConnected, option.key)
+      ).length,
+    ])
+  );
+
+  const visibleRows = businessRows.filter((item) =>
+    matchesAdminBoardFilter(item.business, item.business.notificationSettings, item.ownerConnected, view)
+  );
+
+  const summaryStats = [
+    { label: 'Needs attention', value: filterCounts.get('needs_attention') ?? 0 },
+    { label: 'Live', value: filterCounts.get('live') ?? 0 },
+    { label: 'Pending A2P', value: filterCounts.get('pending_a2p') ?? 0 },
+    { label: 'Archived', value: filterCounts.get('archived') ?? 0 },
+  ];
 
   return (
     <div className="container space-y-6 py-8">
-      <div className="space-y-2">
+      <div className="space-y-3">
         <Badge variant="outline">Internal Admin</Badge>
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Business provisioning dashboard</h1>
-          <p className="text-sm text-muted-foreground">
-            Create business workspaces, connect owners, provision Twilio, and fix webhook drift without touching the customer dashboard.
-          </p>
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold tracking-tight">Operator triage board</h1>
+            <p className="max-w-3xl text-sm text-muted-foreground">
+              Open admin and immediately see which businesses are healthy, which ones need help, and the next safe action to take.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-4">
+            {summaryStats.map((item) => (
+              <Card key={item.label} className="bg-card/90">
+                <CardHeader className="pb-2">
+                  <CardDescription>{item.label}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-2xl font-semibold">{item.value}</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
         </div>
       </div>
 
       {error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{error}</div> : null}
+      {deleted ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Archived test business deleted.</div> : null}
       {createdDemo && createdBusinessId ? (
         <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">
           Demo business ready. Use <code className="rounded bg-background px-1 py-0.5">{createdBusinessId}</code> as `SIMULATOR_BUSINESS_ID`, or open the
-          workspace below.
+          support workspace below.
         </div>
       ) : null}
 
       <Card className="bg-card/90">
         <CardHeader>
-          <CardTitle>Internal database lookup</CardTitle>
-          <CardDescription>
-            Search by business name, owner email, Twilio number, Twilio number SID, or business ID. This tool is internal-only and stays behind the admin
-            dashboard guard.
-          </CardDescription>
+          <CardTitle>Find any business fast</CardTitle>
+          <CardDescription>Search by business name, owner email, business ID, Twilio number, or Twilio SID.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <form className="grid gap-3 md:grid-cols-[1fr_auto_auto]">
@@ -92,34 +220,44 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
               name="q"
               placeholder="Search name, owner email, +18777480449, PN..., or business ID"
             />
+            <input type="hidden" name="view" value={view} />
             <Button type="submit" variant="outline">
               Search
             </Button>
             {query ? (
-              <Link className={buttonVariants({ variant: 'ghost' })} href="/admin">
+              <Link className={buttonVariants({ variant: 'ghost' })} href={`/admin?view=${encodeURIComponent(view)}`}>
                 Clear
               </Link>
             ) : null}
           </form>
-          <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground">
-            {query ? (
-              <>
-                Showing {businesses.length} result{businesses.length === 1 ? '' : 's'} for <span className="font-medium text-foreground">{query}</span>.
-              </>
-            ) : (
-              <>Search is empty, so the full business list is shown below.</>
-            )}
+          <div className="flex flex-wrap gap-2">
+            {adminBoardFilterOptions.map((option) => {
+              const href = query
+                ? `/admin?view=${encodeURIComponent(option.key)}&q=${encodeURIComponent(query)}`
+                : `/admin?view=${encodeURIComponent(option.key)}`;
+              return (
+                <Link
+                  key={option.key}
+                  className={cn(
+                    buttonVariants({ variant: option.key === view ? 'default' : 'outline', size: 'sm' }),
+                    option.key === view && 'pointer-events-none'
+                  )}
+                  href={href}
+                >
+                  {option.label} ({filterCounts.get(option.key) ?? 0})
+                </Link>
+              );
+            })}
           </div>
         </CardContent>
       </Card>
 
-      <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
         <Card className="border-primary/20 bg-primary/5">
           <CardHeader>
             <CardTitle>Create customer business</CardTitle>
             <CardDescription>
-              Save the business workspace, owner contact details, and default routing in one pass. CallbackCloser will connect an existing Clerk owner by
-              email when possible, or send an owner invite and keep the workspace in a pending-owner state.
+              Save the business workspace, owner details, test flag, and default routing in one pass so provisioning can start immediately.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -164,6 +302,10 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                 <Label htmlFor="serviceLabel3">Tertiary service label</Label>
                 <Input id="serviceLabel3" name="serviceLabel3" defaultValue="Maintenance" />
               </div>
+              <label className="md:col-span-2 flex items-start gap-2 rounded-xl border bg-background/80 p-3 text-sm">
+                <input name="isTestBusiness" type="checkbox" value="true" />
+                <span>Mark this as a test/demo business so it can be safely archived and deleted later.</span>
+              </label>
               <div className="md:col-span-2 flex flex-wrap items-center gap-3">
                 <Button type="submit">Create business workspace</Button>
                 <p className="text-sm text-muted-foreground">If the owner already exists in Clerk, CallbackCloser will connect that account automatically.</p>
@@ -175,9 +317,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
         <Card className="bg-card/90">
           <CardHeader>
             <CardTitle>Create dedicated simulator workspace</CardTitle>
-            <CardDescription>
-              Keeps public simulator traffic isolated from real customer accounts while still using the same missed-call workflow.
-            </CardDescription>
+            <CardDescription>Keep simulator traffic isolated from real customers while still using the real operator controls.</CardDescription>
           </CardHeader>
           <CardContent>
             <form action={createDemoBusinessAction} className="space-y-4">
@@ -211,129 +351,151 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                   placeholder="+1 555 000 0001"
                 />
               </div>
-              <Button type="submit">Create Demo Business</Button>
+              <Button type="submit">Create demo workspace</Button>
             </form>
           </CardContent>
         </Card>
       </div>
 
-      <Card className="bg-card/90">
-        <CardHeader>
-          <CardTitle>{query ? 'Search results' : 'All businesses'}</CardTitle>
-          <CardDescription>Operational view of owner state, provisioning progress, Twilio setup, and live readiness.</CardDescription>
-        </CardHeader>
-        <CardContent className="overflow-x-auto">
-          {businesses.length === 0 ? (
-            <div className="rounded-xl border border-dashed p-6 text-sm text-muted-foreground">
-              No businesses matched this lookup. Try the exact business ID, owner email, or normalized Twilio number.
-            </div>
-          ) : (
-            <table className="min-w-full text-sm">
-              <thead>
-                <tr className="border-b text-left text-muted-foreground">
-                  <th className="px-3 py-3 font-medium">Business</th>
-                  <th className="px-3 py-3 font-medium">Owner</th>
-                  <th className="px-3 py-3 font-medium">Business status</th>
-                  <th className="px-3 py-3 font-medium">Provisioning</th>
-                  <th className="px-3 py-3 font-medium">Twilio</th>
-                  <th className="px-3 py-3 font-medium">Phone + webhooks</th>
-                  <th className="px-3 py-3 font-medium">Messaging</th>
-                  <th className="px-3 py-3 font-medium">Live</th>
-                  <th className="px-3 py-3 font-medium">Updated</th>
-                  <th className="px-3 py-3 font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {businesses.map((business) => {
-                const managedSummary = getManagedTwilioStatusSummary(business);
-                const ownerEmail = business.notificationSettings?.ownerEmail || 'Owner email missing';
-                const leadCount = leadCountMap.get(business.id) ?? 0;
-                const hasNumber = Boolean(getManagedTextingNumber(business));
-                const ownerPending = isPendingOwnerClerkId(business.ownerClerkId);
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-semibold tracking-tight">Businesses</h2>
+            <p className="text-sm text-muted-foreground">
+              {query ? `Showing ${visibleRows.length} result${visibleRows.length === 1 ? '' : 's'} for ${query}.` : 'Use this board as the founder control center.'}
+            </p>
+          </div>
+        </div>
 
-                return (
-                  <tr key={business.id} className="border-b align-top last:border-0 hover:bg-muted/20">
-                    <td className="px-3 py-3">
-                      <Link className="font-medium hover:underline" href={`/admin/${business.id}`}>
+        {visibleRows.length === 0 ? (
+          <Card className="bg-card/90">
+            <CardContent className="p-6 text-sm text-muted-foreground">
+              No businesses matched this view. Try a different filter or search for the exact business ID, owner email, or Twilio number.
+            </CardContent>
+          </Card>
+        ) : (
+          visibleRows.map(({ business, ownerPending, managedSummary, nextStep, leadCount, assignedNumber, lastActivityAt, latestFailure }) => (
+            <Card key={business.id} className="bg-card/90">
+              <CardContent className="space-y-5 p-5">
+                <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Link className="text-lg font-semibold hover:underline" href={`/admin/${business.id}`}>
                         {business.name}
                       </Link>
-                      <div className="text-xs text-muted-foreground">{business.id}</div>
-                      <div className="mt-1 text-xs text-muted-foreground">{leadCount} lead{leadCount === 1 ? '' : 's'}</div>
-                    </td>
-                    <td className="px-3 py-3">
-                      <div className="font-medium">{business.ownerName || 'Owner name missing'}</div>
-                      <div className="text-xs text-muted-foreground">{ownerEmail}</div>
-                      <div className="mt-1">
-                        <Badge variant={ownerPending ? 'outline' : 'secondary'}>{ownerPending ? 'Pending owner' : 'Owner linked'}</Badge>
-                      </div>
-                    </td>
-                    <td className="px-3 py-3">
+                      {business.isTestBusiness ? <Badge variant="outline">Test</Badge> : null}
+                      {isBusinessArchived(business) ? <Badge variant="outline">Archived</Badge> : null}
+                      <Badge variant={getNextStepBadgeVariant(nextStep.tone)}>{nextStep.title}</Badge>
+                    </div>
+                    <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                      <span>{business.id}</span>
+                      <span>Owner: {business.ownerName || 'Missing owner name'}</span>
+                      <span>{business.notificationSettings?.ownerEmail || 'Missing owner email'}</span>
+                      {ownerPending ? <span>Owner invite pending</span> : <span>Owner linked</span>}
+                    </div>
+                    <p className="max-w-3xl text-sm text-muted-foreground">{nextStep.detail}</p>
+                    {latestFailure ? (
+                      <p className="text-sm text-destructive">
+                        Latest attention item: {latestFailure.error || `${latestFailure.status.toLowerCase()} owner notification`} on{' '}
+                        {formatDateTime(latestFailure.createdAt)}.
+                      </p>
+                    ) : null}
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <Link className={buttonVariants({ variant: 'default' })} href={`/admin/${business.id}`}>
+                      Open operator page
+                    </Link>
+                    <Link className={buttonVariants({ variant: 'outline' })} href={`/admin/${business.id}/workspace`}>
+                      Open support workspace
+                    </Link>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+                  <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <p className="font-medium text-foreground">Lifecycle</p>
+                    <div className="mt-2 flex flex-wrap gap-2">
                       <Badge variant={getAdminProvisioningStatusVariant(business.provisioningStatus)}>
                         {adminProvisioningStatusLabels[business.provisioningStatus]}
                       </Badge>
-                    </td>
-                    <td className="px-3 py-3">
-                      <div className="font-medium">{managedSummary.label}</div>
-                      <div className="mt-1 text-xs text-muted-foreground">{managedSummary.nextStep}</div>
-                      {business.provisioningError ? <div className="mt-1 text-xs text-destructive">{business.provisioningError}</div> : null}
-                    </td>
-                    <td className="px-3 py-3">
-                      <Badge variant={business.twilioSubaccountSid ? 'success' : 'outline'}>
-                        {business.twilioSubaccountSid ? 'Subaccount ready' : 'Subaccount missing'}
+                      <Badge variant={managedSummary.messagingReady ? 'success' : managedSummary.attentionRequired ? 'destructive' : 'secondary'}>
+                        {managedSummary.messagingReady ? 'Healthy' : managedSummary.attentionRequired ? 'Needs attention' : 'Pending'}
                       </Badge>
-                    </td>
-                    <td className="px-3 py-3">
-                      <div className="font-medium">{hasNumber ? formatPhoneForDisplay(getManagedTextingNumber(business)) : 'No number assigned'}</div>
-                      <div className="text-xs text-muted-foreground">
-                        {business.twilioWebhookSyncedAt ? `Synced ${formatDateTime(business.twilioWebhookSyncedAt)}` : 'Webhook sync needed'}
-                      </div>
-                    </td>
-                    <td className="px-3 py-3">
-                      <Badge variant={managedSummary.messagingReady ? 'success' : managedSummary.onboardingReady ? 'secondary' : 'outline'}>
-                        {managedSummary.messagingReady ? 'Approved' : managedSummary.onboardingReady ? 'A2P pending' : 'Setup pending'}
-                      </Badge>
-                    </td>
-                    <td className="px-3 py-3">
-                      <Badge variant={business.provisioningStatus === 'LIVE' ? 'success' : 'outline'}>
-                        {business.provisioningStatus === 'LIVE' ? 'Yes' : 'No'}
-                      </Badge>
-                    </td>
-                    <td className="px-3 py-3 text-muted-foreground">{formatDateTime(business.updatedAt)}</td>
-                    <td className="px-3 py-3">
-                      <div className="flex flex-col gap-2">
-                        <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`/admin/${business.id}`}>
-                          Open
-                        </Link>
-                        {!hasNumber ? (
-                          <form action={provisionBusinessAction}>
-                            <input type="hidden" name="businessId" value={business.id} />
-                            <input type="hidden" name="mode" value="NEW_NUMBER" />
-                            <Button size="sm" type="submit">Provision</Button>
-                          </form>
-                        ) : (
-                          <form action={resyncBusinessWebhooksAction}>
-                            <input type="hidden" name="businessId" value={business.id} />
-                            <input type="hidden" name="target" value="ALL" />
-                            <Button size="sm" type="submit" variant="outline">Re-sync webhooks</Button>
-                          </form>
-                        )}
-                        <form action={setBusinessProvisioningStatusAction}>
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">{getBusinessLifecycleLabel(business)}</p>
+                  </div>
+
+                  <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <p className="font-medium text-foreground">Twilio readiness</p>
+                    <p className="mt-2">{managedSummary.label}</p>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {assignedNumber ? `Number ${formatPhoneForDisplay(assignedNumber)}` : 'No number assigned yet'}
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <p className="font-medium text-foreground">A2P + webhooks</p>
+                    <p className="mt-2">
+                      {managedSummary.complianceReady ? 'Approved' : managedSummary.complianceStarted ? 'Pending review' : 'Not started'}
+                    </p>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {business.twilioWebhookSyncedAt ? `Webhook sync ${formatRelativeTime(business.twilioWebhookSyncedAt)}` : 'Webhook sync still needed'}
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <p className="font-medium text-foreground">Activity</p>
+                    <p className="mt-2">{leadCount} lead{leadCount === 1 ? '' : 's'}</p>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {lastActivityAt ? `Last activity ${formatRelativeTime(lastActivityAt)}` : 'No activity yet'}
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <p className="font-medium text-foreground">Quick recovery</p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {isBusinessArchived(business) ? (
+                        <form action={restoreBusinessAction}>
                           <input type="hidden" name="businessId" value={business.id} />
-                          <input type="hidden" name="status" value={business.provisioningStatus === 'PAUSED' ? 'ONBOARDING' : 'PAUSED'} />
-                          <Button size="sm" type="submit" variant="ghost">
-                            {business.provisioningStatus === 'PAUSED' ? 'Resume' : 'Pause'}
+                          <input type="hidden" name="confirmationName" value={business.name} />
+                          <Button size="sm" type="submit" variant="outline">
+                            Restore
                           </Button>
                         </form>
-                      </div>
-                    </td>
-                  </tr>
-                );
-                })}
-              </tbody>
-            </table>
-          )}
-        </CardContent>
-      </Card>
+                      ) : !assignedNumber ? (
+                        <form action={provisionBusinessAction}>
+                          <input type="hidden" name="businessId" value={business.id} />
+                          <input type="hidden" name="mode" value="NEW_NUMBER" />
+                          <Button size="sm" type="submit">
+                            Provision
+                          </Button>
+                        </form>
+                      ) : (
+                        <form action={resyncBusinessWebhooksAction}>
+                          <input type="hidden" name="businessId" value={business.id} />
+                          <input type="hidden" name="target" value="ALL" />
+                          <Button size="sm" type="submit" variant="outline">
+                            Re-sync webhooks
+                          </Button>
+                        </form>
+                      )}
+
+                      <form action={setBusinessProvisioningStatusAction}>
+                        <input type="hidden" name="businessId" value={business.id} />
+                        <input type="hidden" name="status" value={business.provisioningStatus === 'PAUSED' ? 'ONBOARDING' : 'PAUSED'} />
+                        <Button size="sm" type="submit" variant="ghost">
+                          {business.provisioningStatus === 'PAUSED' ? 'Resume' : 'Pause'}
+                        </Button>
+                      </form>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
     </div>
   );
 }

--- a/app/app/conversations/page.tsx
+++ b/app/app/conversations/page.tsx
@@ -125,7 +125,7 @@ export default async function ConversationsPage({ searchParams }: { searchParams
                     {leadReadinessLabels[selectedLead.readiness]}
                   </Badge>
                   <Link className="text-sm underline underline-offset-4" href={`/app/leads/${selectedLead.id}?from=%2Fapp%2Fconversations`}>
-                    Open lead workspace
+                    Open lead details
                   </Link>
                 </div>
                 <div className="rounded-xl border bg-muted/20 p-4 text-sm">

--- a/app/app/leads/[leadId]/page.tsx
+++ b/app/app/leads/[leadId]/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { MessageDirection, OwnerNotificationChannel } from '@prisma/client';
+import { LeadStatus, MessageDirection, OwnerNotificationChannel } from '@prisma/client';
 import { notFound } from 'next/navigation';
 
 import { updateLeadStatusAction } from '@/app/app/leads/actions';
@@ -11,7 +11,9 @@ import { getLeadDetailForBusiness } from '@/lib/business-access';
 import {
   formatDateTime,
   formatRelativeTime,
+  getLeadNextStepLabel,
   getLeadStatusBadgeVariant,
+  isLeadOpenStatus,
   isMessageDeliveryIssueStatus,
   leadReadinessLabels,
   leadStatusLabels,
@@ -27,6 +29,22 @@ function resolveSafeReturnPath(value: string | null | undefined) {
     return '/app/leads';
   }
   return nextPath;
+}
+
+function getLeadActionSummary(status: LeadStatus) {
+  if (status === LeadStatus.BOOKED) {
+    return 'This lead is marked booked. Keep the details here for reference.';
+  }
+
+  if (status === LeadStatus.LOST) {
+    return 'This lead is marked lost. You can still review the call and message history here.';
+  }
+
+  if (status === LeadStatus.CONTACTED) {
+    return 'You have already made contact. Update the final outcome when the customer decides.';
+  }
+
+  return 'Call this lead back, then update the outcome so your inbox stays clear.';
 }
 
 function LeadStatusActionForm({
@@ -82,77 +100,83 @@ export default async function LeadDetailPage({
     lead.callerName || lead.contactName ? formatPhoneForDisplay(lead.callerPhoneNormalized || lead.callerPhone) : 'Caller name not captured yet';
   const redirectTo = `/app/leads/${lead.id}`;
   const recordingHref = lead.call?.recordingUrl ? `/api/leads/${lead.id}/recording` : null;
+  const nextStepLabel = getLeadNextStepLabel(lead.status);
+  const isOpenLead = isLeadOpenStatus(lead.status);
 
   return (
     <div className="space-y-6">
       <div className="space-y-2">
         <Link className="text-sm text-muted-foreground underline underline-offset-4" href={returnPath}>
-          Back to lead inbox
+          Back
         </Link>
-        <Badge variant="outline">Lead workspace</Badge>
+        <Badge variant="outline">Lead details</Badge>
       </div>
 
-      {saved ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Lead status updated.</div> : null}
+      {saved ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Lead updated.</div> : null}
       {messageIssues.length > 0 ? (
         <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
           This lead had an SMS delivery issue. Manual follow-up is recommended.
         </div>
       ) : null}
 
-      <Card className="bg-card/95">
-        <CardHeader className="gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div className="space-y-3">
-            <div>
-              <CardTitle className="text-2xl">{primaryLabel}</CardTitle>
-              <CardDescription>{secondaryLabel}</CardDescription>
+      <Card className="border-primary/20 bg-primary/5">
+        <CardHeader className="gap-6">
+          <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:justify-between">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-muted-foreground">{nextStepLabel}</p>
+                <CardTitle className="text-3xl">{primaryLabel}</CardTitle>
+                <CardDescription>{secondaryLabel}</CardDescription>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
+                <Badge variant={lead.readiness === 'URGENT' ? 'destructive' : lead.readiness === 'QUALIFIED' ? 'secondary' : 'outline'}>
+                  {leadReadinessLabels[lead.readiness]}
+                </Badge>
+                <Badge variant="outline">{smsStateLabels[lead.smsState]}</Badge>
+                {lead.notifiedAt || lead.ownerNotifiedAt ? <Badge variant="secondary">Owner alerted</Badge> : null}
+              </div>
+              <p className="max-w-2xl text-sm text-muted-foreground">{getLeadActionSummary(lead.status)}</p>
             </div>
-            <div className="flex flex-wrap gap-2">
-              <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
-              <Badge variant={lead.readiness === 'URGENT' ? 'destructive' : lead.readiness === 'QUALIFIED' ? 'secondary' : 'outline'}>
-                {leadReadinessLabels[lead.readiness]}
-              </Badge>
-              <Badge variant="outline">{smsStateLabels[lead.smsState]}</Badge>
-              {lead.notifiedAt || lead.ownerNotifiedAt ? <Badge variant="secondary">Owner alerted</Badge> : null}
+
+            <div className="grid w-full gap-3 xl:max-w-2xl xl:grid-cols-[minmax(0,1.35fr)_repeat(3,minmax(0,1fr))]">
+              <Link className={buttonVariants({ className: 'w-full' })} href={`tel:${lead.callerPhoneNormalized || lead.callerPhone}`}>
+                Call now
+              </Link>
+              <LeadStatusActionForm leadId={lead.id} status="CONTACTED" redirectTo={redirectTo} label="Mark contacted" variant="outline" />
+              <LeadStatusActionForm leadId={lead.id} status="BOOKED" redirectTo={redirectTo} label="Mark booked" />
+              <LeadStatusActionForm leadId={lead.id} status="LOST" redirectTo={redirectTo} label="Mark lost" variant="destructive" />
             </div>
-          </div>
-          <div className="grid w-full gap-2 sm:grid-cols-2 lg:w-auto lg:min-w-[24rem]">
-            <Link className={buttonVariants({ className: 'w-full' })} href={`tel:${lead.callerPhoneNormalized || lead.callerPhone}`}>
-              Call Now
-            </Link>
-            <LeadStatusActionForm leadId={lead.id} status="CONTACTED" redirectTo={redirectTo} label="Mark Contacted" variant="outline" />
-            <LeadStatusActionForm leadId={lead.id} status="BOOKED" redirectTo={redirectTo} label="Mark Booked" />
-            <LeadStatusActionForm leadId={lead.id} status="LOST" redirectTo={redirectTo} label="Mark Lost" variant="destructive" />
           </div>
         </CardHeader>
-        <CardContent className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          <div className="rounded-xl border bg-background/80 p-4 text-sm">
+        <CardContent className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <div className="rounded-2xl border bg-background/90 p-4 text-sm">
             <p className="text-xs uppercase tracking-wide text-muted-foreground">Phone</p>
             <p className="mt-2 font-medium">{formatPhoneForDisplay(lead.callerPhoneNormalized || lead.callerPhone)}</p>
-            <p className="mt-2 text-muted-foreground">Created {formatRelativeTime(lead.createdAt)} · {formatDateTime(lead.createdAt)}</p>
+            <p className="mt-2 text-muted-foreground">Created {formatRelativeTime(lead.createdAt)}.</p>
           </div>
-          <div className="rounded-xl border bg-background/80 p-4 text-sm">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Service requested</p>
+          <div className="rounded-2xl border bg-background/90 p-4 text-sm">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Service</p>
             <p className="mt-2 font-medium">{lead.serviceType || lead.serviceRequested || 'Still being captured'}</p>
             <p className="mt-2 text-muted-foreground">Urgency: {lead.urgency || 'Pending reply'}</p>
           </div>
-          <div className="rounded-xl border bg-background/80 p-4 text-sm">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Qualification</p>
-            <p className="mt-2 font-medium">{leadReadinessLabels[lead.readiness]}</p>
+          <div className="rounded-2xl border bg-background/90 p-4 text-sm">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Callback timing</p>
+            <p className="mt-2 font-medium">{lead.bestTime || 'No preferred time yet'}</p>
             <p className="mt-2 text-muted-foreground">
-              Callback requested:{' '}
-              {typeof lead.callbackRequested === 'boolean' ? (lead.callbackRequested ? 'Yes' : 'No') : 'Not answered'}
+              Callback requested: {typeof lead.callbackRequested === 'boolean' ? (lead.callbackRequested ? 'Yes' : 'No') : 'Not answered'}
             </p>
           </div>
-          <div className="rounded-xl border bg-background/80 p-4 text-sm">
+          <div className="rounded-2xl border bg-background/90 p-4 text-sm">
             <p className="text-xs uppercase tracking-wide text-muted-foreground">Location</p>
             <p className="mt-2 font-medium">{lead.location || lead.zipCode || 'Still being captured'}</p>
-            <p className="mt-2 text-muted-foreground">Best callback time: {lead.bestTime || 'Pending reply'}</p>
+            <p className="mt-2 text-muted-foreground">{isOpenLead ? 'Still needs an outcome update.' : 'Outcome already captured.'}</p>
           </div>
         </CardContent>
       </Card>
 
-      <div className="grid gap-6 xl:grid-cols-[1.25fr_0.75fr]">
-        <Card className="bg-card/90">
+      <div className="grid gap-6 xl:grid-cols-[1.25fr_0.85fr]">
+        <Card className="bg-card/95">
           <CardHeader>
             <CardTitle>Conversation history</CardTitle>
             <CardDescription>Review the full SMS thread before you call back.</CardDescription>
@@ -164,7 +188,7 @@ export default async function LeadDetailPage({
               lead.messages.map((message) => (
                 <div
                   key={message.id}
-                  className={`rounded-xl border p-3 text-sm ${message.direction === MessageDirection.OUTBOUND ? 'bg-primary/5' : 'bg-card'}`}
+                  className={`rounded-2xl border p-3 text-sm ${message.direction === MessageDirection.OUTBOUND ? 'bg-primary/5' : 'bg-card'}`}
                 >
                   <div className="mb-1 flex items-center justify-between gap-3 text-xs text-muted-foreground">
                     <span>{message.direction === MessageDirection.OUTBOUND ? 'CallbackCloser' : 'Lead'}</span>
@@ -187,8 +211,8 @@ export default async function LeadDetailPage({
         <div className="space-y-6">
           <Card>
             <CardHeader>
-              <CardTitle>Lead summary</CardTitle>
-              <CardDescription>The details captured before the callback.</CardDescription>
+              <CardTitle>Qualification info</CardTitle>
+              <CardDescription>The notes CallbackCloser collected before you call back.</CardDescription>
             </CardHeader>
             <CardContent className="space-y-3 text-sm">
               <div className="grid grid-cols-2 gap-2">
@@ -196,12 +220,16 @@ export default async function LeadDetailPage({
                 <span>{lead.summary || 'Summary will update as the intake progresses.'}</span>
               </div>
               <div className="grid grid-cols-2 gap-2">
-                <span className="text-muted-foreground">Qualified at</span>
-                <span>{formatDateTime(lead.qualifiedAt)}</span>
+                <span className="text-muted-foreground">Service requested</span>
+                <span>{lead.serviceType || lead.serviceRequested || 'Still being captured'}</span>
               </div>
               <div className="grid grid-cols-2 gap-2">
-                <span className="text-muted-foreground">Owner alerted</span>
-                <span>{formatDateTime(lead.notifiedAt || lead.ownerNotifiedAt)}</span>
+                <span className="text-muted-foreground">Urgency</span>
+                <span>{lead.urgency || 'Pending reply'}</span>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <span className="text-muted-foreground">Qualified at</span>
+                <span>{formatDateTime(lead.qualifiedAt)}</span>
               </div>
               <div className="grid grid-cols-2 gap-2">
                 <span className="text-muted-foreground">Current status</span>
@@ -213,7 +241,7 @@ export default async function LeadDetailPage({
           <Card>
             <CardHeader>
               <CardTitle>Missed call details</CardTitle>
-              <CardDescription>The call record that opened this lead.</CardDescription>
+              <CardDescription>The call record that started this lead.</CardDescription>
             </CardHeader>
             <CardContent className="space-y-3 text-sm">
               {lead.call ? (
@@ -225,6 +253,10 @@ export default async function LeadDetailPage({
                   <div className="grid grid-cols-2 gap-2">
                     <span className="text-muted-foreground">Missed</span>
                     <span>{lead.call.missed ? 'Yes' : 'No'}</span>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <span className="text-muted-foreground">Recorded at</span>
+                    <span>{formatDateTime(lead.call.createdAt)}</span>
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     <span className="text-muted-foreground">Recording</span>
@@ -245,7 +277,7 @@ export default async function LeadDetailPage({
           <Card>
             <CardHeader>
               <CardTitle>Owner alerts</CardTitle>
-              <CardDescription>What CallbackCloser sent when this lead was ready for action.</CardDescription>
+              <CardDescription>When CallbackCloser told you this lead was ready.</CardDescription>
             </CardHeader>
             <CardContent className="space-y-3 text-sm">
               <div className="grid grid-cols-2 gap-2">

--- a/app/app/leads/page.tsx
+++ b/app/app/leads/page.tsx
@@ -1,211 +1,237 @@
 import Link from 'next/link';
-import { LeadStatus } from '@prisma/client';
+import { LeadReadiness, LeadStatus } from '@prisma/client';
 
-import { UpgradeBanner } from '@/components/upgrade-banner';
+import { CustomerLeadRow } from '@/components/customer-lead-row';
 import { Badge } from '@/components/ui/badge';
 import { buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { requireBusiness } from '@/lib/auth';
-import { listAllDashboardLeadsForBusiness, listDashboardLeadsForBusiness } from '@/lib/business-access';
-import { db } from '@/lib/db';
-import {
-  formatDateTime,
-  formatRelativeTime,
-  getLeadStatusBadgeVariant,
-  leadReadinessLabels,
-  leadStatusLabels,
-  leadStatusOrder,
-} from '@/lib/lead-presenters';
-import { formatPhoneForDisplay } from '@/lib/phone';
-import { getPortfolioDemoBlockedCount, getPortfolioDemoLeads, isPortfolioDemoMode } from '@/lib/portfolio-demo';
-import { getBusinessBillingAccessState } from '@/lib/subscription';
-import { getConversationUsageForBusiness } from '@/lib/usage';
-import { describeAutomationBlockReason, resolveAutomationBlockReason } from '@/lib/usage-visibility';
+import { listAllDashboardLeadsForBusiness } from '@/lib/business-access';
+import { getLeadLastActivityAt, isLeadOpenStatus, leadStatusLabels } from '@/lib/lead-presenters';
+import { getPortfolioDemoLeads, isPortfolioDemoMode } from '@/lib/portfolio-demo';
 import { cn } from '@/lib/utils';
 
 type SearchParams = Record<string, string | string[] | undefined>;
+type InboxView = 'attention' | 'all' | 'booked' | 'lost';
 
-function buildLeadsHref(status: LeadStatus | null) {
-  const params = new URLSearchParams();
-  if (status) params.set('status', status.toLowerCase());
-  const query = params.toString();
-  return query ? `/app/leads?${query}` : '/app/leads';
+function buildLeadsHref(view: InboxView) {
+  if (view === 'attention') return '/app/leads?view=attention';
+  if (view === 'all') return '/app/leads';
+  return `/app/leads?view=${view}`;
 }
 
-function buildLeadDetailHref(leadId: string, status: LeadStatus | null) {
-  const params = new URLSearchParams();
-  const returnTo = buildLeadsHref(status);
-  if (returnTo !== '/app/leads') {
-    params.set('from', returnTo);
-  }
-  const query = params.toString();
-  return query ? `/app/leads/${leadId}?${query}` : `/app/leads/${leadId}`;
+function buildStatusHref(status: LeadStatus) {
+  return `/app/leads?status=${status.toLowerCase()}`;
 }
 
-function getLeadPrimaryLabel(lead: {
-  callerName?: string | null;
-  contactName?: string | null;
-  callerPhoneNormalized?: string | null;
-  callerPhone: string;
-}) {
-  return lead.callerName || lead.contactName || formatPhoneForDisplay(lead.callerPhoneNormalized || lead.callerPhone);
-}
+function buildLeadDetailHref(leadId: string, params: { view?: InboxView; status?: LeadStatus | null }) {
+  const query = new URLSearchParams();
 
-function getLeadSecondaryLabel(lead: {
-  callerName?: string | null;
-  contactName?: string | null;
-  callerPhoneNormalized?: string | null;
-  callerPhone: string;
-}) {
-  if (lead.callerName || lead.contactName) {
-    return formatPhoneForDisplay(lead.callerPhoneNormalized || lead.callerPhone);
+  if (params.status) {
+    query.set('from', buildStatusHref(params.status));
+  } else if (params.view && params.view !== 'all') {
+    query.set('from', buildLeadsHref(params.view));
   }
 
-  return 'Name not captured yet';
+  const queryString = query.toString();
+  return queryString ? `/app/leads/${leadId}?${queryString}` : `/app/leads/${leadId}`;
+}
+
+function parseInboxView(value: string | undefined): InboxView {
+  if (value === 'all' || value === 'booked' || value === 'lost' || value === 'attention') {
+    return value;
+  }
+
+  return 'attention';
+}
+
+function getAttentionPriority(lead: {
+  status: LeadStatus;
+  readiness: LeadReadiness;
+  createdAt: Date;
+  lastInteractionAt: Date | null;
+  lastInboundAt: Date | null;
+  lastOutboundAt: Date | null;
+}) {
+  const statusPriority: Record<LeadStatus, number> = {
+    NEW: 0,
+    QUALIFIED: 1,
+    NOTIFIED: 2,
+    CONTACTED: 3,
+    BOOKED: 4,
+    LOST: 5,
+  };
+  const readinessPriority: Record<LeadReadiness, number> = {
+    URGENT: 0,
+    QUALIFIED: 1,
+    PENDING: 2,
+  };
+
+  return {
+    status: statusPriority[lead.status],
+    readiness: readinessPriority[lead.readiness],
+    activityAt: getLeadLastActivityAt(lead).getTime(),
+  };
+}
+
+function sortAttentionLeads<
+  T extends {
+    status: LeadStatus;
+    readiness: LeadReadiness;
+    createdAt: Date;
+    lastInteractionAt: Date | null;
+    lastInboundAt: Date | null;
+    lastOutboundAt: Date | null;
+  },
+>(leads: T[]) {
+  return [...leads].sort((left, right) => {
+    const leftPriority = getAttentionPriority(left);
+    const rightPriority = getAttentionPriority(right);
+
+    if (leftPriority.status !== rightPriority.status) {
+      return leftPriority.status - rightPriority.status;
+    }
+
+    if (leftPriority.readiness !== rightPriority.readiness) {
+      return leftPriority.readiness - rightPriority.readiness;
+    }
+
+    return rightPriority.activityAt - leftPriority.activityAt;
+  });
 }
 
 export default async function LeadsPage({ searchParams }: { searchParams?: SearchParams }) {
   const business = await requireBusiness();
-  const rawFilter = typeof searchParams?.status === 'string' ? searchParams.status.toUpperCase() : 'ALL';
-  const statusFilter = Object.values(LeadStatus).includes(rawFilter as LeadStatus) ? (rawFilter as LeadStatus) : null;
+  const demoMode = isPortfolioDemoMode();
   const error = typeof searchParams?.error === 'string' ? searchParams.error : undefined;
   const saved = searchParams?.saved === '1';
-  const demoMode = isPortfolioDemoMode();
-  const billingAccess = getBusinessBillingAccessState(business);
-
-  const [filteredLeads, allLeads, blockedCount, usage] = demoMode
-    ? [getPortfolioDemoLeads(statusFilter), getPortfolioDemoLeads(null), getPortfolioDemoBlockedCount(), null]
-    : await Promise.all([
-        listDashboardLeadsForBusiness(business.id, statusFilter),
-        listAllDashboardLeadsForBusiness(business.id),
-        db.lead.count({ where: { businessId: business.id, billingRequired: true } }),
-        getConversationUsageForBusiness(business),
-      ]);
+  const rawStatus = typeof searchParams?.status === 'string' ? searchParams.status.toUpperCase() : null;
+  const statusFilter = rawStatus && Object.values(LeadStatus).includes(rawStatus as LeadStatus) ? (rawStatus as LeadStatus) : null;
+  const view = statusFilter ? 'all' : parseInboxView(typeof searchParams?.view === 'string' ? searchParams.view : undefined);
+  const allLeads = demoMode ? getPortfolioDemoLeads(null) : await listAllDashboardLeadsForBusiness(business.id);
   const hasLeads = allLeads.length > 0;
-  const automationBlockReason = resolveAutomationBlockReason({
-    blockedCount,
-    subscriptionStatus: business.subscriptionStatus,
-    billingActive: billingAccess.billingActive,
-    usage,
-  });
-  const automationBlockMessage = describeAutomationBlockReason(automationBlockReason, {
-    blockedCount,
-    usage: usage ?? undefined,
-  });
+
+  const filteredLeads = statusFilter
+    ? allLeads.filter((lead) => lead.status === statusFilter)
+    : view === 'attention'
+      ? sortAttentionLeads(allLeads.filter((lead) => isLeadOpenStatus(lead.status)))
+      : view === 'booked'
+        ? allLeads.filter((lead) => lead.status === LeadStatus.BOOKED)
+        : view === 'lost'
+          ? allLeads.filter((lead) => lead.status === LeadStatus.LOST)
+          : allLeads;
+
+  const filterChips = [
+    {
+      key: 'attention' as const,
+      label: 'Needs follow-up',
+      href: buildLeadsHref('attention'),
+      count: allLeads.filter((lead) => isLeadOpenStatus(lead.status)).length,
+      active: !statusFilter && view === 'attention',
+    },
+    {
+      key: 'all' as const,
+      label: 'All leads',
+      href: buildLeadsHref('all'),
+      count: allLeads.length,
+      active: !statusFilter && view === 'all',
+    },
+    {
+      key: 'booked' as const,
+      label: 'Booked',
+      href: buildLeadsHref('booked'),
+      count: allLeads.filter((lead) => lead.status === LeadStatus.BOOKED).length,
+      active: !statusFilter && view === 'booked',
+    },
+    {
+      key: 'lost' as const,
+      label: 'Lost',
+      href: buildLeadsHref('lost'),
+      count: allLeads.filter((lead) => lead.status === LeadStatus.LOST).length,
+      active: !statusFilter && view === 'lost',
+    },
+  ];
+
+  const listDescription = statusFilter
+    ? `Showing ${leadStatusLabels[statusFilter].toLowerCase()} leads. Open a lead to act on it.`
+    : view === 'attention'
+      ? 'Showing leads that still need action. Open one to call back or update the outcome.'
+      : 'Open any lead to review the conversation and update the outcome from the detail page.';
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+      <div className="space-y-3">
+        <Badge variant="outline">Lead inbox</Badge>
         <div className="space-y-2">
-          <Badge variant="outline">Recovered Leads</Badge>
-          <div>
-            <h1 className="text-2xl font-semibold tracking-tight">Lead inbox</h1>
-            <p className="text-sm text-muted-foreground">
-              Open any lead to call back, review the conversation, and update the outcome from one clear workspace.
-            </p>
-          </div>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Link className={buttonVariants({ variant: 'outline' })} href="/app/conversations">
-            Open Conversations
-          </Link>
-          <Link className={buttonVariants({ variant: 'outline' })} href="/app/call-flow">
-            Run test flow
-          </Link>
+          <h1 className="text-2xl font-semibold tracking-tight">Scan the list. Open the lead. Take action.</h1>
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            This page is only for scanning. Click a lead to open the detail page where the real follow-up work happens.
+          </p>
         </div>
       </div>
 
       {error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{error}</div> : null}
-      {saved ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Lead status updated.</div> : null}
-      {automationBlockReason !== 'none' && blockedCount > 0 ? (
-        <UpgradeBanner
-          blockedCount={blockedCount}
-          title="Automated follow-up needs billing attention."
-          description={automationBlockMessage}
-          ctaLabel={automationBlockReason === 'usage_limit_reached' ? 'Upgrade Plan' : 'Open Billing'}
-        />
-      ) : null}
+      {saved ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Lead updated.</div> : null}
 
       {!hasLeads ? (
         <Card className="border-primary/20 bg-primary/5">
           <CardHeader>
-            <CardTitle>No recovered leads yet</CardTitle>
-            <CardDescription>Run your first missed-call test. New leads will appear here as soon as CallbackCloser captures them.</CardDescription>
+            <CardTitle>No leads yet</CardTitle>
+            <CardDescription>When a missed call becomes a lead, it will appear here automatically.</CardDescription>
           </CardHeader>
           <CardContent className="flex flex-wrap gap-3">
-            <Link className={buttonVariants()} href="/app/call-flow">
-              Run your first test call
-            </Link>
             <Link className={buttonVariants({ variant: 'outline' })} href="/app/settings">
-              Finish setup
+              Check setup
+            </Link>
+            <Link className={buttonVariants()} href="/app/call-flow">
+              Run a test call
             </Link>
           </CardContent>
         </Card>
       ) : (
-        <Card className="bg-card/90">
+        <Card className="bg-card/95">
           <CardHeader className="gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <CardTitle>Lead inbox</CardTitle>
-              <CardDescription>
-                {filteredLeads.length} visible lead{filteredLeads.length === 1 ? '' : 's'}.
-                {' '}Click a lead to open the full action screen.
-              </CardDescription>
+              <CardTitle>Inbox</CardTitle>
+              <CardDescription>{listDescription}</CardDescription>
             </div>
             <div className="flex flex-wrap gap-2">
-              <Link href={buildLeadsHref(null)} className={cn('rounded-md border px-3 py-1.5 text-sm', !statusFilter && 'bg-muted')}>
-                All
-              </Link>
-              {leadStatusOrder.map((status) => (
+              {filterChips.map((chip) => (
                 <Link
-                  key={status}
-                  href={buildLeadsHref(status)}
-                  className={cn('rounded-md border px-3 py-1.5 text-sm', statusFilter === status && 'bg-muted')}
+                  key={chip.key}
+                  className={cn('rounded-full border px-3 py-1.5 text-sm transition-colors hover:bg-muted', chip.active && 'bg-muted')}
+                  href={chip.href}
                 >
-                  {leadStatusLabels[status]}
+                  {chip.label} <span className="text-muted-foreground">{chip.count}</span>
                 </Link>
               ))}
             </div>
           </CardHeader>
-          <CardContent className="space-y-1">
+          <CardContent className="space-y-3">
+            {statusFilter ? (
+              <div className="flex items-center gap-3 rounded-2xl border bg-muted/20 px-4 py-3 text-sm">
+                <span className="font-medium">Status filter:</span>
+                <Badge variant="secondary">{leadStatusLabels[statusFilter]}</Badge>
+                <Link className="text-muted-foreground underline underline-offset-4" href="/app/leads?view=attention">
+                  Clear filter
+                </Link>
+              </div>
+            ) : null}
+
             {filteredLeads.length === 0 ? (
-              <div className="rounded-xl border bg-muted/20 p-6 text-sm text-muted-foreground">
-                No leads match this filter right now.
+              <div className="rounded-2xl border border-dashed bg-muted/20 p-6 text-sm text-muted-foreground">
+                No leads match this view right now.
               </div>
             ) : (
               filteredLeads.map((lead) => (
-                <Link
+                <CustomerLeadRow
                   key={lead.id}
-                  href={buildLeadDetailHref(lead.id, statusFilter)}
-                  className="block rounded-2xl border bg-background/70 p-4 transition-colors hover:bg-muted/20"
-                >
-                  <div className="flex flex-col gap-4 lg:grid lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)_minmax(0,0.9fr)_auto] lg:items-center">
-                    <div className="space-y-1">
-                      <p className="font-medium text-foreground">{getLeadPrimaryLabel(lead)}</p>
-                      <p className="text-sm text-muted-foreground">{getLeadSecondaryLabel(lead)}</p>
-                    </div>
-
-                    <div className="space-y-1">
-                      <p className="text-sm font-medium text-foreground">{lead.serviceType || lead.serviceRequested || 'Service not captured yet'}</p>
-                      <p className="text-sm text-muted-foreground">
-                        {lead.location || lead.zipCode ? `Location: ${lead.location || lead.zipCode}` : 'Location pending'}
-                      </p>
-                    </div>
-
-                    <div className="space-y-1">
-                      <p className="text-sm font-medium text-foreground">{lead.urgency || 'Urgency pending'}</p>
-                      <p className="text-sm text-muted-foreground">
-                        Created {formatRelativeTime(lead.createdAt)} · {formatDateTime(lead.createdAt)}
-                      </p>
-                    </div>
-
-                    <div className="flex flex-wrap items-center gap-2 lg:justify-end">
-                      <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
-                      <Badge variant={lead.readiness === 'URGENT' ? 'destructive' : lead.readiness === 'QUALIFIED' ? 'secondary' : 'outline'}>
-                        {leadReadinessLabels[lead.readiness]}
-                      </Badge>
-                    </div>
-                  </div>
-                </Link>
+                  lead={lead}
+                  href={buildLeadDetailHref(lead.id, {
+                    view,
+                    status: statusFilter,
+                  })}
+                />
               ))
             )}
           </CardContent>

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,21 +1,285 @@
-import { auth } from '@clerk/nextjs/server';
-import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { LeadReadiness, LeadStatus } from '@prisma/client';
 
+import { CustomerLeadRow } from '@/components/customer-lead-row';
+import { Badge } from '@/components/ui/badge';
+import { buttonVariants } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { requireBusiness } from '@/lib/auth';
+import { listAllDashboardLeadsForBusiness } from '@/lib/business-access';
 import { db } from '@/lib/db';
-import { isPortfolioDemoMode } from '@/lib/portfolio-demo';
+import { getLeadLastActivityAt, isLeadOpenStatus } from '@/lib/lead-presenters';
+import { getPortfolioDemoBusiness, getPortfolioDemoLeads, isPortfolioDemoMode } from '@/lib/portfolio-demo';
+import { getCustomerSystemStatus } from '@/lib/system-status';
 
-export default async function AppIndexPage() {
-  if (isPortfolioDemoMode()) {
-    redirect('/app/leads');
+function buildLeadDetailHref(leadId: string) {
+  return `/app/leads/${leadId}?from=%2Fapp`;
+}
+
+function parseTimeZoneOffsetMinutes(value: string) {
+  const match = value.match(/GMT([+-])(\d{1,2})(?::?(\d{2}))?/);
+  if (!match) return 0;
+
+  const sign = match[1] === '+' ? 1 : -1;
+  const hours = Number(match[2]);
+  const minutes = Number(match[3] || '0');
+  return sign * (hours * 60 + minutes);
+}
+
+function getTimeZoneOffsetMinutes(date: Date, timeZone: string) {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    timeZoneName: 'shortOffset',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).formatToParts(date);
+
+  const label = parts.find((part) => part.type === 'timeZoneName')?.value || 'GMT';
+  return parseTimeZoneOffsetMinutes(label);
+}
+
+function getTodayRangeForTimeZone(timeZone: string) {
+  try {
+    const now = new Date();
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(now);
+
+    const year = Number(parts.find((part) => part.type === 'year')?.value || now.getUTCFullYear());
+    const month = Number(parts.find((part) => part.type === 'month')?.value || now.getUTCMonth() + 1);
+    const day = Number(parts.find((part) => part.type === 'day')?.value || now.getUTCDate());
+
+    const startGuess = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+    const endGuess = new Date(Date.UTC(year, month - 1, day + 1, 0, 0, 0));
+
+    return {
+      start: new Date(startGuess.getTime() - getTimeZoneOffsetMinutes(startGuess, timeZone) * 60_000),
+      end: new Date(endGuess.getTime() - getTimeZoneOffsetMinutes(endGuess, timeZone) * 60_000),
+    };
+  } catch {
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+
+    const end = new Date(start);
+    end.setDate(end.getDate() + 1);
+
+    return { start, end };
   }
+}
 
-  const { userId } = await auth();
-  if (!userId) redirect('/sign-in');
+function getAttentionPriority(lead: {
+  status: LeadStatus;
+  readiness: LeadReadiness;
+  createdAt: Date;
+  lastInteractionAt: Date | null;
+  lastInboundAt: Date | null;
+  lastOutboundAt: Date | null;
+}) {
+  const statusPriority: Record<LeadStatus, number> = {
+    NEW: 0,
+    QUALIFIED: 1,
+    NOTIFIED: 2,
+    CONTACTED: 3,
+    BOOKED: 4,
+    LOST: 5,
+  };
+  const readinessPriority: Record<LeadReadiness, number> = {
+    URGENT: 0,
+    QUALIFIED: 1,
+    PENDING: 2,
+  };
 
-  const business = await db.business.findUnique({ where: { ownerClerkId: userId } });
-  if (!business) {
-    redirect('/app/onboarding');
-  }
+  return {
+    status: statusPriority[lead.status],
+    readiness: readinessPriority[lead.readiness],
+    activityAt: getLeadLastActivityAt(lead).getTime(),
+  };
+}
 
-  redirect('/app/leads');
+export default async function AppHomePage() {
+  const demoMode = isPortfolioDemoMode();
+  const business = demoMode ? getPortfolioDemoBusiness() : await requireBusiness();
+  const { start, end } = getTodayRangeForTimeZone(business.timezone || 'America/New_York');
+
+  const [allLeads, notificationSettings, missedCallsToday] = demoMode
+    ? [
+        getPortfolioDemoLeads(null),
+        null,
+        getPortfolioDemoLeads(null).filter((lead) => lead.createdAt >= start && lead.createdAt < end).length,
+      ]
+    : await Promise.all([
+        listAllDashboardLeadsForBusiness(business.id),
+        db.businessNotificationSettings.findUnique({ where: { businessId: business.id } }),
+        db.call.count({
+          where: {
+            businessId: business.id,
+            missed: true,
+            createdAt: {
+              gte: start,
+              lt: end,
+            },
+          },
+        }),
+      ]);
+
+  const successfulLeadCount = allLeads.filter((lead) => lead.ownerNotifiedAt || lead.notifiedAt).length;
+  const systemStatus = getCustomerSystemStatus(business, successfulLeadCount);
+  const attentionLeads = allLeads
+    .filter((lead) => isLeadOpenStatus(lead.status))
+    .sort((left, right) => {
+      const leftPriority = getAttentionPriority(left);
+      const rightPriority = getAttentionPriority(right);
+
+      if (leftPriority.status !== rightPriority.status) {
+        return leftPriority.status - rightPriority.status;
+      }
+
+      if (leftPriority.readiness !== rightPriority.readiness) {
+        return leftPriority.readiness - rightPriority.readiness;
+      }
+
+      return rightPriority.activityAt - leftPriority.activityAt;
+    })
+    .slice(0, 5);
+  const recentLeads = [...allLeads]
+    .sort((left, right) => getLeadLastActivityAt(right).getTime() - getLeadLastActivityAt(left).getTime())
+    .slice(0, 6);
+
+  const ownerAlertsReady = Boolean(
+    business.notifyPhone ||
+      notificationSettings?.ownerPhone ||
+      (notificationSettings?.notifySms && notificationSettings.ownerPhone) ||
+      (notificationSettings?.notifyEmail && notificationSettings.ownerEmail),
+  );
+
+  const summaryCards = [
+    {
+      label: 'New leads',
+      value: allLeads.filter((lead) => lead.status === LeadStatus.NEW).length,
+      href: '/app/leads?status=new',
+    },
+    {
+      label: 'Needs follow-up',
+      value: allLeads.filter((lead) => isLeadOpenStatus(lead.status)).length,
+      href: '/app/leads?view=attention',
+    },
+    {
+      label: 'Booked',
+      value: allLeads.filter((lead) => lead.status === LeadStatus.BOOKED).length,
+      href: '/app/leads?status=booked',
+    },
+    {
+      label: 'Missed calls today',
+      value: missedCallsToday,
+      href: '/app/leads?view=attention',
+    },
+  ];
+
+  const healthItems = [
+    {
+      label: 'Texting',
+      value: systemStatus.key === 'live' ? 'Active' : 'Finishing setup',
+      detail: systemStatus.description,
+    },
+    {
+      label: 'Phone line',
+      value: business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber ? 'Connected' : 'Needs setup',
+      detail: business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber ? 'Your business line is attached to CallbackCloser.' : 'Finish phone setup in Settings before going live.',
+    },
+    {
+      label: 'Owner alerts',
+      value: ownerAlertsReady ? 'Ready' : 'Needs setup',
+      detail: ownerAlertsReady ? 'Lead alerts can reach you quickly when a missed call turns into a lead.' : 'Add an owner alert number or email in Settings.',
+    },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <section className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-3">
+          <Badge variant="outline">Customer dashboard</Badge>
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold tracking-tight">Who needs follow-up right now?</h1>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Open the lead that needs attention, take action, and move on. This page keeps the next calls obvious.
+            </p>
+          </div>
+        </div>
+        <Link className={buttonVariants()} href="/app/leads?view=attention">
+          Open lead inbox
+        </Link>
+      </section>
+
+      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {summaryCards.map((card) => (
+          <Link key={card.label} href={card.href} className="rounded-2xl border bg-card p-5 transition-colors hover:bg-muted/20">
+            <p className="text-sm text-muted-foreground">{card.label}</p>
+            <p className="mt-3 text-3xl font-semibold tracking-tight">{card.value}</p>
+          </Link>
+        ))}
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[1.4fr_0.85fr]">
+        <Card className="bg-card/95">
+          <CardHeader>
+            <CardTitle>Leads needing attention first</CardTitle>
+            <CardDescription>These are the leads most likely to need a callback or outcome update next.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {attentionLeads.length === 0 ? (
+              <div className="rounded-2xl border border-dashed bg-muted/20 p-6 text-sm text-muted-foreground">
+                No open leads need action right now.
+              </div>
+            ) : (
+              attentionLeads.map((lead) => <CustomerLeadRow key={lead.id} lead={lead} href={buildLeadDetailHref(lead.id)} compact />)
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>System health</CardTitle>
+            <CardDescription>Only the simple status checks that matter for day-to-day use.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {healthItems.map((item) => (
+              <div key={item.label} className="rounded-2xl border bg-background/80 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-sm font-medium">{item.label}</p>
+                  <Badge variant={item.value === 'Needs setup' ? 'outline' : 'secondary'}>{item.value}</Badge>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section>
+        <Card className="bg-card/95">
+          <CardHeader className="gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <CardTitle>Recent leads</CardTitle>
+              <CardDescription>Everything that came through recently, whether it still needs action or not.</CardDescription>
+            </div>
+            <Link className={buttonVariants({ variant: 'outline' })} href="/app/leads">
+              View all leads
+            </Link>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {recentLeads.length === 0 ? (
+              <div className="rounded-2xl border border-dashed bg-muted/20 p-6 text-sm text-muted-foreground">
+                Leads will show up here as soon as CallbackCloser captures a missed call.
+              </div>
+            ) : (
+              recentLeads.map((lead) => <CustomerLeadRow key={lead.id} lead={lead} href={buildLeadDetailHref(lead.id)} />)
+            )}
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
 }

--- a/app/app/settings/page.tsx
+++ b/app/app/settings/page.tsx
@@ -474,7 +474,9 @@ export default async function SettingsPage({ searchParams }: { searchParams?: Re
                 <div className="rounded-xl border bg-muted/20 p-4">
                   <p className="font-medium">Message disclaimer preview</p>
                   <p className="mt-2 text-muted-foreground">
-                    By replying, callers consent to text messages related to their missed call. Message frequency varies. Message and data rates may apply. Reply STOP to opt out, HELP for help.
+                    By providing a phone number and agreeing to receive messages, callers consent to SMS from CallbackCloser related
+                    to callback coordination, customer support, service updates, and account or service notifications tied to their
+                    request. Message frequency varies. Message and data rates may apply. Reply STOP to opt out or HELP for help.
                   </p>
                 </div>
               </CardContent>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -28,16 +28,16 @@ export default function PrivacyPage() {
           <section className="space-y-2">
             <h2 className="text-xl font-semibold">How We Use Data</h2>
             <p className="text-sm text-muted-foreground">
-              Data is used to deliver missed-call follow-up, surface leads in the dashboard, support customer care, send account
-              notifications, deliver service updates, maintain service reliability, and support account operations.
+              Data is used to support callback coordination, customer support, service updates, account or service notifications,
+              lead visibility in the dashboard, service reliability, and account operations.
             </p>
           </section>
 
           <section className="space-y-2">
             <h2 className="text-xl font-semibold">SMS And Customer Communications</h2>
             <p className="text-sm text-muted-foreground">
-              CallbackCloser may process phone numbers, missed-call records, and SMS conversation content to provide customer care,
-              account notifications, missed call follow-up, and service updates tied to the CallbackCloser workflow.
+              CallbackCloser may process phone numbers, missed-call records, and SMS conversation content to provide callback
+              coordination, customer support, service updates, and account or service notifications related to a user&apos;s request.
             </p>
             <p className="text-sm text-muted-foreground">
               Message frequency varies by conversation. Message and data rates may apply. Recipients can reply STOP to opt out or HELP

--- a/app/simulator/actions.ts
+++ b/app/simulator/actions.ts
@@ -101,6 +101,8 @@ export async function replyToSimulatorRunAction(formData: FormData) {
       ownerClerkId: 'simulator',
       notifyPhone: null,
       subscriptionStatus: SubscriptionStatus.ACTIVE,
+      provisioningStatus: 'LIVE',
+      archivedAt: null,
     },
     leadId: run.leadId,
     body,

--- a/app/sms-consent/page.tsx
+++ b/app/sms-consent/page.tsx
@@ -11,15 +11,16 @@ const EFFECTIVE_DATE = 'April 5, 2026';
 export const metadata: Metadata = {
   title: 'SMS Consent | CallbackCloser',
   description:
-    'Review the SMS consent disclosure language CallbackCloser uses for missed call follow-up, callback coordination, customer care, and account updates.',
+    'CallbackCloser uses SMS messaging to respond to customer inquiries and provide service-related updates.',
 };
 
-const messageTypes = ['Missed call follow-up', 'Callback coordination', 'Service updates', 'Customer care', 'Account notifications'];
-const messageDetails = [
+const messageExamples = ['Callback coordination', 'Customer support', 'Service-related questions', 'Status updates', 'Account or service notifications'];
+const requiredDisclosures = [
   'Message frequency varies.',
   'Message and data rates may apply.',
   'Reply STOP to opt out.',
   'Reply HELP for help.',
+  'Contact: support@callbackcloser.com',
 ];
 
 export default function SmsConsentPage() {
@@ -29,12 +30,11 @@ export default function SmsConsentPage() {
 
       <main className="container py-12">
         <article className="mx-auto max-w-4xl space-y-8">
-          <header className="max-w-2xl space-y-3">
+          <header className="max-w-3xl space-y-3">
             <h1 className="text-4xl font-semibold tracking-tight">SMS Consent</h1>
             <p className="text-sm text-muted-foreground">Effective date: {EFFECTIVE_DATE}</p>
             <p className="text-base text-muted-foreground">
-              Review the disclosure language CallbackCloser uses in live SMS opt-in flows for missed call follow-up, callback
-              coordination, service updates, customer care, and account notifications.
+              CallbackCloser uses SMS messaging to respond to customer inquiries and provide service-related updates.
             </p>
           </header>
 
@@ -44,62 +44,58 @@ export default function SmsConsentPage() {
             <div className="space-y-6">
               <Card>
                 <CardHeader>
-                  <CardTitle>What to expect</CardTitle>
-                  <CardDescription>CallbackCloser uses text messages to keep service conversations moving after a missed call.</CardDescription>
+                  <CardTitle>Consent explanation</CardTitle>
+                  <CardDescription>
+                    By providing a phone number and agreeing to the disclosure, the user consents to receive SMS messages from
+                    CallbackCloser related to callback coordination, customer support, service updates, and account or service
+                    notifications related to the user&apos;s request.
+                  </CardDescription>
                 </CardHeader>
-                <CardContent className="space-y-3 text-sm text-muted-foreground">
-                  <div className="grid gap-2 sm:grid-cols-2">
-                    {messageTypes.map((type) => (
-                      <div key={type} className="rounded-lg border bg-muted/30 px-4 py-3">
-                        <p className="font-medium text-foreground">{type}</p>
-                      </div>
-                    ))}
-                  </div>
+                <CardContent className="text-sm text-muted-foreground">
+                  Consent to receive SMS messages is not a condition of purchase.
                 </CardContent>
               </Card>
 
               <Card>
                 <CardHeader>
-                  <CardTitle>Message details</CardTitle>
-                  <CardDescription>Live opt-in flows must show these terms before consent is captured.</CardDescription>
+                  <CardTitle>These messages may include</CardTitle>
+                  <CardDescription>CallbackCloser uses SMS for coordination, support, and service-related communication tied to a request.</CardDescription>
                 </CardHeader>
-                <CardContent className="space-y-2 text-sm text-muted-foreground">
-                  {messageDetails.map((item) => (
-                    <p key={item}>- {item}</p>
+                <CardContent className="grid gap-2 sm:grid-cols-2">
+                  {messageExamples.map((item) => (
+                    <div key={item} className="rounded-lg border bg-muted/30 px-4 py-3 text-sm">
+                      <p className="font-medium text-foreground">{item}</p>
+                    </div>
                   ))}
                 </CardContent>
               </Card>
 
               <Card>
                 <CardHeader>
-                  <CardTitle>Related trust pages</CardTitle>
-                  <CardDescription>Review the policies connected to CallbackCloser messaging and service use.</CardDescription>
+                  <CardTitle>Required disclosures</CardTitle>
+                  <CardDescription>These terms apply to service-related SMS messages sent by CallbackCloser.</CardDescription>
                 </CardHeader>
-                <CardContent className="flex flex-wrap gap-3 text-sm">
-                  <Link className="underline underline-offset-4" href="/privacy">
-                    Privacy Policy
-                  </Link>
-                  <Link className="underline underline-offset-4" href="/terms">
-                    Terms &amp; Conditions
-                  </Link>
-                  <Link className="underline underline-offset-4" href="/contact">
-                    Contact
-                  </Link>
+                <CardContent className="space-y-2 text-sm text-muted-foreground">
+                  {requiredDisclosures.map((item) => (
+                    <p key={item}>- {item}</p>
+                  ))}
                 </CardContent>
               </Card>
 
-              <p className="text-sm text-muted-foreground">
-                This page is a public compliance reference. CallbackCloser records consent inside the actual signup, intake, or customer
-                messaging flow, not on this page.
-              </p>
-
-              <p className="text-sm text-muted-foreground">
-                Need help? Email{' '}
-                <a className="underline underline-offset-4" href="mailto:support@callbackcloser.com">
-                  support@callbackcloser.com
-                </a>
-                .
-              </p>
+              <div className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground">
+                <p className="font-medium text-foreground">Related policies</p>
+                <p className="mt-2">
+                  Review our{' '}
+                  <Link className="underline underline-offset-4" href="/privacy">
+                    Privacy Policy
+                  </Link>{' '}
+                  and{' '}
+                  <Link className="underline underline-offset-4" href="/terms">
+                    Terms &amp; Conditions
+                  </Link>
+                  .
+                </p>
+              </div>
             </div>
           </section>
         </article>

--- a/app/sms-consent/page.tsx
+++ b/app/sms-consent/page.tsx
@@ -21,6 +21,7 @@ const requiredDisclosures = [
   'Reply STOP to opt out.',
   'Reply HELP for help.',
   'Contact: support@callbackcloser.com',
+  'Consent to receive SMS messages is not a condition of purchase.',
 ];
 
 export default function SmsConsentPage() {
@@ -46,14 +47,12 @@ export default function SmsConsentPage() {
                 <CardHeader>
                   <CardTitle>Consent explanation</CardTitle>
                   <CardDescription>
-                    By providing a phone number and agreeing to the disclosure, the user consents to receive SMS messages from
-                    CallbackCloser related to callback coordination, customer support, service updates, and account or service
-                    notifications related to the user&apos;s request.
+                    By providing your phone number and checking the consent box, you agree to receive SMS messages from CallbackCloser
+                    related to your request, including callback coordination, customer support, service updates, and account or
+                    service notifications.
                   </CardDescription>
                 </CardHeader>
-                <CardContent className="text-sm text-muted-foreground">
-                  Consent to receive SMS messages is not a condition of purchase.
-                </CardContent>
+                <CardContent className="text-sm text-muted-foreground">CallbackCloser uses SMS for service-related communication tied to a customer request.</CardContent>
               </Card>
 
               <Card>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -34,8 +34,8 @@ export default function TermsPage() {
           <section className="space-y-2">
             <h2 className="text-xl font-semibold">SMS Messaging</h2>
             <p className="text-sm text-muted-foreground">
-              CallbackCloser currently uses SMS for customer care, account notifications, missed call follow-up, and service updates.
-              CallbackCloser is not presented on the public website as a promotional SMS marketing program.
+              CallbackCloser uses SMS for callback coordination, customer support, service updates, and account or service
+              notifications related to a user&apos;s request.
             </p>
             <p className="text-sm text-muted-foreground">
               Public opt-in language is described on the{' '}
@@ -43,7 +43,7 @@ export default function TermsPage() {
                 SMS Consent
               </Link>{' '}
               page. Recipients can use STOP to opt out and HELP for help where messaging is active. Message frequency varies and
-              message and data rates may apply.
+              message and data rates may apply. Consent to receive SMS messages is not a condition of purchase.
             </p>
           </section>
 

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -9,10 +9,10 @@ import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 
 const navItems = [
+  { href: '/app', label: 'Home' },
   { href: '/app/leads', label: 'Leads' },
   { href: '/app/conversations', label: 'Conversations' },
-  { href: '/app/call-flow', label: 'Call Flow' },
-  { href: '/app/settings', label: 'Business Settings' },
+  { href: '/app/settings', label: 'Settings' },
   { href: '/app/billing', label: 'Billing' },
 ];
 
@@ -30,6 +30,14 @@ export function AppNav({
   systemStatusVariant?: 'default' | 'secondary' | 'destructive' | 'outline' | 'success';
 }) {
   const pathname = usePathname();
+
+  function isActivePath(href: string) {
+    if (href === '/app') {
+      return pathname === '/app';
+    }
+
+    return pathname.startsWith(href);
+  }
 
   return (
     <header className="sticky top-0 z-40 border-b bg-white/80 backdrop-blur">
@@ -60,7 +68,7 @@ export function AppNav({
               href={item.href}
               className={cn(
                 'rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-muted',
-                pathname.startsWith(item.href) && 'bg-muted text-foreground',
+                isActivePath(item.href) && 'bg-muted text-foreground',
               )}
             >
               {item.label}
@@ -85,7 +93,7 @@ export function AppNav({
             href={item.href}
             className={cn(
               'rounded-md px-3 py-1.5 text-xs font-medium transition-colors hover:bg-muted',
-              pathname.startsWith(item.href) && 'bg-muted text-foreground',
+              isActivePath(item.href) && 'bg-muted text-foreground',
             )}
           >
             {item.label}

--- a/components/customer-lead-row.tsx
+++ b/components/customer-lead-row.tsx
@@ -1,0 +1,108 @@
+import Link from 'next/link';
+import { LeadReadiness, LeadStatus } from '@prisma/client';
+
+import { Badge } from '@/components/ui/badge';
+import {
+  formatRelativeTime,
+  getLeadNextStepLabel,
+  getLeadStatusBadgeVariant,
+  isLeadOpenStatus,
+  leadReadinessLabels,
+  leadStatusLabels,
+} from '@/lib/lead-presenters';
+import { formatPhoneForDisplay } from '@/lib/phone';
+import { cn } from '@/lib/utils';
+
+type CustomerLeadRowLead = {
+  id: string;
+  callerName: string | null;
+  contactName: string | null;
+  callerPhoneNormalized: string | null;
+  callerPhone: string;
+  serviceType: string | null;
+  serviceRequested: string | null;
+  urgency: string | null;
+  status: LeadStatus;
+  readiness: LeadReadiness;
+  createdAt: Date;
+  lastInteractionAt: Date | null;
+};
+
+function getPrimaryLabel(lead: CustomerLeadRowLead) {
+  return lead.callerName || lead.contactName || formatPhoneForDisplay(lead.callerPhoneNormalized || lead.callerPhone);
+}
+
+function getSecondaryLabel(lead: CustomerLeadRowLead) {
+  if (lead.callerName || lead.contactName) {
+    return formatPhoneForDisplay(lead.callerPhoneNormalized || lead.callerPhone);
+  }
+
+  return 'Name not captured yet';
+}
+
+function getServiceLabel(lead: CustomerLeadRowLead) {
+  return lead.serviceType || lead.serviceRequested || 'Service not captured yet';
+}
+
+function getUrgencyLabel(lead: CustomerLeadRowLead) {
+  return lead.urgency || 'Urgency pending';
+}
+
+function getReadinessVariant(readiness: LeadReadiness) {
+  if (readiness === LeadReadiness.URGENT) return 'destructive';
+  if (readiness === LeadReadiness.QUALIFIED) return 'secondary';
+  return 'outline';
+}
+
+export function CustomerLeadRow({
+  lead,
+  href,
+  compact = false,
+}: {
+  lead: CustomerLeadRowLead;
+  href: string;
+  compact?: boolean;
+}) {
+  const isOpen = isLeadOpenStatus(lead.status);
+  const nextStep = getLeadNextStepLabel(lead.status);
+  const activityAt = lead.lastInteractionAt || lead.createdAt;
+
+  return (
+    <Link
+      className={cn(
+        'group block rounded-2xl border bg-background/90 transition-colors hover:bg-muted/20',
+        isOpen && 'border-primary/20',
+        compact ? 'p-4' : 'p-4 sm:p-5',
+      )}
+      href={href}
+    >
+      <div className={cn('flex flex-col gap-4', compact ? 'lg:grid lg:grid-cols-[minmax(0,1.1fr)_auto] lg:items-center' : 'lg:grid lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.9fr)_auto] lg:items-center')}>
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            {lead.status === LeadStatus.NEW ? <span className="h-2.5 w-2.5 rounded-full bg-primary" aria-hidden="true" /> : null}
+            <p className="font-medium text-foreground">{getPrimaryLabel(lead)}</p>
+            {lead.status === LeadStatus.NEW ? <Badge variant="secondary">New lead</Badge> : null}
+          </div>
+          <p className="text-sm text-muted-foreground">{getSecondaryLabel(lead)}</p>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+            <span>{getServiceLabel(lead)}</span>
+            <span>{getUrgencyLabel(lead)}</span>
+            <span>{formatRelativeTime(activityAt)}</span>
+          </div>
+        </div>
+
+        {!compact ? (
+          <div className="space-y-1 text-sm">
+            <p className="font-medium text-foreground">{nextStep}</p>
+            <p className="text-muted-foreground">{isOpen ? 'Open the lead to call back or update the outcome.' : 'Closed lead for reference.'}</p>
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+          <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
+          <Badge variant={getReadinessVariant(lead.readiness)}>{leadReadinessLabels[lead.readiness]}</Badge>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/components/public-sms-consent-form.tsx
+++ b/components/public-sms-consent-form.tsx
@@ -1,39 +1,31 @@
 import Link from 'next/link';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 
 export function PublicSmsConsentForm() {
   return (
     <Card className="border-primary/20 bg-card/95">
       <CardHeader>
-        <CardTitle>Consent language reference</CardTitle>
+        <CardTitle>Consent disclosure</CardTitle>
         <CardDescription>
-          This page documents the disclosure language CallbackCloser uses for SMS opt-in flows. It does not submit or store phone numbers.
+          By providing a phone number and agreeing to this disclosure, a user consents to receive SMS messages from CallbackCloser
+          related to callback coordination, customer support, service updates, and account or service notifications related to the
+          user&apos;s request.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="space-y-2">
-          <Label htmlFor="sms-consent-phone">Example mobile number field</Label>
-          <Input defaultValue="+1 555 123 4567" disabled id="sms-consent-phone" inputMode="tel" name="phone" type="tel" />
-          <p className="text-xs text-muted-foreground">Use a real phone field in your live signup or intake flow before recording consent.</p>
-        </div>
-
         <div className="rounded-lg border bg-muted/30 p-4">
           <div className="flex items-start gap-3 text-sm text-muted-foreground">
             <input
-              checked={false}
+              defaultChecked={false}
               className="mt-1 h-4 w-4 rounded border"
-              disabled
               id="sms-consent-checkbox"
               name="consent"
-              readOnly
               type="checkbox"
             />
             <span>
-              By checking this box, you agree to receive SMS messages from CallbackCloser related to customer care and account
-              notifications. Message frequency varies. Message and data rates may apply. Reply STOP to opt out or HELP for help. See our{' '}
+              I agree to receive SMS messages from CallbackCloser related to my request. Message frequency varies. Message &amp; data
+              rates may apply. Reply STOP to opt out or HELP for help. See our{' '}
               <Link className="underline underline-offset-4" href="/privacy">
                 Privacy Policy
               </Link>{' '}
@@ -44,14 +36,14 @@ export function PublicSmsConsentForm() {
               .
             </span>
           </div>
-          <p className="mt-3 text-xs text-muted-foreground">
-            In production, your real consent flow should require an unchecked checkbox and a phone number before submission.
-          </p>
+          <p className="mt-3 text-xs text-muted-foreground">Consent to receive SMS messages is not a condition of purchase.</p>
         </div>
 
         <div className="rounded-lg border bg-background/80 p-4 text-sm text-muted-foreground">
-          This public page is a compliance reference for buyers, carriers, and reviewers. It does not create a subscription, submit
-          consent, or capture any phone number data by itself.
+          Support contact:{' '}
+          <a className="underline underline-offset-4" href="mailto:support@callbackcloser.com">
+            support@callbackcloser.com
+          </a>
         </div>
       </CardContent>
     </Card>

--- a/components/public-sms-consent-form.tsx
+++ b/components/public-sms-consent-form.tsx
@@ -1,49 +1,73 @@
 import Link from 'next/link';
 
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 export function PublicSmsConsentForm() {
   return (
     <Card className="border-primary/20 bg-card/95">
       <CardHeader>
-        <CardTitle>Consent disclosure</CardTitle>
+        <CardTitle>Request SMS updates</CardTitle>
         <CardDescription>
-          By providing a phone number and agreeing to this disclosure, a user consents to receive SMS messages from CallbackCloser
-          related to callback coordination, customer support, service updates, and account or service notifications related to the
-          user&apos;s request.
+          Enter your phone number and confirm consent to receive service-related SMS messages from CallbackCloser.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="rounded-lg border bg-muted/30 p-4">
-          <div className="flex items-start gap-3 text-sm text-muted-foreground">
-            <input
-              defaultChecked={false}
-              className="mt-1 h-4 w-4 rounded border"
-              id="sms-consent-checkbox"
-              name="consent"
-              type="checkbox"
+        <form className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="sms-consent-phone">Phone number</Label>
+            <Input
+              autoComplete="tel"
+              id="sms-consent-phone"
+              inputMode="tel"
+              name="phone"
+              placeholder="(555) 123-4567"
+              type="tel"
             />
-            <span>
-              I agree to receive SMS messages from CallbackCloser related to my request. Message frequency varies. Message &amp; data
-              rates may apply. Reply STOP to opt out or HELP for help. See our{' '}
-              <Link className="underline underline-offset-4" href="/privacy">
-                Privacy Policy
-              </Link>{' '}
-              and{' '}
-              <Link className="underline underline-offset-4" href="/terms">
-                Terms &amp; Conditions
-              </Link>
-              .
-            </span>
           </div>
-          <p className="mt-3 text-xs text-muted-foreground">Consent to receive SMS messages is not a condition of purchase.</p>
-        </div>
+
+          <div className="rounded-lg border bg-muted/30 p-4">
+            <div className="flex items-start gap-3 text-sm text-muted-foreground">
+              <input
+                defaultChecked={false}
+                className="mt-1 h-4 w-4 rounded border"
+                id="sms-consent-checkbox"
+                name="consent"
+                type="checkbox"
+              />
+              <Label className="font-normal leading-6 text-muted-foreground" htmlFor="sms-consent-checkbox">
+                I agree to receive SMS messages from CallbackCloser related to my request. Message frequency varies. Message &amp;
+                data rates may apply. Reply STOP to opt out or HELP for help.
+              </Label>
+            </div>
+          </div>
+
+          <Button className="w-full sm:w-auto" type="button">
+            Continue
+          </Button>
+        </form>
 
         <div className="rounded-lg border bg-background/80 p-4 text-sm text-muted-foreground">
-          Support contact:{' '}
-          <a className="underline underline-offset-4" href="mailto:support@callbackcloser.com">
-            support@callbackcloser.com
-          </a>
+          <p>Consent to receive SMS messages is not a condition of purchase.</p>
+          <p className="mt-2">
+            Contact:{' '}
+            <a className="underline underline-offset-4" href="mailto:support@callbackcloser.com">
+              support@callbackcloser.com
+            </a>
+          </p>
+          <p className="mt-2">
+            Review our{' '}
+            <Link className="underline underline-offset-4" href="/privacy">
+              Privacy Policy
+            </Link>{' '}
+            and{' '}
+            <Link className="underline underline-offset-4" href="/terms">
+              Terms &amp; Conditions
+            </Link>
+            .
+          </p>
         </div>
       </CardContent>
     </Card>

--- a/lib/admin-dashboard.ts
+++ b/lib/admin-dashboard.ts
@@ -1,0 +1,429 @@
+import {
+  BusinessProvisioningStatus,
+  ManagedTwilioStatus,
+  OwnerNotificationStatus,
+  type Business,
+  type BusinessNotificationSettings,
+  type Call,
+  type Lead,
+  type Message,
+  type OwnerNotification,
+} from '@prisma/client';
+
+import { getManagedTextingNumber, getManagedTwilioStatusSummary } from '@/lib/managed-twilio-status';
+import { formatMessageStatus, isMessageDeliveryIssueStatus } from '@/lib/lead-presenters';
+
+type DashboardBusiness = Pick<
+  Business,
+  | 'id'
+  | 'name'
+  | 'ownerClerkId'
+  | 'ownerName'
+  | 'isTestBusiness'
+  | 'archivedAt'
+  | 'provisioningStatus'
+  | 'provisioningError'
+  | 'provisioningLastRunAt'
+  | 'forwardingNumber'
+  | 'notifyPhone'
+  | 'twilioSubaccountSid'
+  | 'twilioMessagingServiceSid'
+  | 'twilioPrimaryNumberSid'
+  | 'twilioPhoneNumberSid'
+  | 'twilioPrimaryPhoneNumber'
+  | 'twilioPhoneNumber'
+  | 'twilioWebhookSyncedAt'
+  | 'managedTwilioStatus'
+  | 'a2pCustomerProfileSid'
+  | 'a2pBrandSid'
+  | 'a2pCampaignSid'
+  | 'a2pFailureReason'
+  | 'a2pApprovedAt'
+  | 'subscriptionStatus'
+  | 'stripePriceId'
+  | 'updatedAt'
+>;
+
+type DashboardNotificationSettings = Pick<
+  BusinessNotificationSettings,
+  'ownerPhone' | 'ownerEmail' | 'notifySms' | 'notifyEmail' | 'notifyInApp' | 'urgentOnly'
+>;
+
+type EventMessage = Pick<Message, 'id' | 'leadId' | 'participant' | 'direction' | 'status' | 'body' | 'createdAt'>;
+type EventOwnerNotification = Pick<OwnerNotification, 'id' | 'channel' | 'status' | 'error' | 'createdAt' | 'destination'>;
+type EventLead = Pick<Lead, 'id' | 'status' | 'readiness' | 'billingRequired' | 'smsState' | 'summary' | 'createdAt' | 'lastInteractionAt'>;
+type EventCall = Pick<Call, 'id' | 'status' | 'missed' | 'answered' | 'dialCallStatus' | 'createdAt'>;
+
+export type AdminBoardFilter =
+  | 'all'
+  | 'needs_attention'
+  | 'pending_a2p'
+  | 'not_fully_provisioned'
+  | 'live'
+  | 'paused'
+  | 'archived';
+
+export type AdminBoardFilterOption = {
+  key: AdminBoardFilter;
+  label: string;
+};
+
+export type AdminNextStep = {
+  title: string;
+  detail: string;
+  tone: 'healthy' | 'pending' | 'attention' | 'paused';
+  actionLabel: string;
+};
+
+export type AdminBusinessEvent = {
+  id: string;
+  at: Date;
+  severity: 'info' | 'warning' | 'error';
+  label: string;
+  summary: string;
+  detail: string;
+};
+
+export const adminBoardFilterOptions: AdminBoardFilterOption[] = [
+  { key: 'all', label: 'All' },
+  { key: 'needs_attention', label: 'Needs attention' },
+  { key: 'pending_a2p', label: 'Pending A2P' },
+  { key: 'not_fully_provisioned', label: 'Not fully provisioned' },
+  { key: 'live', label: 'Live' },
+  { key: 'paused', label: 'Paused' },
+  { key: 'archived', label: 'Archived' },
+];
+
+const DEMO_OWNER_CLERK_ID = 'simulator_demo_callbackcloser';
+
+export function isBusinessArchived(business: Pick<DashboardBusiness, 'archivedAt'>) {
+  return Boolean(business.archivedAt);
+}
+
+export function isBusinessAutomationPaused(
+  business: Pick<DashboardBusiness, 'provisioningStatus' | 'archivedAt'>
+) {
+  return business.provisioningStatus === BusinessProvisioningStatus.PAUSED || isBusinessArchived(business);
+}
+
+export function canDeleteTestBusiness(
+  business: Pick<DashboardBusiness, 'isTestBusiness' | 'ownerClerkId' | 'archivedAt'>
+) {
+  return isBusinessArchived(business) && (business.isTestBusiness || business.ownerClerkId === DEMO_OWNER_CLERK_ID);
+}
+
+export function getBusinessLifecycleLabel(
+  business: Pick<DashboardBusiness, 'archivedAt' | 'provisioningStatus'>
+) {
+  if (isBusinessArchived(business)) return 'Archived';
+  if (business.provisioningStatus === BusinessProvisioningStatus.PAUSED) return 'Paused';
+  if (business.provisioningStatus === BusinessProvisioningStatus.LIVE) return 'Live';
+  return 'Active';
+}
+
+export function getBusinessCommercialPlanLabel(
+  business: Pick<DashboardBusiness, 'stripePriceId' | 'subscriptionStatus'>
+) {
+  if (business.stripePriceId) {
+    const compact = business.stripePriceId.replace(/^price_/, '');
+    return compact.length > 18 ? `${compact.slice(0, 18)}…` : compact;
+  }
+
+  return business.subscriptionStatus.toLowerCase();
+}
+
+export function buildAdminNextStep(params: {
+  business: DashboardBusiness;
+  notificationSettings: DashboardNotificationSettings | null;
+  ownerConnected: boolean;
+}): AdminNextStep {
+  const { business, notificationSettings, ownerConnected } = params;
+  const managedSummary = getManagedTwilioStatusSummary(business);
+  const ownerEmail = notificationSettings?.ownerEmail?.trim() || null;
+  const ownerPhone = notificationSettings?.ownerPhone?.trim() || business.notifyPhone || null;
+  const hasTextingNumber = Boolean(getManagedTextingNumber(business) && (business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid));
+
+  if (isBusinessArchived(business)) {
+    return {
+      title: 'Business archived',
+      detail: 'Automation is off and the workspace is hidden from normal triage. Restore it only if this customer should become active again.',
+      tone: 'paused',
+      actionLabel: 'Restore business',
+    };
+  }
+
+  if (business.provisioningStatus === BusinessProvisioningStatus.PAUSED) {
+    return {
+      title: 'Automation is paused',
+      detail: 'New missed calls are preserved, but automation should stay off until you resume this business.',
+      tone: 'paused',
+      actionLabel: 'Resume automation',
+    };
+  }
+
+  if (business.provisioningError) {
+    return {
+      title: 'Provisioning needs attention',
+      detail: business.provisioningError,
+      tone: 'attention',
+      actionLabel: hasTextingNumber ? 'Re-run provisioning' : 'Finish provisioning',
+    };
+  }
+
+  if (!ownerEmail && !ownerPhone) {
+    return {
+      title: 'Owner contact info is missing',
+      detail: 'Add the owner email or alert phone so CallbackCloser can route invites and alerts without manual digging.',
+      tone: 'attention',
+      actionLabel: 'Save owner contact info',
+    };
+  }
+
+  if (!ownerConnected) {
+    return {
+      title: 'Owner account still needs connection',
+      detail: ownerEmail
+        ? 'The business is saved, but the Clerk owner is not attached yet. Re-run the owner connection flow from admin.'
+        : 'Add the owner email first, then connect or invite the owner.',
+      tone: 'attention',
+      actionLabel: 'Connect owner',
+    };
+  }
+
+  if (!business.twilioSubaccountSid) {
+    return {
+      title: 'Twilio subaccount is missing',
+      detail: 'Managed provisioning cannot finish until the business has a Twilio subaccount attached.',
+      tone: 'attention',
+      actionLabel: 'Re-run provisioning',
+    };
+  }
+
+  if (!hasTextingNumber) {
+    return {
+      title: 'No texting number is assigned',
+      detail: 'Provision a new number or attach the approved existing number so missed-call SMS can start.',
+      tone: 'attention',
+      actionLabel: 'Provision number',
+    };
+  }
+
+  if (!business.twilioMessagingServiceSid) {
+    return {
+      title: 'Messaging service is missing',
+      detail: 'The business has a number, but Twilio messaging still needs a Messaging Service for compliant delivery.',
+      tone: 'attention',
+      actionLabel: 'Re-run provisioning',
+    };
+  }
+
+  if (!business.twilioWebhookSyncedAt) {
+    return {
+      title: 'Webhook sync is missing',
+      detail: 'The assigned number still needs the current voice, SMS, and status callback URLs synced from admin.',
+      tone: 'attention',
+      actionLabel: 'Re-sync webhooks',
+    };
+  }
+
+  if (business.managedTwilioStatus === ManagedTwilioStatus.AWAITING_BUSINESS_VERIFICATION) {
+    return {
+      title: 'Business verification still needed',
+      detail: 'Messaging is wired up, but the A2P business details still need to be completed before compliant live texting can launch.',
+      tone: 'pending',
+      actionLabel: 'Review A2P readiness',
+    };
+  }
+
+  if (business.managedTwilioStatus === ManagedTwilioStatus.BRAND_SUBMITTED) {
+    return {
+      title: 'A2P brand submitted',
+      detail: 'Brand review is in progress. No action is needed unless Twilio requests changes.',
+      tone: 'pending',
+      actionLabel: 'Watch for review updates',
+    };
+  }
+
+  if (business.managedTwilioStatus === ManagedTwilioStatus.CAMPAIGN_SUBMITTED) {
+    return {
+      title: 'A2P campaign still pending',
+      detail: 'The campaign is waiting on Twilio or carrier review. No action is needed yet.',
+      tone: 'pending',
+      actionLabel: 'Wait for approval',
+    };
+  }
+
+  if (managedSummary.attentionRequired) {
+    return {
+      title: 'Compliance review needs attention',
+      detail: business.a2pFailureReason || managedSummary.nextStep,
+      tone: 'attention',
+      actionLabel: 'Review compliance notes',
+    };
+  }
+
+  if (managedSummary.messagingReady && business.provisioningStatus !== BusinessProvisioningStatus.LIVE) {
+    return {
+      title: 'Ready to go live',
+      detail: 'Infrastructure and compliance look ready. Mark the business live when you want automation active.',
+      tone: 'pending',
+      actionLabel: 'Mark live',
+    };
+  }
+
+  if (managedSummary.messagingReady && business.provisioningStatus === BusinessProvisioningStatus.LIVE) {
+    return {
+      title: 'Business is live and healthy',
+      detail: 'Twilio, webhooks, alerts, and rollout status all look ready for normal operator monitoring.',
+      tone: 'healthy',
+      actionLabel: 'Open support workspace',
+    };
+  }
+
+  return {
+    title: 'Finish onboarding',
+    detail: managedSummary.nextStep,
+    tone: 'pending',
+    actionLabel: 'Review provisioning health',
+  };
+}
+
+export function matchesAdminBoardFilter(
+  business: DashboardBusiness,
+  notificationSettings: DashboardNotificationSettings | null,
+  ownerConnected: boolean,
+  filter: AdminBoardFilter
+) {
+  if (filter === 'all') return true;
+
+  const managedSummary = getManagedTwilioStatusSummary(business);
+  const nextStep = buildAdminNextStep({ business, notificationSettings, ownerConnected });
+  const archived = isBusinessArchived(business);
+  const paused = isBusinessAutomationPaused(business) && !archived;
+
+  if (filter === 'archived') return archived;
+  if (archived) return false;
+
+  if (filter === 'paused') {
+    return paused || business.managedTwilioStatus === ManagedTwilioStatus.PAUSED_NONCOMPLIANT;
+  }
+
+  if (filter === 'live') {
+    return business.provisioningStatus === BusinessProvisioningStatus.LIVE && managedSummary.messagingReady;
+  }
+
+  if (filter === 'pending_a2p') {
+    return (
+      business.managedTwilioStatus === ManagedTwilioStatus.AWAITING_BUSINESS_VERIFICATION ||
+      business.managedTwilioStatus === ManagedTwilioStatus.BRAND_SUBMITTED ||
+      business.managedTwilioStatus === ManagedTwilioStatus.CAMPAIGN_SUBMITTED
+    );
+  }
+
+  if (filter === 'not_fully_provisioned') {
+    return !managedSummary.onboardingReady || !ownerConnected;
+  }
+
+  if (filter === 'needs_attention') {
+    return nextStep.tone === 'attention';
+  }
+
+  return true;
+}
+
+function compactBody(value: string, maxLength = 120) {
+  const trimmed = value.trim();
+  if (!trimmed) return 'No extra detail recorded.';
+  if (trimmed.length <= maxLength) return trimmed;
+  return `${trimmed.slice(0, maxLength - 1)}…`;
+}
+
+export function buildAdminBusinessEvents(params: {
+  business: DashboardBusiness;
+  messages: EventMessage[];
+  ownerNotifications: EventOwnerNotification[];
+  leads: EventLead[];
+  calls: EventCall[];
+}) {
+  const events: AdminBusinessEvent[] = [];
+
+  if (params.business.provisioningLastRunAt) {
+    events.push({
+      id: 'provisioning-run',
+      at: params.business.provisioningLastRunAt,
+      severity: params.business.provisioningError ? 'error' : 'info',
+      label: 'Provisioning',
+      summary: params.business.provisioningError ? 'Latest provisioning run failed' : 'Latest provisioning run completed',
+      detail: params.business.provisioningError || 'The most recent admin provisioning run completed without a stored error.',
+    });
+  }
+
+  if (getManagedTextingNumber(params.business) && !params.business.twilioWebhookSyncedAt) {
+    events.push({
+      id: 'webhook-sync-missing',
+      at: params.business.updatedAt,
+      severity: 'warning',
+      label: 'Webhook sync',
+      summary: 'Assigned number still needs webhook sync',
+      detail: 'The business has a number assigned, but admin has not recorded a webhook sync yet.',
+    });
+  }
+
+  for (const notification of params.ownerNotifications) {
+    const severity =
+      notification.status === OwnerNotificationStatus.FAILED
+        ? 'error'
+        : notification.status === OwnerNotificationStatus.SKIPPED
+          ? 'warning'
+          : 'info';
+    events.push({
+      id: `notification-${notification.id}`,
+      at: notification.createdAt,
+      severity,
+      label: `Owner ${notification.channel.toLowerCase()} alert`,
+      summary:
+        notification.status === OwnerNotificationStatus.FAILED
+          ? 'Owner alert failed'
+          : notification.status === OwnerNotificationStatus.SKIPPED
+            ? 'Owner alert skipped'
+            : 'Owner alert sent',
+      detail: notification.error || notification.destination || 'Owner notification recorded.',
+    });
+  }
+
+  for (const message of params.messages) {
+    const issue = isMessageDeliveryIssueStatus(message.status);
+    events.push({
+      id: `message-${message.id}`,
+      at: message.createdAt,
+      severity: issue ? 'error' : 'info',
+      label: message.participant === 'OWNER' ? 'Owner SMS' : 'Lead SMS',
+      summary: `${message.direction === 'OUTBOUND' ? 'Outbound' : 'Inbound'} message${message.status ? ` · ${formatMessageStatus(message.status)}` : ''}`,
+      detail: compactBody(message.body),
+    });
+  }
+
+  for (const lead of params.leads) {
+    events.push({
+      id: `lead-${lead.id}`,
+      at: lead.lastInteractionAt || lead.createdAt,
+      severity: lead.billingRequired ? 'warning' : 'info',
+      label: 'Lead activity',
+      summary: `${lead.status.toLowerCase()} lead · ${lead.readiness.toLowerCase()}`,
+      detail: lead.summary || `SMS state: ${lead.smsState.toLowerCase().replace(/_/g, ' ')}.`,
+    });
+  }
+
+  for (const call of params.calls) {
+    events.push({
+      id: `call-${call.id}`,
+      at: call.createdAt,
+      severity: call.missed ? 'warning' : 'info',
+      label: 'Call event',
+      summary: call.missed ? 'Missed call captured' : call.answered ? 'Answered call recorded' : 'Call status recorded',
+      detail: call.dialCallStatus || call.status,
+    });
+  }
+
+  return events.sort((left, right) => right.at.getTime() - left.at.getTime());
+}

--- a/lib/lead-presenters.ts
+++ b/lib/lead-presenters.ts
@@ -88,6 +88,17 @@ export function getLeadStatusBadgeVariant(status: LeadStatus) {
   return 'secondary';
 }
 
+export function isLeadOpenStatus(status: LeadStatus) {
+  return status !== LeadStatus.BOOKED && status !== LeadStatus.LOST;
+}
+
+export function getLeadNextStepLabel(status: LeadStatus) {
+  if (status === LeadStatus.BOOKED) return 'Booked';
+  if (status === LeadStatus.LOST) return 'Closed lost';
+  if (status === LeadStatus.CONTACTED) return 'Follow up again';
+  return 'Needs follow-up';
+}
+
 type LeadActivityInput = Pick<Lead, 'createdAt' | 'lastInteractionAt' | 'lastInboundAt' | 'lastOutboundAt'>;
 
 export function getLeadLastActivityAt(lead: LeadActivityInput) {

--- a/lib/missed-call-flow.ts
+++ b/lib/missed-call-flow.ts
@@ -1,5 +1,6 @@
 import { LeadStatus, SmsConversationState, type Business, type Lead } from '@prisma/client';
 
+import { isBusinessAutomationPaused } from '@/lib/admin-dashboard';
 import { db } from '@/lib/db';
 import { buildLeadSummary, getLeadReadiness, getQualifiedLeadStatus, isLeadQualified } from '@/lib/lead-qualification';
 import { notifyQualifiedLeadIfNeeded } from '@/lib/owner-notifications';
@@ -21,6 +22,8 @@ type LeadFlowBusiness = Pick<
   | 'managedTwilioStatus'
   | 'a2pFailureReason'
   | 'subscriptionStatus'
+  | 'provisioningStatus'
+  | 'archivedAt'
   | 'serviceLabel1'
   | 'serviceLabel2'
   | 'serviceLabel3'
@@ -147,6 +150,14 @@ export async function startMissedCallRecovery(params: StartRecoveryParams) {
     });
   }
 
+  if (isBusinessAutomationPaused(params.business)) {
+    return {
+      lead,
+      started: false as const,
+      reason: 'automation_paused' as const,
+    };
+  }
+
   const fromPhone = getBusinessTextingNumber(params.business);
   if (!fromPhone || lead.smsStartedAt || (!params.forceAutomation && lead.billingRequired)) {
     return {
@@ -255,7 +266,7 @@ export async function processLeadInboundReply(params: ProcessReplyParams) {
   }
 
   const fromPhone = getBusinessTextingNumber(params.business);
-  if (!fromPhone) {
+  if (!fromPhone || isBusinessAutomationPaused(params.business)) {
     return { lead: updatedLead, transition, duplicate: false as const, notificationResult };
   }
 

--- a/lib/owner-notifications.ts
+++ b/lib/owner-notifications.ts
@@ -1,6 +1,7 @@
 import { LeadReadiness, LeadStatus, OwnerNotificationChannel, OwnerNotificationStatus, type Business, type Lead } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 
+import { isBusinessAutomationPaused } from '@/lib/admin-dashboard';
 import { getEffectiveBusinessNotificationSettings } from '@/lib/business-notification-settings';
 import { db } from '@/lib/db';
 import { sendTransactionalEmail } from '@/lib/email';
@@ -137,6 +138,8 @@ async function getLeadForOwnerNotifications(leadId: string) {
           twilioPhoneNumber: true,
           managedTwilioStatus: true,
           a2pFailureReason: true,
+          provisioningStatus: true,
+          archivedAt: true,
         },
       },
     },
@@ -310,6 +313,9 @@ export async function notifyQualifiedLeadIfNeeded(leadId: string) {
   if (!lead) return { notified: false, reason: 'lead_not_found' as const };
   if (!isLeadQualified(lead)) return { notified: false, reason: 'lead_not_qualified' as const };
   if (lead.notifiedAt) return { notified: false, reason: 'already_notified' as const };
+  if (isBusinessAutomationPaused(lead.business)) {
+    return { notified: false, reason: 'business_paused' as const };
+  }
 
   const settings = await getEffectiveBusinessNotificationSettings(lead.business);
   if (settings.urgentOnly && lead.readiness !== LeadReadiness.URGENT) {

--- a/lib/portfolio-demo.ts
+++ b/lib/portfolio-demo.ts
@@ -35,6 +35,8 @@ const demoBusiness: Business = {
   ownerClerkId: DEMO_USER_ID,
   name: 'Northside HVAC & Plumbing (Demo)',
   ownerName: 'Jordan Smith',
+  isTestBusiness: false,
+  archivedAt: null,
   forwardingNumber: '+15125550111',
   notifyPhone: '+15125550199',
   provisioningStatus: BusinessProvisioningStatus.LIVE,

--- a/lib/simulator.ts
+++ b/lib/simulator.ts
@@ -52,6 +52,8 @@ export async function getSimulatorBusiness() {
       managedTwilioStatus: true,
       a2pFailureReason: true,
       subscriptionStatus: true,
+      provisioningStatus: true,
+      archivedAt: true,
       serviceLabel1: true,
       serviceLabel2: true,
       serviceLabel3: true,
@@ -84,6 +86,8 @@ export async function getSimulatorRun(publicId: string) {
           twilioPrimaryPhoneNumber: true,
           managedTwilioStatus: true,
           a2pFailureReason: true,
+          provisioningStatus: true,
+          archivedAt: true,
           serviceLabel1: true,
           serviceLabel2: true,
           serviceLabel3: true,
@@ -105,6 +109,8 @@ export type SimulatorRunRecord = SimulatorRun & {
     | 'twilioPrimaryPhoneNumber'
     | 'managedTwilioStatus'
     | 'a2pFailureReason'
+    | 'provisioningStatus'
+    | 'archivedAt'
     | 'serviceLabel1'
     | 'serviceLabel2'
     | 'serviceLabel3'

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -42,6 +42,7 @@ export const adminBusinessDraftSchema = z.object({
   ownerName: z.string().trim().max(120).optional().or(z.literal('')),
   ownerEmail: z.string().trim().email(),
   ownerPhone: z.string().max(30).optional().or(z.literal('')),
+  isTestBusiness: z.coerce.boolean().optional().default(false),
   forwardingNumber: z.string().min(7).max(30),
   timezone: z.string().min(2).max(100).default('America/New_York'),
   missedCallSeconds: z.coerce.number().int().min(5).max(90).default(20),
@@ -122,6 +123,21 @@ export const adminWebhookSyncSchema = z.object({
 export const adminProvisioningStatusSchema = z.object({
   businessId: z.string().min(1),
   status: z.enum(['DRAFT', 'ONBOARDING', 'NEEDS_ATTENTION', 'LIVE', 'PAUSED']),
+});
+
+export const adminSendTestSmsSchema = z.object({
+  businessId: z.string().min(1),
+  destinationPhone: z.string().trim().min(7).max(30),
+});
+
+export const adminArchiveBusinessSchema = z.object({
+  businessId: z.string().min(1),
+  confirmationName: z.string().trim().min(1),
+});
+
+export const adminDeleteBusinessSchema = z.object({
+  businessId: z.string().min(1),
+  confirmationName: z.string().trim().min(1),
 });
 
 export const businessTwilioAdminOverrideSchema = z.object({

--- a/prisma/migrations/20260417173000_add_admin_business_lifecycle_flags/migration.sql
+++ b/prisma/migrations/20260417173000_add_admin_business_lifecycle_flags/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "Business"
+ADD COLUMN "archivedAt" TIMESTAMP(3),
+ADD COLUMN "isTestBusiness" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE INDEX "Business_archivedAt_idx" ON "Business"("archivedAt");
+
+-- CreateIndex
+CREATE INDEX "Business_isTestBusiness_idx" ON "Business"("isTestBusiness");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,8 @@ model Business {
   ownerClerkId                String             @unique
   name                        String
   ownerName                   String?
+  isTestBusiness              Boolean            @default(false)
+  archivedAt                  DateTime?
   forwardingNumber            String
   notifyPhone                 String?
   provisioningStatus          BusinessProvisioningStatus @default(DRAFT)
@@ -58,6 +60,8 @@ model Business {
   smsConsents                 SmsConsent[]
 
   @@index([subscriptionStatus])
+  @@index([archivedAt])
+  @@index([isTestBusiness])
 }
 
 model Call {

--- a/tests/admin-dashboard.test.ts
+++ b/tests/admin-dashboard.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { BusinessProvisioningStatus, ManagedTwilioStatus, SubscriptionStatus } from '@prisma/client';
+
+import {
+  buildAdminBusinessEvents,
+  buildAdminNextStep,
+  canDeleteTestBusiness,
+  matchesAdminBoardFilter,
+} from '../lib/admin-dashboard.ts';
+
+function createBusiness(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'biz_123',
+    name: 'Acme Plumbing',
+    ownerClerkId: 'user_123',
+    ownerName: 'Casey Owner',
+    isTestBusiness: false,
+    archivedAt: null,
+    forwardingNumber: '+15557654321',
+    notifyPhone: '+15551234567',
+    provisioningStatus: BusinessProvisioningStatus.ONBOARDING,
+    provisioningLastRunAt: new Date('2026-04-15T00:00:00.000Z'),
+    provisioningError: null,
+    twilioSubaccountSid: 'AC_TEST_SUBACCOUNT',
+    twilioMessagingServiceSid: 'MG_TEST_SERVICE',
+    twilioPrimaryNumberSid: 'PN_TEST_PRIMARY',
+    twilioPhoneNumberSid: 'PN_TEST_PRIMARY',
+    twilioPrimaryPhoneNumber: '+15550001111',
+    twilioPhoneNumber: '+15550001111',
+    twilioWebhookSyncedAt: new Date('2026-04-15T00:00:00.000Z'),
+    managedTwilioStatus: ManagedTwilioStatus.CAMPAIGN_SUBMITTED,
+    a2pCustomerProfileSid: 'BU_TEST_PROFILE',
+    a2pBrandSid: 'BN_TEST_BRAND',
+    a2pCampaignSid: 'QE_TEST_CAMPAIGN',
+    a2pFailureReason: null,
+    a2pApprovedAt: null,
+    subscriptionStatus: SubscriptionStatus.ACTIVE,
+    stripePriceId: 'price_callbackcloser_pro',
+    updatedAt: new Date('2026-04-15T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createNotificationSettings(overrides: Record<string, unknown> = {}) {
+  return {
+    ownerPhone: '+15551234567',
+    ownerEmail: 'owner@example.com',
+    notifySms: true,
+    notifyEmail: true,
+    notifyInApp: true,
+    urgentOnly: false,
+    ...overrides,
+  };
+}
+
+test('next-step guidance calls out webhook recovery and live health clearly', () => {
+  const webhookMissing = buildAdminNextStep({
+    business: createBusiness({ twilioWebhookSyncedAt: null, managedTwilioStatus: ManagedTwilioStatus.AWAITING_BUSINESS_VERIFICATION }),
+    notificationSettings: createNotificationSettings(),
+    ownerConnected: true,
+  });
+
+  assert.equal(webhookMissing.title, 'Webhook sync is missing');
+  assert.match(webhookMissing.detail, /status callback URLs/i);
+
+  const healthy = buildAdminNextStep({
+    business: createBusiness({
+      provisioningStatus: BusinessProvisioningStatus.LIVE,
+      managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+      a2pApprovedAt: new Date('2026-04-15T00:00:00.000Z'),
+    }),
+    notificationSettings: createNotificationSettings(),
+    ownerConnected: true,
+  });
+
+  assert.equal(healthy.title, 'Business is live and healthy');
+  assert.equal(healthy.tone, 'healthy');
+});
+
+test('board filters and delete guard stay conservative', () => {
+  const pausedTestBusiness = createBusiness({
+    isTestBusiness: true,
+    archivedAt: new Date('2026-04-16T00:00:00.000Z'),
+    provisioningStatus: BusinessProvisioningStatus.PAUSED,
+  });
+
+  assert.equal(canDeleteTestBusiness(pausedTestBusiness), true);
+  assert.equal(
+    matchesAdminBoardFilter(pausedTestBusiness, createNotificationSettings(), true, 'archived'),
+    true
+  );
+  assert.equal(
+    matchesAdminBoardFilter(createBusiness(), createNotificationSettings(), true, 'pending_a2p'),
+    true
+  );
+  assert.equal(
+    canDeleteTestBusiness(createBusiness({ isTestBusiness: false, archivedAt: new Date('2026-04-16T00:00:00.000Z') })),
+    false
+  );
+});
+
+test('recent event synthesis prioritizes provisioning failures and owner alert failures', () => {
+  const events = buildAdminBusinessEvents({
+    business: createBusiness({
+      provisioningError: 'Messaging service missing after attach.',
+      provisioningLastRunAt: new Date('2026-04-17T10:00:00.000Z'),
+      twilioWebhookSyncedAt: null,
+    }),
+    messages: [
+      {
+        id: 'msg_1',
+        leadId: 'lead_1',
+        participant: 'LEAD',
+        direction: 'OUTBOUND',
+        status: 'failed',
+        body: 'CallbackCloser: We missed your call.',
+        createdAt: new Date('2026-04-17T09:58:00.000Z'),
+      },
+    ],
+    ownerNotifications: [
+      {
+        id: 'notify_1',
+        channel: 'SMS',
+        status: 'FAILED',
+        error: 'Owner SMS failed',
+        createdAt: new Date('2026-04-17T09:59:00.000Z'),
+        destination: '+15551234567',
+      },
+    ],
+    leads: [],
+    calls: [],
+  });
+
+  assert.equal(events[0]?.label, 'Provisioning');
+  assert.equal(events.some((event) => event.label === 'Owner sms alert' && event.severity === 'error'), true);
+  assert.equal(events.some((event) => event.label === 'Lead SMS' && event.severity === 'error'), true);
+});

--- a/tests/admin-operator-routes.test.ts
+++ b/tests/admin-operator-routes.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+function read(path: string) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+test('admin routes expose support workspace and safe lifecycle controls', () => {
+  const adminHome = read('app/admin/page.tsx');
+  const adminDetail = read('app/admin/[businessId]/page.tsx');
+  const supportWorkspace = read('app/admin/[businessId]/workspace/page.tsx');
+
+  assert.match(adminHome, /Operator triage board/);
+  assert.match(adminHome, /Open support workspace/);
+  assert.match(adminDetail, /What should I do next\?/);
+  assert.match(adminDetail, /Archive \/ delete controls/);
+  assert.match(adminDetail, /Send test SMS/);
+  assert.match(supportWorkspace, /support workspace/);
+  assert.match(supportWorkspace, /Read-only snapshot/);
+});

--- a/tests/leads-workspace-routing.test.ts
+++ b/tests/leads-workspace-routing.test.ts
@@ -8,24 +8,34 @@ function read(relativePath: string) {
 }
 
 test('lead inbox stays list-only while lead detail is the main action workspace', () => {
+  const appHomePage = read('app/app/page.tsx');
   const leadsPage = read('app/app/leads/page.tsx');
   const leadDetailPage = read('app/app/leads/[leadId]/page.tsx');
   const conversationsPage = read('app/app/conversations/page.tsx');
 
+  assert.match(appHomePage, /Who needs follow-up right now\?/);
+  assert.match(appHomePage, /Leads needing attention first/);
+  assert.match(appHomePage, /Recent leads/);
+  assert.match(appHomePage, /Missed calls today/);
+  assert.match(appHomePage, /return `\/app\/leads\/\$\{leadId\}\?from=%2Fapp`/);
+
   assert.match(leadsPage, /Lead inbox/);
-  assert.match(leadsPage, /Click a lead to open the full action screen/i);
-  assert.match(leadsPage, /buildLeadDetailHref/);
+  assert.match(leadsPage, /This page is only for scanning/i);
+  assert.match(leadsPage, /Needs follow-up/);
   assert.doesNotMatch(leadsPage, /selectedLeadId/);
   assert.doesNotMatch(leadsPage, /Lead detail panel/);
   assert.doesNotMatch(leadsPage, /Quick actions/);
+  assert.doesNotMatch(leadsPage, /Open Conversations/);
 
-  assert.match(leadDetailPage, /Lead workspace/);
-  assert.match(leadDetailPage, /Call Now/);
-  assert.match(leadDetailPage, /Mark Contacted/);
-  assert.match(leadDetailPage, /Mark Booked/);
-  assert.match(leadDetailPage, /Mark Lost/);
+  assert.match(leadDetailPage, /Lead details/);
+  assert.match(leadDetailPage, /Call now/);
+  assert.match(leadDetailPage, /Mark contacted/);
+  assert.match(leadDetailPage, /Mark booked/);
+  assert.match(leadDetailPage, /Mark lost/);
   assert.match(leadDetailPage, /Conversation history/);
+  assert.match(leadDetailPage, /Qualification info/);
   assert.match(leadDetailPage, /Missed call details/);
 
   assert.match(conversationsPage, /href=\{`\/app\/leads\/\$\{selectedLead\.id\}\?from=%2Fapp%2Fconversations`\}/);
+  assert.match(conversationsPage, /Open lead details/);
 });

--- a/tests/legal-pages.test.ts
+++ b/tests/legal-pages.test.ts
@@ -46,10 +46,17 @@ test('sms consent page includes required disclosures and trust links', () => {
     smsConsentForm,
     /I agree to receive SMS messages from CallbackCloser related to my request\./
   );
+  assert.match(smsConsentForm, /htmlFor="sms-consent-phone"/);
+  assert.match(smsConsentForm, /name="phone"/);
+  assert.match(smsConsentForm, /type="tel"/);
   assert.match(smsConsentForm, /defaultChecked=\{false\}/);
+  assert.match(smsConsentForm, /Continue/);
   assert.match(smsConsentForm, /Consent to receive SMS messages is not a condition of purchase/i);
-  assert.doesNotMatch(smsConsent, /visual-only|Twilio review only|pilot reference|demo|public compliance reference/i);
-  assert.doesNotMatch(smsConsentForm, /does not submit or store phone numbers|compliance reference|buyers, carriers, and reviewers/i);
+  assert.doesNotMatch(smsConsent, /visual-only|Twilio review only|pilot reference|demo|public compliance reference|consent is recorded elsewhere/i);
+  assert.doesNotMatch(
+    smsConsentForm,
+    /consent language reference|does not submit or store phone numbers|compliance reference|buyers, carriers, and reviewers|use a real phone field|in production, your real consent flow should/i
+  );
   assert.match(privacy, /does not sell mobile numbers/i);
   assert.match(privacy, /callback coordination/i);
   assert.match(terms, /SMS Consent/);

--- a/tests/legal-pages.test.ts
+++ b/tests/legal-pages.test.ts
@@ -30,25 +30,30 @@ test('sms consent page includes required disclosures and trust links', () => {
   const terms = read('app/terms/page.tsx');
   const contact = read('app/contact/page.tsx');
 
-  assert.match(smsConsent, /missed call follow-up/i);
-  assert.match(smsConsent, /customer care/i);
+  assert.match(smsConsent, /respond to customer inquiries/i);
+  assert.match(smsConsent, /callback coordination/i);
+  assert.match(smsConsent, /customer support/i);
   assert.match(smsConsent, /service updates/i);
-  assert.match(smsConsent, /account notifications/i);
+  assert.match(smsConsent, /account or service notifications/i);
+  assert.match(smsConsent, /Consent to receive SMS messages is not a condition of purchase/i);
   assert.match(smsConsent, /Message and data rates may apply/i);
   assert.match(smsConsent, /Reply STOP/i);
   assert.match(smsConsent, /HELP/i);
+  assert.match(smsConsent, /support@callbackcloser\.com/i);
   assert.match(smsConsent, /href="\/privacy"/);
   assert.match(smsConsent, /href="\/terms"/);
-  assert.match(smsConsent, /href="\/contact"/);
   assert.match(
     smsConsentForm,
-    /By checking this box, you agree to receive SMS messages from CallbackCloser related to customer care and account[\s\S]*notifications\./
+    /I agree to receive SMS messages from CallbackCloser related to my request\./
   );
-  assert.match(smsConsentForm, /does not submit or store phone numbers/i);
-  assert.match(smsConsentForm, /compliance reference/i);
-  assert.match(smsConsent, /records consent inside the actual signup, intake, or customer[\s\S]*messaging flow/i);
+  assert.match(smsConsentForm, /defaultChecked=\{false\}/);
+  assert.match(smsConsentForm, /Consent to receive SMS messages is not a condition of purchase/i);
+  assert.doesNotMatch(smsConsent, /visual-only|Twilio review only|pilot reference|demo|public compliance reference/i);
+  assert.doesNotMatch(smsConsentForm, /does not submit or store phone numbers|compliance reference|buyers, carriers, and reviewers/i);
   assert.match(privacy, /does not sell mobile numbers/i);
+  assert.match(privacy, /callback coordination/i);
   assert.match(terms, /SMS Consent/);
+  assert.match(terms, /callback coordination/i);
   assert.match(contact, /support@callbackcloser\.com/);
 });
 

--- a/tests/tenant-isolation-wiring.test.ts
+++ b/tests/tenant-isolation-wiring.test.ts
@@ -9,6 +9,7 @@ function read(relativePath: string) {
 
 test('protected app surfaces use shared tenant-scoped access helpers', () => {
   const auth = read('lib/auth.ts');
+  const appHomePage = read('app/app/page.tsx');
   const leadsPage = read('app/app/leads/page.tsx');
   const leadDetailPage = read('app/app/leads/[leadId]/page.tsx');
   const conversationsPage = read('app/app/conversations/page.tsx');
@@ -19,7 +20,8 @@ test('protected app surfaces use shared tenant-scoped access helpers', () => {
   const recordingRoute = read('app/api/leads/[leadId]/recording/route.ts');
 
   assert.match(auth, /getBusinessForOwnerClerkId/);
-  assert.match(leadsPage, /listDashboardLeadsForBusiness/);
+  assert.match(appHomePage, /requireBusiness/);
+  assert.match(appHomePage, /listAllDashboardLeadsForBusiness/);
   assert.match(leadsPage, /listAllDashboardLeadsForBusiness/);
   assert.match(leadsPage, /buildLeadDetailHref/);
   assert.doesNotMatch(leadsPage, /selectedLeadId/);


### PR DESCRIPTION
## Summary
- replace the redirect-only customer `/app` landing page with a simple command center focused on who needs follow-up now
- tighten `/app/leads` into a cleaner inbox list with lighter filters and direct single-lead navigation
- make `/app/leads/[leadId]` more obviously action-first with primary actions at the top and support context below
- simplify customer nav labels and align conversation links with the new detail-page language
- update routing and tenant-safety tests around the new customer flow

## Root cause
The customer-facing experience had the right underlying data and scoping, but the product still made owners work too hard to understand where to go next. The protected home page was only a redirect, the lead inbox still carried extra setup-oriented clutter, and the single-lead page was not visually dominant enough as the main action screen.

## User impact
Business owners now land on a calmer home page that immediately highlights open work, scan a simpler inbox page for leads, and move straight into one obvious lead detail page for action.

## Validation
- `npm install`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`
