### PR TITLE
Add operator timeline and onboarding confidence

### DIFF
--- a/app/admin/[businessId]/page.tsx
+++ b/app/admin/[businessId]/page.tsx
@@ -13,11 +13,11 @@ import {
   setBusinessProvisioningStatusAction,
 } from '@/app/admin/actions';
 import {
-  buildAdminBusinessEvents,
-  buildAdminNextStep,
+  buildAdminOnboardingConfidence,
   canDeleteTestBusiness,
   isBusinessArchived,
 } from '@/lib/admin-dashboard';
+import { CopyValueButton } from '@/components/copy-value-button';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -45,6 +45,14 @@ import {
   leadStatusLabels,
 } from '@/lib/lead-presenters';
 import { getManagedTextingNumber, getManagedTwilioStatusSummary, managedTwilioStatusLabels } from '@/lib/managed-twilio-status';
+import {
+  businessTimelineFilterOptions,
+  countTimelineFilters,
+  matchesTimelineFilter,
+  operatorEventCategoryLabels,
+  operatorEventStatusLabels,
+  type BusinessTimelineFilter,
+} from '@/lib/operator-events';
 import { formatPhoneForDisplay } from '@/lib/phone';
 import { getBusinessBillingAccessState } from '@/lib/subscription';
 import { getAdminBusinessStatus, getCustomerSystemStatus } from '@/lib/system-status';
@@ -129,11 +137,52 @@ function getQueryValue(searchParams: Record<string, string | string[] | undefine
   return typeof value === 'string' ? value : null;
 }
 
-function getNextStepBadgeVariant(tone: 'healthy' | 'pending' | 'attention' | 'paused') {
-  if (tone === 'healthy') return 'success' as const;
-  if (tone === 'attention') return 'destructive' as const;
-  if (tone === 'paused') return 'outline' as const;
+function getTimelineFilter(searchParams: Record<string, string | string[] | undefined> | undefined): BusinessTimelineFilter {
+  const value = getQueryValue(searchParams, 'activity');
+  return businessTimelineFilterOptions.some((option) => option.key === value) ? (value as BusinessTimelineFilter) : 'all';
+}
+
+function getOperatorEventBadgeVariant(status: keyof typeof operatorEventStatusLabels) {
+  if (status === 'FAILED') return 'destructive' as const;
+  if (status === 'WARNING') return 'outline' as const;
+  if (status === 'SUCCESS') return 'success' as const;
   return 'secondary' as const;
+}
+
+function getConfidenceMilestoneBadgeVariant(variant: 'success' | 'warning' | 'pending') {
+  if (variant === 'success') return 'success' as const;
+  if (variant === 'warning') return 'outline' as const;
+  return 'secondary' as const;
+}
+
+function formatOperatorEventDetailValue(value: unknown): string {
+  if (value === null || value === undefined) return '-';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) return value.map((item) => formatOperatorEventDetailValue(item)).join(', ');
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([key, nested]) => `${key}: ${formatOperatorEventDetailValue(nested)}`)
+      .join(' | ');
+  }
+  return String(value);
+}
+
+function getOperatorEventDetails(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return [];
+  return Object.entries(value as Record<string, unknown>).map(([key, detail]) => ({
+    key,
+    label: key.replace(/([A-Z])/g, ' $1').replace(/_/g, ' '),
+    value: formatOperatorEventDetailValue(detail),
+  }));
+}
+
+function buildOperatorEventRelatedHref(businessId: string, relatedEntityType: string | null, relatedEntityId: string | null) {
+  if (!relatedEntityType || !relatedEntityId) return null;
+  if (relatedEntityType === 'lead') return `/admin/${businessId}/workspace#recent-leads`;
+  if (relatedEntityType === 'message') return `/admin/${businessId}/workspace#recent-activity`;
+  if (relatedEntityType === 'call') return `/admin/${businessId}/workspace#call-flow-snapshot`;
+  return null;
 }
 
 function HiddenAdminBusinessFields({
@@ -240,8 +289,9 @@ export default async function AdminBusinessDetailPage({
   searchParams?: Record<string, string | string[] | undefined>;
 }) {
   await requireAdmin();
+  const activityFilter = getTimelineFilter(searchParams);
 
-  const [business, successfulLeadCount, leadCount, callCount, messageCount, recentLeads, recentCalls, recentMessages, recentOwnerNotifications] =
+  const [business, successfulLeadCount, leadCount, callCount, messageCount, recentLeads, recentCalls, recentMessages, recentOwnerNotifications, operatorEvents] =
     await Promise.all([
       db.business.findUnique({
         where: { id: params.businessId },
@@ -315,6 +365,22 @@ export default async function AdminBusinessDetailPage({
           destination: true,
         },
       }),
+      db.businessOperatorEvent.findMany({
+        where: { businessId: params.businessId },
+        orderBy: { createdAt: 'desc' },
+        take: 120,
+        select: {
+          id: true,
+          type: true,
+          category: true,
+          status: true,
+          summary: true,
+          detailsJson: true,
+          relatedEntityType: true,
+          relatedEntityId: true,
+          createdAt: true,
+        },
+      }),
     ]);
 
   if (!business) notFound();
@@ -335,22 +401,23 @@ export default async function AdminBusinessDetailPage({
     ownerConnected: ownerState.connected,
     webhookSnapshot,
   });
-  const nextStep = buildAdminNextStep({
+  const onboardingConfidence = buildAdminOnboardingConfidence({
     business,
     notificationSettings: business.notificationSettings,
     ownerConnected: ownerState.connected,
+    successfulLeadCount,
+    operatorEvents: operatorEvents.map((event) => ({
+      type: event.type,
+      status: event.status,
+      createdAt: event.createdAt,
+    })),
   });
-  const recentEvents = buildAdminBusinessEvents({
-    business,
-    messages: recentMessages,
-    ownerNotifications: recentOwnerNotifications,
-    leads: recentLeads,
-    calls: recentCalls,
-  }).slice(0, 8);
+  const timelineFilterCounts = countTimelineFilters(operatorEvents);
+  const visibleTimelineEvents = operatorEvents.filter((event) => {
+    return matchesTimelineFilter(event, activityFilter);
+  });
   const assignedNumber = getManagedTextingNumber(business);
   const defaults = buildAdminFormDefaults(business);
-  const pendingChecklist = checklist.filter((item) => !item.complete);
-  const completedChecklistCount = checklist.filter((item) => item.complete).length;
   const webhooksNeedAttention = Boolean(
     assignedNumber &&
       (!business.twilioWebhookSyncedAt ||
@@ -372,17 +439,22 @@ export default async function AdminBusinessDetailPage({
         ? 'Needs attention'
         : 'Pending'
     : 'Not started';
-  const latestProvisioningEvent = recentEvents.find((event) => event.label === 'Provisioning') || null;
+  const latestProvisioningEvent = operatorEvents.find((event) => event.category === 'PROVISIONING') || null;
   const latestWebhookEvent =
-    recentEvents.find((event) => event.label === 'Webhook sync') ||
+    operatorEvents.find((event) => event.category === 'WEBHOOKS') ||
     (webhooksNeedAttention
       ? {
           id: 'webhook-attention',
-          at: business.updatedAt,
-          severity: 'warning' as const,
-          label: 'Webhook sync',
+          createdAt: business.updatedAt,
+          status: 'WARNING' as const,
+          category: 'WEBHOOKS' as const,
           summary: 'Webhook mismatch detected',
-          detail: webhookSnapshot?.error || 'Voice, SMS, or status callback sync still needs attention.',
+          detailsJson: {
+            detail: webhookSnapshot?.error || 'Voice, SMS, or status callback sync still needs attention.',
+          },
+          relatedEntityType: null,
+          relatedEntityId: null,
+          type: 'webhooks.mismatch_detected',
         }
       : null);
   const latestOutboundSms = recentMessages[0] || null;
@@ -439,7 +511,8 @@ export default async function AdminBusinessDetailPage({
           </Badge>
           <Badge variant={rolloutStatus.badgeVariant}>{rolloutStatus.label}</Badge>
           <Badge variant={customerStatus.badgeVariant}>{customerStatus.label}</Badge>
-          <Badge variant={getNextStepBadgeVariant(nextStep.tone)}>{nextStep.title}</Badge>
+          <Badge variant={onboardingConfidence.stateVariant}>{onboardingConfidence.stateLabel}</Badge>
+          <Badge variant={onboardingConfidence.readinessVariant}>{onboardingConfidence.readinessLabel}</Badge>
         </div>
       </div>
 
@@ -469,20 +542,22 @@ export default async function AdminBusinessDetailPage({
       <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
         <Card className="border-primary/20 bg-primary/5">
           <CardHeader>
-            <CardTitle>What should I do next?</CardTitle>
-            <CardDescription>Plain-English operator guidance with the fastest next action at the top.</CardDescription>
+            <CardTitle>Onboarding confidence</CardTitle>
+            <CardDescription>Current state, blockers, next action, and the exact gate between setup, testing, and launch.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="rounded-xl border bg-background/80 p-4">
               <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                 <div className="space-y-2">
                   <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-lg font-semibold">{nextStep.title}</p>
-                    <Badge variant={getNextStepBadgeVariant(nextStep.tone)}>{nextStep.actionLabel}</Badge>
+                    <p className="text-lg font-semibold">{onboardingConfidence.stateLabel}</p>
+                    <Badge variant={onboardingConfidence.stateVariant}>{onboardingConfidence.readinessLabel}</Badge>
                   </div>
-                  <p className="max-w-3xl text-sm text-muted-foreground">{nextStep.detail}</p>
+                  <p className="max-w-3xl text-sm text-muted-foreground">{onboardingConfidence.summary}</p>
+                  <p className="text-sm font-medium">Next action: {onboardingConfidence.nextAction}</p>
                   <p className="text-xs text-muted-foreground">
-                    Setup progress: {completedChecklistCount} / {checklist.length} steps done
+                    Confidence checklist: {onboardingConfidence.milestones.filter((item) => item.complete).length} /{' '}
+                    {onboardingConfidence.milestones.length} signals complete
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
@@ -513,7 +588,12 @@ export default async function AdminBusinessDetailPage({
                   ) : webhooksNeedAttention ? (
                     <WebhookResyncButton businessId={business.id} label="Re-sync webhooks" target="ALL" variant="default" />
                   ) : managedSummary.messagingReady && business.provisioningStatus !== 'LIVE' ? (
-                    <StatusButton businessId={business.id} label="Mark live" status="LIVE" variant="default" />
+                    <StatusButton
+                      businessId={business.id}
+                      label={onboardingConfidence.canSafelyMarkLive ? 'Mark live' : 'Mark live with warnings'}
+                      status="LIVE"
+                      variant={onboardingConfidence.canSafelyMarkLive ? 'default' : 'outline'}
+                    />
                   ) : (
                     <Link className={buttonVariants({ size: 'sm' })} href={`/admin/${business.id}/workspace`}>
                       Open support workspace
@@ -534,18 +614,37 @@ export default async function AdminBusinessDetailPage({
               </div>
             </div>
 
-            {pendingChecklist.length > 0 ? (
+            {onboardingConfidence.blockers.length > 0 ? (
+              <div className="grid gap-3">
+                {onboardingConfidence.blockers.map((blocker, index) => (
+                  <div
+                    key={`${blocker.message}-${index}`}
+                    className={cn(
+                      'rounded-xl border p-4 text-sm',
+                      blocker.level === 'error' ? 'border-destructive/30 bg-destructive/5 text-destructive' : 'bg-background/80'
+                    )}
+                  >
+                    {blocker.message}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            {onboardingConfidence.milestones.length > 0 ? (
               <div className="grid gap-3 md:grid-cols-2">
-                {pendingChecklist.slice(0, 4).map((item) => (
+                {onboardingConfidence.milestones.map((item) => (
                   <div key={item.key} className="rounded-xl border bg-background/80 p-4 text-sm">
-                    <p className="font-medium">{item.label}</p>
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="font-medium">{item.label}</p>
+                      <Badge variant={getConfidenceMilestoneBadgeVariant(item.variant)}>{item.complete ? 'Done' : 'Next'}</Badge>
+                    </div>
                     <p className="mt-2 text-muted-foreground">{item.detail}</p>
                   </div>
                 ))}
               </div>
             ) : (
               <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground">
-                Setup checklist is complete. This business should only need normal monitoring and support-mode shortcuts.
+                No onboarding milestones are available for this business yet.
               </div>
             )}
 
@@ -805,7 +904,12 @@ export default async function AdminBusinessDetailPage({
               {assignedNumber ? <WebhookResyncButton businessId={business.id} label="Re-sync voice" target="VOICE" /> : null}
               {assignedNumber ? <WebhookResyncButton businessId={business.id} label="Re-sync SMS" target="SMS" /> : null}
               {managedSummary.messagingReady && business.provisioningStatus !== 'LIVE' ? (
-                <StatusButton businessId={business.id} label="Mark live" status="LIVE" variant="secondary" />
+                <StatusButton
+                  businessId={business.id}
+                  label={onboardingConfidence.canSafelyMarkLive ? 'Mark live' : 'Mark live with warnings'}
+                  status="LIVE"
+                  variant={onboardingConfidence.canSafelyMarkLive ? 'secondary' : 'outline'}
+                />
               ) : null}
             </div>
           </CardContent>
@@ -978,7 +1082,12 @@ export default async function AdminBusinessDetailPage({
               <div className="flex flex-wrap gap-2">
                 <Button type="submit">Save automation settings</Button>
                 {business.provisioningStatus !== 'LIVE' ? (
-                  <StatusButton businessId={business.id} label="Mark live" status="LIVE" variant="secondary" />
+                  <StatusButton
+                    businessId={business.id}
+                    label={onboardingConfidence.canSafelyMarkLive ? 'Mark live' : 'Mark live with warnings'}
+                    status="LIVE"
+                    variant={onboardingConfidence.canSafelyMarkLive ? 'secondary' : 'outline'}
+                  />
                 ) : (
                   <StatusButton businessId={business.id} label="Back to onboarding" status="ONBOARDING" variant="outline" />
                 )}
@@ -1023,8 +1132,8 @@ export default async function AdminBusinessDetailPage({
 
       <Card className="bg-card/90" id="recent-events">
         <CardHeader>
-          <CardTitle>Recent events / troubleshooting</CardTitle>
-          <CardDescription>Short operator summaries first, then the supporting event history.</CardDescription>
+          <CardTitle>Recent activity</CardTitle>
+          <CardDescription>Business-scoped operator timeline with plain-English summaries first and details on demand.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4 text-sm">
@@ -1032,14 +1141,18 @@ export default async function AdminBusinessDetailPage({
               <p className="font-medium">Latest provisioning attempt</p>
               <p className="mt-2">{latestProvisioningEvent?.summary || 'No provisioning run recorded'}</p>
               <p className="mt-2 text-xs text-muted-foreground">
-                {latestProvisioningEvent ? latestProvisioningEvent.detail : 'Run provisioning from the top of this page when setup should continue.'}
+                {latestProvisioningEvent
+                  ? getOperatorEventDetails(latestProvisioningEvent.detailsJson)[0]?.value || 'Open the timeline below for full provisioning detail.'
+                  : 'Run provisioning from the top of this page when setup should continue.'}
               </p>
             </div>
             <div className="rounded-xl border bg-background/80 p-4">
               <p className="font-medium">Latest webhook issue</p>
               <p className="mt-2">{latestWebhookEvent?.summary || 'No webhook issue recorded'}</p>
               <p className="mt-2 text-xs text-muted-foreground">
-                {latestWebhookEvent?.detail || 'Webhook sync looks healthy.'}
+                {latestWebhookEvent
+                  ? getOperatorEventDetails(latestWebhookEvent.detailsJson)[0]?.value || 'Webhook sync looks healthy.'
+                  : 'Webhook sync looks healthy.'}
               </p>
             </div>
             <div className="rounded-xl border bg-background/80 p-4">
@@ -1062,29 +1175,74 @@ export default async function AdminBusinessDetailPage({
             </div>
           </div>
 
-          {recentEvents.length === 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {businessTimelineFilterOptions.map((option) => {
+              const href = option.key === 'all' ? `/admin/${business.id}#recent-events` : `/admin/${business.id}?activity=${option.key}#recent-events`;
+              return (
+                <Link
+                  key={option.key}
+                  className={cn(
+                    buttonVariants({ variant: option.key === activityFilter ? 'default' : 'outline', size: 'sm' }),
+                    option.key === activityFilter && 'pointer-events-none'
+                  )}
+                  href={href}
+                >
+                  {option.label} ({timelineFilterCounts.get(option.key) ?? 0})
+                </Link>
+              );
+            })}
+          </div>
+
+          {visibleTimelineEvents.length === 0 ? (
             <div className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">No recent operator events are recorded for this business yet.</div>
           ) : (
             <div className="grid gap-3">
-              {recentEvents.map((event) => (
+              {visibleTimelineEvents.map((event) => {
+                const details = getOperatorEventDetails(event.detailsJson);
+                const relatedHref = buildOperatorEventRelatedHref(business.id, event.relatedEntityType, event.relatedEntityId);
+                return (
                 <details key={event.id} className="rounded-xl border bg-background/80 p-4 text-sm">
                   <summary className="cursor-pointer list-none">
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                       <div>
                         <div className="flex flex-wrap items-center gap-2">
-                          <Badge variant={event.severity === 'error' ? 'destructive' : event.severity === 'warning' ? 'outline' : 'secondary'}>
-                            {event.label}
+                          <Badge variant={getOperatorEventBadgeVariant(event.status)}>
+                            {operatorEventStatusLabels[event.status]}
                           </Badge>
+                          <Badge variant="outline">{operatorEventCategoryLabels[event.category]}</Badge>
                           <span className="font-medium">{event.summary}</span>
                         </div>
-                        <p className="mt-2 text-xs text-muted-foreground">{formatDateTime(event.at)}</p>
+                        <p className="mt-2 text-xs text-muted-foreground">{formatDateTime(event.createdAt)}</p>
                       </div>
                       <span className="text-xs text-muted-foreground">Show detail</span>
                     </div>
                   </summary>
-                  <p className="mt-3 text-muted-foreground">{event.detail}</p>
+                  <div className="mt-3 space-y-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{event.id}</code>
+                      <CopyValueButton value={event.id} label="Copy event ID" />
+                      {relatedHref ? (
+                        <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={relatedHref}>
+                          Open related view
+                        </Link>
+                      ) : null}
+                    </div>
+                    {details.length > 0 ? (
+                      <div className="grid gap-2 md:grid-cols-2">
+                        {details.map((detail) => (
+                          <div key={detail.key} className="rounded-lg border bg-background/70 p-3">
+                            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{detail.label}</p>
+                            <p className="mt-1 text-muted-foreground">{detail.value}</p>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-muted-foreground">No extra detail recorded.</p>
+                    )}
+                  </div>
                 </details>
-              ))}
+                );
+              })}
             </div>
           )}
         </CardContent>

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -15,6 +15,7 @@ import { requireAdmin } from '@/lib/admin';
 import { canDeleteTestBusiness } from '@/lib/admin-dashboard';
 import { logAuditEvent } from '@/lib/audit-log';
 import { db } from '@/lib/db';
+import { formatPhoneDetail, maskSid, recordBusinessOperatorEvent } from '@/lib/operator-events';
 import { maskPhoneForAudit, normalizePhoneNumber, normalizePhoneNumberToE164 } from '@/lib/phone';
 import { sendAndPersistOutboundMessage } from '@/lib/twilio-messaging';
 import {
@@ -235,6 +236,18 @@ export async function createAdminBusinessAction(formData: FormData) {
       urgentOnly: false,
     },
   });
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'onboarding.business_workspace_created',
+    category: 'ONBOARDING',
+    status: 'PENDING',
+    summary: 'Business workspace created',
+    details: {
+      ownerEmail: data.ownerEmail.trim().toLowerCase(),
+      ownerPhone: formatPhoneDetail(ownerPhone),
+      isTestBusiness: data.isTestBusiness,
+    },
+  });
 
   let redirectPath: string;
   try {
@@ -257,6 +270,16 @@ export async function createAdminBusinessAction(formData: FormData) {
       data: {
         provisioningStatus: BusinessProvisioningStatus.NEEDS_ATTENTION,
         provisioningError: message,
+      },
+    });
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'onboarding.owner_setup_failed',
+      category: 'ONBOARDING',
+      status: 'FAILED',
+      summary: 'Owner setup failed after business creation',
+      details: {
+        error: message,
       },
     });
 
@@ -460,6 +483,16 @@ export async function saveAdminBusinessProfileAction(formData: FormData) {
   });
 
   if (changedFields.length > 0) {
+    await recordBusinessOperatorEvent({
+      businessId: data.businessId,
+      type: managedTwilioStatusChanged || a2pMetadataChanged ? 'admin.readiness_tracking_updated' : 'admin.business_profile_updated',
+      category: managedTwilioStatusChanged || a2pMetadataChanged ? 'ONBOARDING' : 'ADMIN_ACTIONS',
+      status: managedTwilioStatusChanged || a2pMetadataChanged ? 'INFO' : 'SUCCESS',
+      summary: managedTwilioStatusChanged || a2pMetadataChanged ? 'Onboarding tracking updated' : 'Business profile updated',
+      details: {
+        changedFields: buildChangedFieldMetadata(changedFields),
+      },
+    });
     logAuditEvent({
       event: 'admin_business_editor_saved',
       actorType: 'user',
@@ -512,6 +545,16 @@ export async function connectBusinessOwnerAction(formData: FormData) {
       data: {
         provisioningStatus: BusinessProvisioningStatus.NEEDS_ATTENTION,
         provisioningError: message,
+      },
+    });
+    await recordBusinessOperatorEvent({
+      businessId: parsed.data.businessId,
+      type: 'onboarding.owner_connection_failed',
+      category: 'ONBOARDING',
+      status: 'FAILED',
+      summary: 'Owner connection failed',
+      details: {
+        error: message,
       },
     });
 
@@ -600,6 +643,17 @@ export async function resyncBusinessWebhooksAction(formData: FormData) {
         provisioningError: message,
       },
     });
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'webhooks.sync_failed',
+      category: 'WEBHOOKS',
+      status: 'FAILED',
+      summary: 'Webhook sync failed',
+      details: {
+        target: parsed.data.target,
+        error: message,
+      },
+    });
 
     redirectPath = buildAdminBusinessRedirectPath(business.id, { error: message });
   }
@@ -641,6 +695,17 @@ export async function sendBusinessTestSmsAction(formData: FormData) {
   }
 
   try {
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'admin.test_sms_initiated',
+      category: 'ADMIN_ACTIONS',
+      status: 'PENDING',
+      summary: 'Test SMS initiated',
+      details: {
+        destinationPhone: formatPhoneDetail(destinationPhone),
+        fromPhone: formatPhoneDetail(fromPhone),
+      },
+    });
     const result = await sendAndPersistOutboundMessage({
       businessId: business.id,
       fromPhone,
@@ -654,12 +719,38 @@ export async function sendBusinessTestSmsAction(formData: FormData) {
     });
 
     if (result.suppressed) {
+      await recordBusinessOperatorEvent({
+        businessId: business.id,
+        type: 'admin.test_sms_suppressed',
+        category: 'ADMIN_ACTIONS',
+        status: 'WARNING',
+        summary: 'Test SMS could not be sent',
+        details: {
+          destinationPhone: formatPhoneDetail(destinationPhone),
+          reason: result.reason,
+        },
+      });
       redirect(
         buildAdminBusinessRedirectPath(business.id, {
           error: `Test SMS was suppressed: ${result.reason.replace(/_/g, ' ')}.`,
         })
       );
     }
+
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'admin.test_sms_accepted',
+      category: 'ADMIN_ACTIONS',
+      status: 'SUCCESS',
+      summary: 'Test SMS accepted by Twilio',
+      details: {
+        destinationPhone: formatPhoneDetail(destinationPhone),
+        fromPhone: formatPhoneDetail(fromPhone),
+        messageSid: maskSid(result.sent.sid),
+      },
+      relatedEntityType: 'message',
+      relatedEntityId: result.message.id,
+    });
 
     logAuditEvent({
       event: 'admin_test_sms_sent',
@@ -676,6 +767,17 @@ export async function sendBusinessTestSmsAction(formData: FormData) {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to send test SMS.';
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'admin.test_sms_failed',
+      category: 'ADMIN_ACTIONS',
+      status: 'FAILED',
+      summary: 'Test SMS failed',
+      details: {
+        destinationPhone: formatPhoneDetail(destinationPhone),
+        error: message,
+      },
+    });
     redirect(buildAdminBusinessRedirectPath(business.id, { error: message }));
   }
 
@@ -723,6 +825,17 @@ export async function archiveBusinessAction(formData: FormData) {
       isTestBusiness: business.isTestBusiness,
     },
   });
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'admin.business_archived',
+    category: 'ADMIN_ACTIONS',
+    status: 'WARNING',
+    summary: 'Business archived',
+    details: {
+      businessName: business.name,
+      isTestBusiness: business.isTestBusiness,
+    },
+  });
 
   await revalidateAdminPaths(business.id);
   redirect(buildAdminBusinessRedirectPath(business.id, { archived: 1 }));
@@ -764,6 +877,16 @@ export async function restoreBusinessAction(formData: FormData) {
     targetId: business.id,
     metadata: {
       actorEmail: admin.email,
+      businessName: business.name,
+    },
+  });
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'admin.business_restored',
+    category: 'ADMIN_ACTIONS',
+    status: 'SUCCESS',
+    summary: 'Business restored',
+    details: {
       businessName: business.name,
     },
   });

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -25,6 +25,7 @@ import { searchBusinessesForAdmin } from '@/lib/business';
 import { db } from '@/lib/db';
 import { formatDateTime, formatRelativeTime } from '@/lib/lead-presenters';
 import { getManagedTextingNumber, getManagedTwilioStatusSummary } from '@/lib/managed-twilio-status';
+import { OperatorEventStatus } from '@prisma/client';
 import { formatPhoneForDisplay } from '@/lib/phone';
 import { cn } from '@/lib/utils';
 
@@ -81,7 +82,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   const view = (getQueryValue(searchParams, 'view') as AdminBoardFilter | null) || 'all';
   const adminBusiness = await db.business.findUnique({ where: { ownerClerkId: admin.userId } });
 
-  const [businesses, leadCounts, leadActivity, callActivity, messageActivity, notificationFailures] = await Promise.all([
+  const [businesses, leadCounts, leadActivity, callActivity, messageActivity, notificationFailures, operatorSignals] = await Promise.all([
     query
       ? searchBusinessesForAdmin(query)
       : db.business.findMany({
@@ -120,6 +121,17 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       },
       take: 200,
     }),
+    db.businessOperatorEvent.findMany({
+      where: {
+        status: { in: [OperatorEventStatus.FAILED, OperatorEventStatus.WARNING] },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        businessId: true,
+        status: true,
+      },
+      take: 600,
+    }),
   ]);
 
   const leadCountMap = new Map(leadCounts.map((item) => [item.businessId, item._count._all]));
@@ -129,11 +141,22 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   const callActivityMap = new Map(callActivity.map((item) => [item.businessId, item._max.createdAt]));
   const messageActivityMap = new Map(messageActivity.map((item) => [item.businessId, item._max.createdAt]));
   const notificationFailureMap = new Map<string, { status: string; error: string | null; createdAt: Date }>();
+  const operatorSignalMap = new Map<string, { failed: number; warning: number }>();
 
   for (const failure of notificationFailures) {
     if (!notificationFailureMap.has(failure.businessId)) {
       notificationFailureMap.set(failure.businessId, failure);
     }
+  }
+
+  for (const signal of operatorSignals) {
+    const entry = operatorSignalMap.get(signal.businessId) || { failed: 0, warning: 0 };
+    if (signal.status === OperatorEventStatus.FAILED) {
+      entry.failed += 1;
+    } else {
+      entry.warning += 1;
+    }
+    operatorSignalMap.set(signal.businessId, entry);
   }
 
   const businessRows = businesses.map((business) => {
@@ -171,6 +194,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       : nextStep.tone === 'healthy'
         ? 'Healthy. No immediate operator action needed.'
         : compactCopy(`${nextStep.title}. ${nextStep.detail}`);
+    const operatorSignals = operatorSignalMap.get(business.id) || { failed: 0, warning: 0 };
 
     return {
       business,
@@ -185,6 +209,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       overallStatus,
       a2pState,
       attentionSignal,
+      operatorSignals,
       canSendTestSms: Boolean(assignedNumber && (business.notificationSettings?.ownerPhone || business.notifyPhone)),
     };
   });
@@ -415,6 +440,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                   overallStatus,
                   a2pState,
                   attentionSignal,
+                  operatorSignals,
                   canSendTestSms,
                 }) => (
                   <div key={business.id} className="grid gap-4 border-t bg-background/80 px-5 py-4 first:border-t-0 xl:grid-cols-[1.7fr_1fr_1.15fr_0.95fr_1.3fr]">
@@ -435,6 +461,8 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                         <span>{business.id}</span>
                         <span>{leadCount} lead{leadCount === 1 ? '' : 's'}</span>
                         <span>{lastActivityAt ? `Last activity ${formatRelativeTime(lastActivityAt)}` : 'No activity yet'}</span>
+                        {operatorSignals.failed > 0 ? <span>{operatorSignals.failed} error{operatorSignals.failed === 1 ? '' : 's'}</span> : null}
+                        {operatorSignals.warning > 0 ? <span>{operatorSignals.warning} warning{operatorSignals.warning === 1 ? '' : 's'}</span> : null}
                       </div>
                     </div>
 

--- a/app/api/twilio/status/route.ts
+++ b/app/api/twilio/status/route.ts
@@ -4,6 +4,7 @@ import { findBusinessByTwilioNumber } from '@/lib/business';
 import { db } from '@/lib/db';
 import { startMissedCallRecovery } from '@/lib/missed-call-flow';
 import { getCorrelationIdFromRequest, withCorrelationIdHeader } from '@/lib/observability';
+import { formatPhoneDetail, recordBusinessOperatorEvent } from '@/lib/operator-events';
 import { normalizePhoneNumber, normalizePhoneNumberToE164 } from '@/lib/phone';
 import { RATE_LIMIT_TWILIO_AUTH_MAX, RATE_LIMIT_TWILIO_UNAUTH_MAX, RATE_LIMIT_WINDOW_MS } from '@/lib/rate-limit-config';
 import { buildRateLimitHeaders, consumeRateLimit, getClientIpAddress } from '@/lib/rate-limit';
@@ -252,6 +253,22 @@ export async function POST(request: Request) {
       return withCorrelation(xmlOk());
     }
 
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'voice.call_marked_missed',
+      category: 'VOICE',
+      status: 'WARNING',
+      summary: 'Call marked missed',
+      details: {
+        callSid,
+        dialCallSid,
+        fromPhone: formatPhoneDetail(from || formField(formData, 'From')),
+        toPhone: formatPhoneDetail(to),
+      },
+      relatedEntityType: 'call',
+      relatedEntityId: call.id,
+    });
+
     const callerPhone = from || formField(formData, 'From');
     const callerPhoneNormalized = normalizePhoneNumber(callerPhone) || callerPhone;
 
@@ -277,6 +294,19 @@ export async function POST(request: Request) {
         leadId: lead.id,
         decision: 'create_lead',
       });
+      await recordBusinessOperatorEvent({
+        businessId: business.id,
+        type: 'voice.lead_created_from_call',
+        category: 'VOICE',
+        status: 'SUCCESS',
+        summary: 'Lead created from missed call',
+        details: {
+          callSid,
+          callerPhone: formatPhoneDetail(callerPhoneNormalized),
+        },
+        relatedEntityType: 'lead',
+        relatedEntityId: lead.id,
+      });
     } else {
       logTwilioInfo('status', 'lead_reused_for_retry', {
         callSid,
@@ -286,6 +316,19 @@ export async function POST(request: Request) {
         businessId: business.id,
         leadId: lead.id,
         decision: 'reuse_existing_lead',
+      });
+      await recordBusinessOperatorEvent({
+        businessId: business.id,
+        type: 'voice.lead_updated_from_call',
+        category: 'VOICE',
+        status: 'INFO',
+        summary: 'Existing lead reused for missed call',
+        details: {
+          callSid,
+          callerPhone: formatPhoneDetail(callerPhoneNormalized),
+        },
+        relatedEntityType: 'lead',
+        relatedEntityId: lead.id,
       });
     }
 
@@ -446,6 +489,19 @@ export async function POST(request: Request) {
       });
 
       if (!recovery.started) {
+        await recordBusinessOperatorEvent({
+          businessId: business.id,
+          type: 'messaging.missed_call_sms_suppressed',
+          category: 'MESSAGING',
+          status: 'WARNING',
+          summary: 'Missed-call SMS did not start',
+          details: {
+            reason: recovery.reason ?? 'unknown',
+            callSid,
+          },
+          relatedEntityType: 'lead',
+          relatedEntityId: lead.id,
+        });
         logTwilioWarn('status', 'initial_missed_call_sms_suppressed', {
           callSid,
           dialCallSid,
@@ -458,6 +514,19 @@ export async function POST(request: Request) {
         return withCorrelation(xmlOk());
       }
 
+      await recordBusinessOperatorEvent({
+        businessId: business.id,
+        type: 'messaging.missed_call_sms_started',
+        category: 'MESSAGING',
+        status: 'SUCCESS',
+        summary: 'Missed-call SMS flow started',
+        details: {
+          callSid,
+          leadId: recovery.lead.id,
+        },
+        relatedEntityType: 'lead',
+        relatedEntityId: recovery.lead.id,
+      });
       logTwilioInfo('status', 'initial_missed_call_sms_started', {
         callSid,
         dialCallSid,

--- a/app/api/twilio/voice/route.ts
+++ b/app/api/twilio/voice/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { findBusinessByTwilioNumber } from '@/lib/business';
 import { db } from '@/lib/db';
 import { getCorrelationIdFromRequest, withCorrelationIdHeader } from '@/lib/observability';
+import { formatPhoneDetail, recordBusinessOperatorEvent } from '@/lib/operator-events';
 import { normalizePhoneNumber, normalizePhoneNumberToE164 } from '@/lib/phone';
 import { RATE_LIMIT_TWILIO_AUTH_MAX, RATE_LIMIT_TWILIO_UNAUTH_MAX, RATE_LIMIT_WINDOW_MS } from '@/lib/rate-limit-config';
 import { buildRateLimitHeaders, consumeRateLimit, getClientIpAddress } from '@/lib/rate-limit';
@@ -147,6 +148,20 @@ export async function POST(request: Request) {
           parentCallSid: formField(formData, 'ParentCallSid') || undefined,
           rawPayload: payload,
         },
+      });
+      await recordBusinessOperatorEvent({
+        businessId: business.id,
+        type: 'voice.inbound_call_received',
+        category: 'VOICE',
+        status: 'INFO',
+        summary: 'Inbound call received',
+        details: {
+          fromPhone: formatPhoneDetail(from || formField(formData, 'From')),
+          toPhone: formatPhoneDetail(to || formField(formData, 'To')),
+          callSid,
+        },
+        relatedEntityType: 'call',
+        relatedEntityId: callSid,
       });
 
       logTwilioInfo('voice', 'call_persisted', {

--- a/lib/admin-dashboard.ts
+++ b/lib/admin-dashboard.ts
@@ -1,6 +1,7 @@
 import {
   BusinessProvisioningStatus,
   ManagedTwilioStatus,
+  OperatorEventStatus,
   OwnerNotificationStatus,
   type Business,
   type BusinessNotificationSettings,
@@ -82,6 +83,52 @@ export type AdminBusinessEvent = {
   label: string;
   summary: string;
   detail: string;
+};
+
+export type OnboardingConfidenceState =
+  | 'draft'
+  | 'in_setup'
+  | 'needs_attention'
+  | 'waiting_on_a2p'
+  | 'ready_for_test'
+  | 'ready_to_go_live'
+  | 'live'
+  | 'live_with_warnings'
+  | 'archived';
+
+export type OnboardingConfidenceMilestone = {
+  key:
+    | 'business_profile'
+    | 'owner_connected'
+    | 'owner_alerts'
+    | 'twilio_setup'
+    | 'texting_number'
+    | 'messaging_service'
+    | 'webhooks'
+    | 'a2p'
+    | 'test_sms'
+    | 'missed_call_validation'
+    | 'live_gate';
+  label: string;
+  complete: boolean;
+  variant: 'success' | 'warning' | 'pending';
+  detail: string;
+};
+
+export type AdminOnboardingConfidence = {
+  state: OnboardingConfidenceState;
+  stateLabel: string;
+  stateVariant: 'success' | 'secondary' | 'outline' | 'destructive';
+  readinessLabel: 'Not ready' | 'Ready for test' | 'Ready for live' | 'Live with warnings' | 'Waiting on external approval';
+  readinessVariant: 'success' | 'secondary' | 'outline' | 'destructive';
+  nextAction: string;
+  summary: string;
+  blockers: Array<{ level: 'warning' | 'error'; message: string }>;
+  milestones: OnboardingConfidenceMilestone[];
+  readyForTest: boolean;
+  readyForLive: boolean;
+  canSafelyMarkLive: boolean;
+  hasRecentFailures: boolean;
 };
 
 export const adminBoardFilterOptions: AdminBoardFilterOption[] = [
@@ -286,6 +333,252 @@ export function buildAdminNextStep(params: {
     tone: 'pending',
     actionLabel: 'Review provisioning health',
   };
+}
+
+function milestoneVariant(params: { complete: boolean; blocking?: boolean }) {
+  if (params.complete) return 'success' as const;
+  if (params.blocking) return 'warning' as const;
+  return 'pending' as const;
+}
+
+export function buildAdminOnboardingConfidence(params: {
+  business: DashboardBusiness;
+  notificationSettings: DashboardNotificationSettings | null;
+  ownerConnected: boolean;
+  successfulLeadCount: number;
+  operatorEvents: Array<{ type: string; status: OperatorEventStatus; createdAt: Date }>;
+}) {
+  const { business, notificationSettings, ownerConnected, successfulLeadCount, operatorEvents } = params;
+  const managedSummary = getManagedTwilioStatusSummary(business);
+  const nextStep = buildAdminNextStep({ business, notificationSettings, ownerConnected });
+  const ownerEmail = notificationSettings?.ownerEmail?.trim() || null;
+  const ownerPhone = notificationSettings?.ownerPhone?.trim() || business.notifyPhone || null;
+  const hasProfile = Boolean(business.name.trim() && business.forwardingNumber.trim());
+  const ownerAlertsReady = Boolean(ownerPhone || ownerEmail);
+  const twilioSetupReady = Boolean(business.twilioSubaccountSid);
+  const numberReady = Boolean(getManagedTextingNumber(business) && (business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid));
+  const messagingServiceReady = Boolean(business.twilioMessagingServiceSid);
+  const webhooksReady = Boolean(business.twilioWebhookSyncedAt);
+  const compliancePending =
+    managedSummary.onboardingReady && !managedSummary.complianceReady && !managedSummary.attentionRequired;
+  const hasTestSmsSuccess = operatorEvents.some(
+    (event) => event.type === 'admin.test_sms_accepted' && event.status === OperatorEventStatus.SUCCESS
+  );
+  const hasTestSmsFailure = operatorEvents.some(
+    (event) => event.type === 'admin.test_sms_failed' || event.type === 'admin.test_sms_suppressed'
+  );
+  const hasRecentFailures = operatorEvents.some(
+    (event) => event.status === OperatorEventStatus.FAILED || event.status === OperatorEventStatus.WARNING
+  );
+  const missedCallValidated = successfulLeadCount > 0;
+  const readyForTest = ownerConnected && ownerAlertsReady && twilioSetupReady && numberReady && messagingServiceReady && webhooksReady && managedSummary.complianceReady;
+  const readyForLive = readyForTest && hasTestSmsSuccess && missedCallValidated;
+  const canSafelyMarkLive = readyForLive;
+
+  let state: OnboardingConfidenceState = 'in_setup';
+  if (isBusinessArchived(business)) {
+    state = 'archived';
+  } else if (business.provisioningStatus === BusinessProvisioningStatus.LIVE && (!canSafelyMarkLive || hasRecentFailures || managedSummary.attentionRequired)) {
+    state = 'live_with_warnings';
+  } else if (business.provisioningStatus === BusinessProvisioningStatus.LIVE && canSafelyMarkLive) {
+    state = 'live';
+  } else if (nextStep.tone === 'attention' || managedSummary.attentionRequired || business.provisioningStatus === BusinessProvisioningStatus.NEEDS_ATTENTION) {
+    state = 'needs_attention';
+  } else if (compliancePending) {
+    state = 'waiting_on_a2p';
+  } else if (readyForLive) {
+    state = 'ready_to_go_live';
+  } else if (readyForTest) {
+    state = 'ready_for_test';
+  } else if (!twilioSetupReady && !numberReady && !messagingServiceReady && !webhooksReady && !ownerConnected) {
+    state = 'draft';
+  }
+
+  const blockers: AdminOnboardingConfidence['blockers'] = [];
+  if (nextStep.tone === 'attention') {
+    blockers.push({ level: 'error', message: nextStep.detail });
+  }
+  if (managedSummary.attentionRequired && business.a2pFailureReason) {
+    blockers.push({ level: 'error', message: business.a2pFailureReason });
+  }
+  if (compliancePending) {
+    blockers.push({ level: 'warning', message: 'A2P review is still pending. No operator action is needed unless Twilio asks for changes.' });
+  }
+  if (readyForTest && !hasTestSmsSuccess) {
+    blockers.push({ level: 'warning', message: 'Run an admin test SMS from the business line before treating this onboarding as launch-ready.' });
+  }
+  if (readyForTest && hasTestSmsFailure) {
+    blockers.push({ level: 'error', message: 'The latest admin test SMS did not complete cleanly. Fix that before you go live.' });
+  }
+  if (readyForTest && !missedCallValidated) {
+    blockers.push({ level: 'warning', message: 'Run one real missed-call test and confirm the lead reaches the owner before marking this business live.' });
+  }
+
+  const milestones: OnboardingConfidenceMilestone[] = [
+    {
+      key: 'business_profile',
+      label: 'Business info complete',
+      complete: hasProfile,
+      variant: milestoneVariant({ complete: hasProfile, blocking: true }),
+      detail: hasProfile ? 'Business name and call-forwarding details are saved.' : 'Add the business name and forwarding number first.',
+    },
+    {
+      key: 'owner_connected',
+      label: 'Owner connected',
+      complete: ownerConnected,
+      variant: milestoneVariant({ complete: ownerConnected, blocking: true }),
+      detail: ownerConnected ? 'A Clerk owner is linked to this business.' : ownerEmail ? 'Owner invite or attachment still needs to finish.' : 'Add the owner email and connect the owner account.',
+    },
+    {
+      key: 'owner_alerts',
+      label: 'Owner alert route',
+      complete: ownerAlertsReady,
+      variant: milestoneVariant({ complete: ownerAlertsReady, blocking: true }),
+      detail: ownerAlertsReady ? 'Owner phone or email is saved for alerts.' : 'Save an owner phone or email before you rely on alerts.',
+    },
+    {
+      key: 'twilio_setup',
+      label: 'Twilio subaccount ready',
+      complete: twilioSetupReady,
+      variant: milestoneVariant({ complete: twilioSetupReady, blocking: true }),
+      detail: twilioSetupReady ? 'Managed Twilio subaccount is attached.' : 'Provisioning still needs to create or reconnect the subaccount.',
+    },
+    {
+      key: 'texting_number',
+      label: 'Number assigned',
+      complete: numberReady,
+      variant: milestoneVariant({ complete: numberReady, blocking: true }),
+      detail: numberReady ? 'The business texting number is attached.' : 'Assign a new number or attach the approved existing number.',
+    },
+    {
+      key: 'messaging_service',
+      label: 'Messaging Service ready',
+      complete: messagingServiceReady,
+      variant: milestoneVariant({ complete: messagingServiceReady, blocking: true }),
+      detail: messagingServiceReady ? 'Twilio Messaging Service is attached.' : 'Provisioning still needs to create or repair the Messaging Service.',
+    },
+    {
+      key: 'webhooks',
+      label: 'Webhooks synced',
+      complete: webhooksReady,
+      variant: milestoneVariant({ complete: webhooksReady, blocking: true }),
+      detail: webhooksReady ? 'Voice, SMS, and status callbacks have been synced.' : 'Run Re-sync webhooks before testing.',
+    },
+    {
+      key: 'a2p',
+      label: 'A2P / readiness acknowledged',
+      complete: managedSummary.complianceReady,
+      variant: milestoneVariant({ complete: managedSummary.complianceReady, blocking: managedSummary.attentionRequired }),
+      detail: managedSummary.complianceReady ? 'A2P approval is recorded.' : managedSummary.nextStep,
+    },
+    {
+      key: 'test_sms',
+      label: 'Test SMS run',
+      complete: hasTestSmsSuccess,
+      variant: milestoneVariant({ complete: hasTestSmsSuccess, blocking: readyForTest }),
+      detail: hasTestSmsSuccess ? 'Admin test SMS was accepted by Twilio from the business line.' : 'Run the admin test SMS once the business is ready for messaging.',
+    },
+    {
+      key: 'missed_call_validation',
+      label: 'Missed-call flow validated',
+      complete: missedCallValidated,
+      variant: milestoneVariant({ complete: missedCallValidated, blocking: readyForTest }),
+      detail: missedCallValidated ? 'At least one missed-call lead reached the owner flow for this business.' : 'Run one real missed-call test from start to finish before going live.',
+    },
+    {
+      key: 'live_gate',
+      label: 'Safe to mark live',
+      complete: canSafelyMarkLive,
+      variant: milestoneVariant({ complete: canSafelyMarkLive, blocking: business.provisioningStatus === BusinessProvisioningStatus.LIVE || readyForTest }),
+      detail: canSafelyMarkLive ? 'This business has passed the key operator checks for launch.' : 'Keep the business in onboarding until test SMS and a real missed-call validation are complete.',
+    },
+  ];
+
+  const stateMeta: Record<OnboardingConfidenceState, Pick<AdminOnboardingConfidence, 'stateLabel' | 'stateVariant' | 'readinessLabel' | 'readinessVariant' | 'nextAction' | 'summary'>> = {
+    draft: {
+      stateLabel: 'Draft',
+      stateVariant: 'outline',
+      readinessLabel: 'Not ready',
+      readinessVariant: 'outline',
+      nextAction: nextStep.title,
+      summary: 'Core onboarding details are still missing. Start with owner connection and Twilio setup.',
+    },
+    in_setup: {
+      stateLabel: 'In setup',
+      stateVariant: 'secondary',
+      readinessLabel: 'Not ready',
+      readinessVariant: 'outline',
+      nextAction: nextStep.title,
+      summary: 'Onboarding is in progress, but at least one blocking setup step still needs attention.',
+    },
+    needs_attention: {
+      stateLabel: 'Needs attention',
+      stateVariant: 'destructive',
+      readinessLabel: 'Not ready',
+      readinessVariant: 'destructive',
+      nextAction: nextStep.title,
+      summary: 'Something is broken or incomplete enough that the founder should stop and repair it before testing.',
+    },
+    waiting_on_a2p: {
+      stateLabel: 'Waiting on A2P',
+      stateVariant: 'secondary',
+      readinessLabel: 'Waiting on external approval',
+      readinessVariant: 'secondary',
+      nextAction: 'Wait for Twilio approval',
+      summary: 'Infrastructure is in place, but compliant messaging is still waiting on Twilio or carrier review.',
+    },
+    ready_for_test: {
+      stateLabel: 'Ready for test',
+      stateVariant: 'secondary',
+      readinessLabel: 'Ready for test',
+      readinessVariant: 'secondary',
+      nextAction: hasTestSmsSuccess ? 'Run a real missed-call test' : 'Send a test SMS',
+      summary: 'The business looks ready for operator-led validation. Run the checks before you mark it live.',
+    },
+    ready_to_go_live: {
+      stateLabel: 'Ready to go live',
+      stateVariant: 'success',
+      readinessLabel: 'Ready for live',
+      readinessVariant: 'success',
+      nextAction: 'Mark this business live',
+      summary: 'Setup, compliance, and operator validation checks are in place for a clean launch decision.',
+    },
+    live: {
+      stateLabel: 'Live',
+      stateVariant: 'success',
+      readinessLabel: 'Ready for live',
+      readinessVariant: 'success',
+      nextAction: 'Monitor normal activity',
+      summary: 'This business is live and the operator confidence checks are green.',
+    },
+    live_with_warnings: {
+      stateLabel: 'Live with warnings',
+      stateVariant: 'destructive',
+      readinessLabel: 'Live with warnings',
+      readinessVariant: 'destructive',
+      nextAction: nextStep.title,
+      summary: 'The business is live, but recent failures or missing validations mean the founder should review it closely.',
+    },
+    archived: {
+      stateLabel: 'Archived',
+      stateVariant: 'outline',
+      readinessLabel: 'Not ready',
+      readinessVariant: 'outline',
+      nextAction: 'Restore business if work should resume',
+      summary: 'Automation is paused because this business is archived.',
+    },
+  };
+
+  return {
+    state,
+    ...stateMeta[state],
+    blockers,
+    milestones,
+    readyForTest,
+    readyForLive,
+    canSafelyMarkLive,
+    hasRecentFailures,
+  } satisfies AdminOnboardingConfidence;
 }
 
 export function matchesAdminBoardFilter(

--- a/lib/admin-provisioning.ts
+++ b/lib/admin-provisioning.ts
@@ -18,6 +18,7 @@ import {
   syncManagedTwilioNumberWebhooks,
   updateManagedTwilioStatus,
 } from '@/lib/managed-twilio';
+import { formatPhoneDetail, maskSid, recordBusinessOperatorEvent } from '@/lib/operator-events';
 import { normalizePhoneNumber } from '@/lib/phone';
 import { getTwilioBusinessClient, hasTwilioClientEnv } from '@/lib/twilio-client';
 import { getTwilioWebhookConfig, syncTwilioIncomingPhoneNumberWebhooks, type TwilioWebhookSyncOptions } from '@/lib/twilio';
@@ -168,6 +169,18 @@ export async function connectOrInviteBusinessOwner(params: {
       }
     );
 
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'onboarding.owner_connected',
+      category: 'ONBOARDING',
+      status: 'SUCCESS',
+      summary: 'Owner connected to business',
+      details: {
+        ownerEmail,
+        ownerClerkId: userId,
+      },
+    });
+
     return { state: 'connected' as const, ownerClerkId: userId };
   }
 
@@ -203,6 +216,18 @@ export async function connectOrInviteBusinessOwner(params: {
       ownerEmail,
     }
   );
+
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'onboarding.owner_invited',
+    category: 'ONBOARDING',
+    status: 'PENDING',
+    summary: 'Owner invite sent',
+    details: {
+      ownerEmail,
+      inviteSentAt: new Date().toISOString(),
+    },
+  });
 
   return { state: 'invited' as const, ownerClerkId: pendingOwnerId };
 }
@@ -315,6 +340,19 @@ export async function syncBusinessTwilioWebhooks(
       provisioningError: null,
     },
   });
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'webhooks.sync_succeeded',
+    category: 'WEBHOOKS',
+    status: 'SUCCESS',
+    summary: 'Webhook sync completed',
+    details: {
+      target: options,
+      phoneNumber: formatPhoneDetail(normalizedPhoneNumber),
+      phoneNumberSid: maskSid(number.sid),
+      syncedAt: syncedAt.toISOString(),
+    },
+  });
 
   return { number, syncedAt };
 }
@@ -401,6 +439,20 @@ export async function attachExistingNumberToBusiness(params: {
     twilioProvisionedAt: new Date(),
     twilioWebhookSyncedAt: syncedNumber.syncedAt,
   });
+  await recordBusinessOperatorEvent({
+    businessId: params.business.id,
+    type: 'provisioning.existing_number_attached',
+    category: 'PROVISIONING',
+    status: 'SUCCESS',
+    summary: 'Existing number attached',
+    details: {
+      phoneNumber: formatPhoneDetail(syncedNumber.phoneNumber),
+      phoneNumberSid: maskSid(syncedNumber.phoneNumberSid),
+      messagingServiceSid: maskSid(messagingServiceSid),
+      subaccountSid: maskSid(subaccountSid),
+      correlationId,
+    },
+  });
 
   return db.business.findUniqueOrThrow({ where: { id: params.business.id } });
 }
@@ -437,6 +489,18 @@ export async function runAdminProvisioning(params: {
       provisioningStatus: BusinessProvisioningStatus.ONBOARDING,
       provisioningLastRunAt: new Date(),
       provisioningError: null,
+    },
+  });
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'provisioning.started',
+    category: 'PROVISIONING',
+    status: 'PENDING',
+    summary: 'Provisioning started',
+    details: {
+      mode: params.mode,
+      areaCode: params.areaCode ?? null,
+      existingNumberSid: maskSid(params.existingNumberSid),
     },
   });
 
@@ -483,6 +547,16 @@ export async function runAdminProvisioning(params: {
         provisioningError: null,
       },
     });
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'provisioning.run_completed',
+      category: 'PROVISIONING',
+      status: 'SUCCESS',
+      summary: 'Provisioning run completed',
+      details: {
+        mode: params.mode,
+      },
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Provisioning failed.';
     await db.business.update({
@@ -491,6 +565,17 @@ export async function runAdminProvisioning(params: {
         provisioningStatus: BusinessProvisioningStatus.NEEDS_ATTENTION,
         provisioningLastRunAt: new Date(),
         provisioningError: message,
+      },
+    });
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'provisioning.failed',
+      category: 'PROVISIONING',
+      status: 'FAILED',
+      summary: 'Provisioning failed',
+      details: {
+        mode: params.mode,
+        error: message,
       },
     });
     throw error;
@@ -502,7 +587,7 @@ export async function updateBusinessProvisioningStatus(
   status: BusinessProvisioningStatus,
   error: string | null = null
 ) {
-  return db.business.update({
+  const updated = await db.business.update({
     where: { id: businessId },
     data: {
       provisioningStatus: status,
@@ -510,4 +595,21 @@ export async function updateBusinessProvisioningStatus(
       provisioningError: error,
     },
   });
+  await recordBusinessOperatorEvent({
+    businessId,
+    type: 'admin.provisioning_status_updated',
+    category: 'ADMIN_ACTIONS',
+    status: status === BusinessProvisioningStatus.PAUSED ? 'WARNING' : 'INFO',
+    summary:
+      status === BusinessProvisioningStatus.PAUSED
+        ? 'Automation paused'
+        : status === BusinessProvisioningStatus.LIVE
+          ? 'Business marked live'
+          : `Provisioning state set to ${status.toLowerCase().replace(/_/g, ' ')}`,
+    details: {
+      provisioningStatus: status,
+      error,
+    },
+  });
+  return updated;
 }

--- a/lib/managed-twilio.ts
+++ b/lib/managed-twilio.ts
@@ -9,6 +9,7 @@ import {
   resolveManagedTwilioStatus,
   type ManagedTwilioSummary,
 } from '@/lib/managed-twilio-status';
+import { formatPhoneDetail, maskSid, recordBusinessOperatorEvent } from '@/lib/operator-events';
 import { normalizePhoneNumber } from '@/lib/phone';
 import { logTwilioInfo } from '@/lib/twilio-logging';
 import { getTwilioWebhookConfig, syncTwilioIncomingPhoneNumberWebhooks } from '@/lib/twilio';
@@ -129,10 +130,38 @@ async function updateManagedTwilioFields(
 }
 
 export async function createSubaccountForBusiness(business: Pick<ManagedTwilioBusiness, 'id' | 'name'>, correlationId = 'n/a') {
+  const existing = await db.business.findUnique({
+    where: { id: business.id },
+    select: { twilioSubaccountSid: true },
+  });
+  if (existing?.twilioSubaccountSid) {
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'provisioning.twilio_subaccount_reused',
+      category: 'PROVISIONING',
+      status: 'INFO',
+      summary: 'Twilio subaccount reused',
+      details: {
+        subaccountSid: maskSid(existing.twilioSubaccountSid),
+        correlationId,
+      },
+    });
+  }
   const subaccountSid = await ensureTwilioSubaccount(business.id, business.name, correlationId);
   await updateManagedTwilioStatus(business.id, ManagedTwilioStatus.PROVISIONING, {
     twilioSubaccountSid: subaccountSid,
     twilioProvisioningStartedAt: new Date(),
+  });
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'provisioning.twilio_subaccount_ready',
+    category: 'PROVISIONING',
+    status: 'SUCCESS',
+    summary: 'Twilio subaccount ready',
+    details: {
+      subaccountSid: maskSid(subaccountSid),
+      correlationId,
+    },
   });
   return subaccountSid;
 }
@@ -142,6 +171,17 @@ export async function createMessagingServiceForBusiness(
   correlationId = 'n/a'
 ) {
   if (business.twilioMessagingServiceSid) {
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'provisioning.messaging_service_reused',
+      category: 'PROVISIONING',
+      status: 'INFO',
+      summary: 'Messaging Service reused',
+      details: {
+        messagingServiceSid: maskSid(business.twilioMessagingServiceSid),
+        correlationId,
+      },
+    });
     return business.twilioMessagingServiceSid;
   }
 
@@ -156,6 +196,18 @@ export async function createMessagingServiceForBusiness(
     twilioSubaccountSid: subaccountSid,
     twilioMessagingServiceSid: service.sid,
     twilioProvisioningStartedAt: new Date(),
+  });
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'provisioning.messaging_service_created',
+    category: 'PROVISIONING',
+    status: 'SUCCESS',
+    summary: 'Messaging Service created',
+    details: {
+      subaccountSid: maskSid(subaccountSid),
+      messagingServiceSid: maskSid(service.sid),
+      correlationId,
+    },
   });
 
   logTwilioInfo('provisioning', 'messaging_service_created', {
@@ -174,6 +226,18 @@ export async function buyOrProvisionPrimaryNumberForBusiness(
 ) {
   const correlationId = options.correlationId ?? 'n/a';
   if (business.twilioPrimaryNumberSid && business.twilioPrimaryPhoneNumber) {
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'provisioning.number_reused',
+      category: 'PROVISIONING',
+      status: 'INFO',
+      summary: 'Business number reused',
+      details: {
+        phoneNumber: formatPhoneDetail(business.twilioPrimaryPhoneNumber),
+        phoneNumberSid: maskSid(business.twilioPrimaryNumberSid),
+        correlationId,
+      },
+    });
     return {
       phoneNumberSid: business.twilioPrimaryNumberSid,
       phoneNumber: business.twilioPrimaryPhoneNumber,
@@ -213,6 +277,19 @@ export async function buyOrProvisionPrimaryNumberForBusiness(
     twilioPhoneNumber: normalized,
     twilioWebhookSyncedAt: syncedAt,
     twilioProvisioningStartedAt: new Date(),
+  });
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'provisioning.number_purchased',
+    category: 'PROVISIONING',
+    status: 'SUCCESS',
+    summary: 'Business number purchased',
+    details: {
+      phoneNumber: formatPhoneDetail(normalized),
+      phoneNumberSid: maskSid(number.sid),
+      areaCode: options.areaCode ?? null,
+      correlationId,
+    },
   });
 
   logTwilioInfo('provisioning', 'primary_number_provisioned', {
@@ -263,6 +340,19 @@ export async function syncManagedTwilioNumberWebhooks(
     twilioPhoneNumber: normalized,
     twilioWebhookSyncedAt: syncedAt,
   });
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'webhooks.sync_succeeded',
+    category: 'WEBHOOKS',
+    status: 'SUCCESS',
+    summary: 'Webhook sync completed',
+    details: {
+      phoneNumber: formatPhoneDetail(normalized),
+      phoneNumberSid: maskSid(number.sid),
+      appBaseUrl: getTwilioWebhookConfig().appBaseUrl,
+      correlationId,
+    },
+  });
 
   logTwilioInfo('provisioning', 'number_webhooks_synced', {
     correlationId,
@@ -298,11 +388,35 @@ export async function attachNumberToMessagingService(
     await client.messaging.v1.services(messagingServiceSid).phoneNumbers.create({
       phoneNumberSid: primaryNumberSid,
     });
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'provisioning.number_attached_to_messaging_service',
+      category: 'PROVISIONING',
+      status: 'SUCCESS',
+      summary: 'Number attached to Messaging Service',
+      details: {
+        messagingServiceSid: maskSid(messagingServiceSid),
+        phoneNumberSid: maskSid(primaryNumberSid),
+        correlationId,
+      },
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : '';
     if (!message.toLowerCase().includes('already')) {
       throw error;
     }
+    await recordBusinessOperatorEvent({
+      businessId: business.id,
+      type: 'provisioning.number_attachment_reused',
+      category: 'PROVISIONING',
+      status: 'INFO',
+      summary: 'Messaging Service already had the business number',
+      details: {
+        messagingServiceSid: maskSid(messagingServiceSid),
+        phoneNumberSid: maskSid(primaryNumberSid),
+        correlationId,
+      },
+    });
   }
 
   logTwilioInfo('provisioning', 'number_attached_to_messaging_service', {
@@ -347,6 +461,17 @@ export async function provisionManagedTwilioForBusiness(
   options: { areaCode?: AreaCodeInput; correlationId?: string } = {}
 ) {
   const correlationId = options.correlationId ?? 'n/a';
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'provisioning.started',
+    category: 'PROVISIONING',
+    status: 'PENDING',
+    summary: 'Provisioning started',
+    details: {
+      areaCode: options.areaCode ?? null,
+      correlationId,
+    },
+  });
   await updateManagedTwilioStatus(business.id, ManagedTwilioStatus.PROVISIONING, {
     twilioProvisioningStartedAt: new Date(),
   });
@@ -411,6 +536,21 @@ export async function provisionManagedTwilioForBusiness(
     twilioPhoneNumber: syncedNumber.phoneNumber,
     twilioWebhookSyncedAt: syncedNumber.syncedAt,
     twilioProvisionedAt: new Date(),
+  });
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'provisioning.completed',
+    category: 'PROVISIONING',
+    status: 'SUCCESS',
+    summary: 'Provisioning completed',
+    details: {
+      subaccountSid: maskSid(subaccountSid),
+      messagingServiceSid: maskSid(messagingServiceSid),
+      phoneNumber: formatPhoneDetail(syncedNumber.phoneNumber),
+      phoneNumberSid: maskSid(syncedNumber.phoneNumberSid),
+      nextStatus,
+      correlationId,
+    },
   });
 
   return db.business.findUniqueOrThrow({ where: { id: business.id } });

--- a/lib/operator-events.ts
+++ b/lib/operator-events.ts
@@ -1,0 +1,247 @@
+import { OperatorEventCategory, OperatorEventStatus, Prisma } from '@prisma/client';
+
+import { db } from '@/lib/db';
+import { maskPhoneForAudit } from '@/lib/phone';
+
+const REDACTED_DETAIL_PATTERNS = /(token|secret|password|signature|authorization|recordingurl|webhookurl)/i;
+
+export type OperatorEventCategoryKey =
+  | 'PROVISIONING'
+  | 'MESSAGING'
+  | 'VOICE'
+  | 'WEBHOOKS'
+  | 'OWNER_ALERTS'
+  | 'ADMIN_ACTIONS'
+  | 'ONBOARDING'
+  | 'ERRORS';
+
+export type OperatorEventStatusKey = 'SUCCESS' | 'PENDING' | 'WARNING' | 'FAILED' | 'INFO';
+
+export type BusinessTimelineFilter = 'all' | 'errors' | 'provisioning' | 'messaging' | 'voice' | 'webhooks' | 'admin';
+
+type OperatorEventDetails =
+  | Prisma.InputJsonObject
+  | Prisma.InputJsonArray
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
+
+type CreateOperatorEventInput = {
+  businessId: string;
+  type: string;
+  category: OperatorEventCategory;
+  status: OperatorEventStatus;
+  summary: string;
+  details?: OperatorEventDetails;
+  relatedEntityType?: string | null;
+  relatedEntityId?: string | null;
+  createdAt?: Date;
+};
+
+export const operatorEventCategoryLabels: Record<OperatorEventCategory, string> = {
+  PROVISIONING: 'Provisioning',
+  MESSAGING: 'Messaging',
+  VOICE: 'Voice',
+  WEBHOOKS: 'Webhooks',
+  OWNER_ALERTS: 'Owner alerts',
+  ADMIN_ACTIONS: 'Admin',
+  ONBOARDING: 'Onboarding',
+  ERRORS: 'Errors',
+};
+
+export const operatorEventStatusLabels: Record<OperatorEventStatus, string> = {
+  SUCCESS: 'Success',
+  PENDING: 'Pending',
+  WARNING: 'Warning',
+  FAILED: 'Failed',
+  INFO: 'Info',
+};
+
+export const businessTimelineFilterOptions: Array<{ key: BusinessTimelineFilter; label: string }> = [
+  { key: 'all', label: 'All' },
+  { key: 'errors', label: 'Errors' },
+  { key: 'provisioning', label: 'Provisioning' },
+  { key: 'messaging', label: 'Messaging' },
+  { key: 'voice', label: 'Voice' },
+  { key: 'webhooks', label: 'Webhooks' },
+  { key: 'admin', label: 'Admin' },
+];
+
+function sanitizeText(value: string | null | undefined, maxLength = 240) {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength - 1)}…` : trimmed;
+}
+
+export function maskSid(value: string | null | undefined) {
+  const trimmed = sanitizeText(value, 128);
+  if (!trimmed) return null;
+  if (trimmed.length <= 8) return trimmed;
+  return `${trimmed.slice(0, 4)}...${trimmed.slice(-4)}`;
+}
+
+function sanitizeJsonValue(value: unknown, depth = 0): Prisma.InputJsonValue | undefined {
+  if (value === null) return undefined;
+  if (value === undefined) return undefined;
+
+  if (typeof value === 'string') {
+    return sanitizeText(value, 500) ?? undefined;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    if (depth >= 3) {
+      return value
+        .slice(0, 8)
+        .map((item) => sanitizeJsonValue(item, depth + 1))
+        .filter((item): item is Prisma.InputJsonValue => item !== undefined);
+    }
+
+    return value
+      .slice(0, 12)
+      .map((item) => sanitizeJsonValue(item, depth + 1))
+      .filter((item): item is Prisma.InputJsonValue => item !== undefined);
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).slice(0, 20);
+    const output: Record<string, Prisma.InputJsonValue> = {};
+
+    for (const [key, raw] of entries) {
+      if (REDACTED_DETAIL_PATTERNS.test(key)) {
+        output[key] = '[redacted]';
+        continue;
+      }
+
+      const sanitized = sanitizeJsonValue(raw, depth + 1);
+      if (sanitized !== undefined) {
+        output[key] = sanitized;
+      }
+    }
+
+    return output as Prisma.InputJsonObject;
+  }
+
+  return sanitizeText(String(value), 200) ?? undefined;
+}
+
+export function formatPhoneDetail(value: string | null | undefined) {
+  return maskPhoneForAudit(value);
+}
+
+export function buildTimelineWhereClause(businessId: string, filter: BusinessTimelineFilter): Prisma.BusinessOperatorEventWhereInput {
+  if (filter === 'errors') {
+    return {
+      businessId,
+      status: { in: [OperatorEventStatus.FAILED, OperatorEventStatus.WARNING] },
+    };
+  }
+
+  if (filter === 'provisioning') {
+    return {
+      businessId,
+      category: { in: [OperatorEventCategory.PROVISIONING, OperatorEventCategory.ONBOARDING] },
+    };
+  }
+
+  if (filter === 'messaging') {
+    return {
+      businessId,
+      category: { in: [OperatorEventCategory.MESSAGING, OperatorEventCategory.OWNER_ALERTS] },
+    };
+  }
+
+  if (filter === 'voice') {
+    return {
+      businessId,
+      category: OperatorEventCategory.VOICE,
+    };
+  }
+
+  if (filter === 'webhooks') {
+    return {
+      businessId,
+      category: OperatorEventCategory.WEBHOOKS,
+    };
+  }
+
+  if (filter === 'admin') {
+    return {
+      businessId,
+      category: OperatorEventCategory.ADMIN_ACTIONS,
+    };
+  }
+
+  return { businessId };
+}
+
+export function matchesTimelineFilter(
+  event: { category: OperatorEventCategory; status: OperatorEventStatus },
+  filter: BusinessTimelineFilter
+) {
+  if (filter === 'all') return true;
+  if (filter === 'errors') return event.status === OperatorEventStatus.FAILED || event.status === OperatorEventStatus.WARNING;
+  if (filter === 'provisioning') {
+    return event.category === OperatorEventCategory.PROVISIONING || event.category === OperatorEventCategory.ONBOARDING;
+  }
+  if (filter === 'messaging') {
+    return event.category === OperatorEventCategory.MESSAGING || event.category === OperatorEventCategory.OWNER_ALERTS;
+  }
+  if (filter === 'voice') return event.category === OperatorEventCategory.VOICE;
+  if (filter === 'webhooks') return event.category === OperatorEventCategory.WEBHOOKS;
+  if (filter === 'admin') return event.category === OperatorEventCategory.ADMIN_ACTIONS;
+  return true;
+}
+
+export function countTimelineFilters(events: Array<{ category: OperatorEventCategory; status: OperatorEventStatus }>) {
+  return new Map(
+    businessTimelineFilterOptions.map((option) => [
+      option.key,
+      events.filter((event) => matchesTimelineFilter(event, option.key)).length,
+    ])
+  );
+}
+
+export async function listBusinessOperatorEvents(businessId: string, filter: BusinessTimelineFilter = 'all', take = 120) {
+  return db.businessOperatorEvent.findMany({
+    where: buildTimelineWhereClause(businessId, filter),
+    orderBy: { createdAt: 'desc' },
+    take,
+  });
+}
+
+export async function recordBusinessOperatorEvent(input: CreateOperatorEventInput) {
+  try {
+    return await db.businessOperatorEvent.create({
+      data: {
+        businessId: input.businessId,
+        type: sanitizeText(input.type, 120) || 'unknown_event',
+        category: input.category,
+        status: input.status,
+        summary: sanitizeText(input.summary, 220) || 'Event recorded',
+        detailsJson: sanitizeJsonValue(input.details) ?? undefined,
+        relatedEntityType: sanitizeText(input.relatedEntityType, 80),
+        relatedEntityId: sanitizeText(input.relatedEntityId, 128),
+        createdAt: input.createdAt,
+      },
+    });
+  } catch (error) {
+    console.error('operator_event_write_failed', {
+      businessId: input.businessId,
+      type: input.type,
+      category: input.category,
+      status: input.status,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}

--- a/lib/owner-notifications.ts
+++ b/lib/owner-notifications.ts
@@ -6,6 +6,7 @@ import { getEffectiveBusinessNotificationSettings } from '@/lib/business-notific
 import { db } from '@/lib/db';
 import { sendTransactionalEmail } from '@/lib/email';
 import { buildLeadSummary, getLeadServiceType, isLeadQualified } from '@/lib/lead-qualification';
+import { formatPhoneDetail, recordBusinessOperatorEvent } from '@/lib/operator-events';
 import { formatPhoneForDisplay } from '@/lib/phone';
 import { logTwilioError, logTwilioInfo, logTwilioWarn } from '@/lib/twilio-logging';
 import { sendAndPersistOutboundMessage } from '@/lib/twilio-messaging';
@@ -166,6 +167,19 @@ export async function sendOwnerLeadSms(leadId: string) {
       status: OwnerNotificationStatus.SKIPPED,
       error: 'SMS notifications disabled',
     });
+    await recordBusinessOperatorEvent({
+      businessId: lead.businessId,
+      type: 'owner_alert.sms_skipped',
+      category: 'OWNER_ALERTS',
+      status: 'WARNING',
+      summary: 'Owner SMS alert skipped',
+      details: {
+        reason: 'SMS notifications disabled',
+        destinationPhone: formatPhoneDetail(destination),
+      },
+      relatedEntityType: 'lead',
+      relatedEntityId: leadId,
+    });
     return { status: 'skipped' as const };
   }
 
@@ -174,6 +188,19 @@ export async function sendOwnerLeadSms(leadId: string) {
       status: OwnerNotificationStatus.SKIPPED,
       error: 'Missing owner phone or business texting number',
     });
+    await recordBusinessOperatorEvent({
+      businessId: lead.businessId,
+      type: 'owner_alert.sms_skipped',
+      category: 'OWNER_ALERTS',
+      status: 'WARNING',
+      summary: 'Owner SMS alert skipped',
+      details: {
+        reason: 'Missing owner phone or business texting number',
+        destinationPhone: formatPhoneDetail(destination),
+      },
+      relatedEntityType: 'lead',
+      relatedEntityId: leadId,
+    });
     return { status: 'skipped' as const };
   }
 
@@ -181,6 +208,19 @@ export async function sendOwnerLeadSms(leadId: string) {
     await markNotificationResult(leadId, OwnerNotificationChannel.SMS, {
       status: OwnerNotificationStatus.SENT,
       metadata: { simulated: true, preview: true },
+    });
+    await recordBusinessOperatorEvent({
+      businessId: lead.businessId,
+      type: 'owner_alert.sms_sent',
+      category: 'OWNER_ALERTS',
+      status: 'SUCCESS',
+      summary: 'Owner SMS alert recorded for simulator',
+      details: {
+        destinationPhone: formatPhoneDetail(destination),
+        simulated: true,
+      },
+      relatedEntityType: 'lead',
+      relatedEntityId: leadId,
     });
     return { status: 'simulated' as const };
   }
@@ -204,6 +244,19 @@ export async function sendOwnerLeadSms(leadId: string) {
         status: OwnerNotificationStatus.SKIPPED,
         error: result.reason,
       });
+      await recordBusinessOperatorEvent({
+        businessId: lead.businessId,
+        type: 'owner_alert.sms_skipped',
+        category: 'OWNER_ALERTS',
+        status: 'WARNING',
+        summary: 'Owner SMS alert skipped',
+        details: {
+          reason: result.reason,
+          destinationPhone: formatPhoneDetail(destination),
+        },
+        relatedEntityType: 'lead',
+        relatedEntityId: leadId,
+      });
       logTwilioWarn('sms', 'owner_lead_sms_skipped', { leadId, businessId: lead.businessId, decision: result.reason });
       return { status: 'skipped' as const };
     }
@@ -212,12 +265,37 @@ export async function sendOwnerLeadSms(leadId: string) {
       status: OwnerNotificationStatus.SENT,
       metadata: { twilioSid: result.sent.sid, provider: 'twilio' },
     });
+    await recordBusinessOperatorEvent({
+      businessId: lead.businessId,
+      type: 'owner_alert.sms_sent',
+      category: 'OWNER_ALERTS',
+      status: 'SUCCESS',
+      summary: 'Owner SMS alert sent',
+      details: {
+        destinationPhone: formatPhoneDetail(destination),
+      },
+      relatedEntityType: 'lead',
+      relatedEntityId: leadId,
+    });
 
     return { status: 'sent' as const };
   } catch (error) {
     await markNotificationResult(leadId, OwnerNotificationChannel.SMS, {
       status: OwnerNotificationStatus.FAILED,
       error: error instanceof Error ? error.message : String(error),
+    });
+    await recordBusinessOperatorEvent({
+      businessId: lead.businessId,
+      type: 'owner_alert.sms_failed',
+      category: 'OWNER_ALERTS',
+      status: 'FAILED',
+      summary: 'Owner SMS alert failed',
+      details: {
+        destinationPhone: formatPhoneDetail(destination),
+        error: error instanceof Error ? error.message : String(error),
+      },
+      relatedEntityType: 'lead',
+      relatedEntityId: leadId,
     });
     logTwilioError('sms', 'owner_lead_sms_failed', { leadId, businessId: lead.businessId, decision: 'owner_sms_failed' }, error);
     return { status: 'failed' as const };
@@ -244,6 +322,19 @@ export async function sendOwnerLeadEmail(leadId: string) {
       status: OwnerNotificationStatus.SKIPPED,
       error: 'Email notifications disabled',
     });
+    await recordBusinessOperatorEvent({
+      businessId: lead.businessId,
+      type: 'owner_alert.email_skipped',
+      category: 'OWNER_ALERTS',
+      status: 'WARNING',
+      summary: 'Owner email alert skipped',
+      details: {
+        reason: 'Email notifications disabled',
+        destinationEmail: settings.ownerEmail,
+      },
+      relatedEntityType: 'lead',
+      relatedEntityId: leadId,
+    });
     return { status: 'skipped' as const };
   }
 
@@ -252,6 +343,18 @@ export async function sendOwnerLeadEmail(leadId: string) {
       status: OwnerNotificationStatus.SKIPPED,
       error: 'Missing owner email',
     });
+    await recordBusinessOperatorEvent({
+      businessId: lead.businessId,
+      type: 'owner_alert.email_skipped',
+      category: 'OWNER_ALERTS',
+      status: 'WARNING',
+      summary: 'Owner email alert skipped',
+      details: {
+        reason: 'Missing owner email',
+      },
+      relatedEntityType: 'lead',
+      relatedEntityId: leadId,
+    });
     return { status: 'skipped' as const };
   }
 
@@ -259,6 +362,19 @@ export async function sendOwnerLeadEmail(leadId: string) {
     await markNotificationResult(leadId, OwnerNotificationChannel.EMAIL, {
       status: OwnerNotificationStatus.SENT,
       metadata: { simulated: true, preview: true },
+    });
+    await recordBusinessOperatorEvent({
+      businessId: lead.businessId,
+      type: 'owner_alert.email_sent',
+      category: 'OWNER_ALERTS',
+      status: 'SUCCESS',
+      summary: 'Owner email alert recorded for simulator',
+      details: {
+        destinationEmail: settings.ownerEmail,
+        simulated: true,
+      },
+      relatedEntityType: 'lead',
+      relatedEntityId: leadId,
     });
     return { status: 'simulated' as const };
   }
@@ -269,12 +385,38 @@ export async function sendOwnerLeadEmail(leadId: string) {
       status: result.reason === 'missing_config' ? OwnerNotificationStatus.SKIPPED : OwnerNotificationStatus.FAILED,
       error: result.error || result.reason,
     });
+    await recordBusinessOperatorEvent({
+      businessId: lead.businessId,
+      type: result.reason === 'missing_config' ? 'owner_alert.email_skipped' : 'owner_alert.email_failed',
+      category: 'OWNER_ALERTS',
+      status: result.reason === 'missing_config' ? 'WARNING' : 'FAILED',
+      summary: result.reason === 'missing_config' ? 'Owner email alert skipped' : 'Owner email alert failed',
+      details: {
+        destinationEmail: settings.ownerEmail,
+        error: result.error || result.reason,
+      },
+      relatedEntityType: 'lead',
+      relatedEntityId: leadId,
+    });
     return { status: result.reason === 'missing_config' ? 'skipped' as const : 'failed' as const };
   }
 
   await markNotificationResult(leadId, OwnerNotificationChannel.EMAIL, {
     status: OwnerNotificationStatus.SENT,
     metadata: { provider: result.provider },
+  });
+  await recordBusinessOperatorEvent({
+    businessId: lead.businessId,
+    type: 'owner_alert.email_sent',
+    category: 'OWNER_ALERTS',
+    status: 'SUCCESS',
+    summary: 'Owner email alert sent',
+    details: {
+      destinationEmail: settings.ownerEmail,
+      provider: result.provider,
+    },
+    relatedEntityType: 'lead',
+    relatedEntityId: leadId,
   });
   return { status: 'sent' as const };
 }
@@ -298,12 +440,36 @@ export async function createOwnerInAppNotification(leadId: string) {
       status: OwnerNotificationStatus.SKIPPED,
       error: 'In-app notifications disabled',
     });
+    await recordBusinessOperatorEvent({
+      businessId: lead.businessId,
+      type: 'owner_alert.in_app_skipped',
+      category: 'OWNER_ALERTS',
+      status: 'WARNING',
+      summary: 'In-app owner alert skipped',
+      details: {
+        reason: 'In-app notifications disabled',
+      },
+      relatedEntityType: 'lead',
+      relatedEntityId: leadId,
+    });
     return { status: 'skipped' as const };
   }
 
   await markNotificationResult(leadId, OwnerNotificationChannel.IN_APP, {
     status: OwnerNotificationStatus.SENT,
     metadata: { dashboardVisible: true },
+  });
+  await recordBusinessOperatorEvent({
+    businessId: lead.businessId,
+    type: 'owner_alert.in_app_sent',
+    category: 'OWNER_ALERTS',
+    status: 'SUCCESS',
+    summary: 'In-app owner alert created',
+    details: {
+      dashboardVisible: true,
+    },
+    relatedEntityType: 'lead',
+    relatedEntityId: leadId,
   });
   return { status: 'sent' as const };
 }

--- a/lib/twilio-messaging.ts
+++ b/lib/twilio-messaging.ts
@@ -2,6 +2,7 @@ import { ManagedTwilioStatus, Prisma, MessageParticipant } from '@prisma/client'
 
 import { db } from '@/lib/db';
 import { getManagedTwilioStatusSummary } from '@/lib/managed-twilio';
+import { formatPhoneDetail, recordBusinessOperatorEvent } from '@/lib/operator-events';
 import { normalizePhoneNumber } from '@/lib/phone';
 import { logTwilioError, logTwilioInfo, logTwilioWarn } from '@/lib/twilio-logging';
 import { isSmsRecipientOptedOut } from '@/lib/twilio-sms-compliance';
@@ -51,6 +52,21 @@ export async function persistInboundMessage(params: {
     throw error;
   }
 
+  await recordBusinessOperatorEvent({
+    businessId: params.businessId,
+    type: 'messaging.inbound_sms_received',
+    category: 'MESSAGING',
+    status: 'INFO',
+    summary: 'Inbound SMS received',
+    details: {
+      fromPhone: formatPhoneDetail(normalizedFrom),
+      toPhone: formatPhoneDetail(normalizedTo),
+      bodyPreview: params.body.slice(0, 80),
+    },
+    relatedEntityType: params.leadId ? 'lead' : 'message',
+    relatedEntityId: params.leadId ?? message.id,
+  });
+
   return { message, duplicate: false };
 }
 
@@ -70,8 +86,23 @@ export async function sendAndPersistOutboundMessage(params: {
   const from = normalizePhoneNumber(params.fromPhone) || params.fromPhone;
   const to = normalizePhoneNumber(params.toPhone) || params.toPhone;
   const participant = params.participant ?? 'LEAD';
+  const recipientLabel = participant === 'OWNER' ? 'owner SMS' : 'lead SMS';
 
   if (await isSmsRecipientOptedOut({ businessId: params.businessId, phone: to })) {
+    await recordBusinessOperatorEvent({
+      businessId: params.businessId,
+      type: 'messaging.outbound_sms_suppressed',
+      category: 'MESSAGING',
+      status: 'WARNING',
+      summary: `Outbound ${recipientLabel} suppressed`,
+      details: {
+        reason: 'recipient_opted_out',
+        toPhone: formatPhoneDetail(to),
+        participant,
+      },
+      relatedEntityType: params.leadId ? 'lead' : null,
+      relatedEntityId: params.leadId ?? null,
+    });
     logTwilioWarn('messaging', 'outbound_suppressed_opted_out', {
       decision: 'suppress_opted_out',
       businessId: params.businessId,
@@ -112,6 +143,20 @@ export async function sendAndPersistOutboundMessage(params: {
         ? 'managed_twilio_compliance_blocked'
         : 'managed_twilio_compliance_pending';
 
+    await recordBusinessOperatorEvent({
+      businessId: params.businessId,
+      type: 'messaging.outbound_sms_suppressed',
+      category: 'MESSAGING',
+      status: 'WARNING',
+      summary: `Outbound ${recipientLabel} suppressed`,
+      details: {
+        reason,
+        participant,
+        nextStep: managedSummary.nextStep,
+      },
+      relatedEntityType: params.leadId ? 'lead' : null,
+      relatedEntityId: params.leadId ?? null,
+    });
     logTwilioWarn('messaging', 'outbound_suppressed_managed_twilio_not_ready', {
       decision: reason,
       businessId: params.businessId,
@@ -125,6 +170,21 @@ export async function sendAndPersistOutboundMessage(params: {
       reason,
     };
   }
+
+  await recordBusinessOperatorEvent({
+    businessId: params.businessId,
+    type: 'messaging.outbound_sms_requested',
+    category: 'MESSAGING',
+    status: 'PENDING',
+    summary: `Outbound ${recipientLabel} requested`,
+    details: {
+      fromPhone: formatPhoneDetail(from),
+      toPhone: formatPhoneDetail(to),
+      participant,
+    },
+    relatedEntityType: params.leadId ? 'lead' : null,
+    relatedEntityId: params.leadId ?? null,
+  });
 
   const client = getTwilioBusinessClient(params.twilioSubaccountSid);
   const sent = await client.messages.create(
@@ -151,6 +211,21 @@ export async function sendAndPersistOutboundMessage(params: {
     twilioSid: sent.sid,
     status: sent.status,
     twilioCreatedAt: sent.dateCreated ?? undefined,
+  });
+  await recordBusinessOperatorEvent({
+    businessId: params.businessId,
+    type: 'messaging.outbound_sms_accepted',
+    category: 'MESSAGING',
+    status: 'SUCCESS',
+    summary: `Outbound ${recipientLabel} accepted by Twilio`,
+    details: {
+      fromPhone: formatPhoneDetail(from),
+      toPhone: formatPhoneDetail(to),
+      messageStatus: sent.status,
+      participant,
+    },
+    relatedEntityType: params.leadId ? 'lead' : 'message',
+    relatedEntityId: params.leadId ?? message.id,
   });
 
   logTwilioInfo('messaging', 'outbound_sent_and_persisted', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3637,7 +3637,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/prisma/migrations/20260418120000_add_business_operator_events/migration.sql
+++ b/prisma/migrations/20260418120000_add_business_operator_events/migration.sql
@@ -1,0 +1,48 @@
+-- CreateEnum
+CREATE TYPE "OperatorEventCategory" AS ENUM (
+    'PROVISIONING',
+    'MESSAGING',
+    'VOICE',
+    'WEBHOOKS',
+    'OWNER_ALERTS',
+    'ADMIN_ACTIONS',
+    'ONBOARDING',
+    'ERRORS'
+);
+
+-- CreateEnum
+CREATE TYPE "OperatorEventStatus" AS ENUM (
+    'SUCCESS',
+    'PENDING',
+    'WARNING',
+    'FAILED',
+    'INFO'
+);
+
+-- CreateTable
+CREATE TABLE "BusinessOperatorEvent" (
+    "id" TEXT NOT NULL,
+    "businessId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "category" "OperatorEventCategory" NOT NULL,
+    "status" "OperatorEventStatus" NOT NULL,
+    "summary" TEXT NOT NULL,
+    "detailsJson" JSONB,
+    "relatedEntityType" TEXT,
+    "relatedEntityId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BusinessOperatorEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BusinessOperatorEvent_businessId_createdAt_idx" ON "BusinessOperatorEvent"("businessId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "BusinessOperatorEvent_businessId_category_createdAt_idx" ON "BusinessOperatorEvent"("businessId", "category", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "BusinessOperatorEvent_businessId_status_createdAt_idx" ON "BusinessOperatorEvent"("businessId", "status", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "BusinessOperatorEvent" ADD CONSTRAINT "BusinessOperatorEvent_businessId_fkey" FOREIGN KEY ("businessId") REFERENCES "Business"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,7 @@ model Business {
   leads                       Lead[]
   messages                    Message[]
   ownerNotifications          OwnerNotification[]
+  operatorEvents              BusinessOperatorEvent[]
   notificationSettings        BusinessNotificationSettings?
   simulatorRuns               SimulatorRun[]
   smsConsents                 SmsConsent[]
@@ -190,6 +191,24 @@ model OwnerNotification {
   @@index([leadId, status])
 }
 
+model BusinessOperatorEvent {
+  id                String                @id @default(cuid())
+  businessId        String
+  type              String
+  category          OperatorEventCategory
+  status            OperatorEventStatus
+  summary           String
+  detailsJson       Json?
+  relatedEntityType String?
+  relatedEntityId   String?
+  createdAt         DateTime              @default(now())
+  business          Business              @relation(fields: [businessId], references: [id], onDelete: Cascade)
+
+  @@index([businessId, createdAt])
+  @@index([businessId, category, createdAt])
+  @@index([businessId, status, createdAt])
+}
+
 model BusinessNotificationSettings {
   id          String   @id @default(cuid())
   businessId  String   @unique
@@ -297,6 +316,25 @@ enum OwnerNotificationStatus {
   SENT
   FAILED
   SKIPPED
+}
+
+enum OperatorEventCategory {
+  PROVISIONING
+  MESSAGING
+  VOICE
+  WEBHOOKS
+  OWNER_ALERTS
+  ADMIN_ACTIONS
+  ONBOARDING
+  ERRORS
+}
+
+enum OperatorEventStatus {
+  SUCCESS
+  PENDING
+  WARNING
+  FAILED
+  INFO
 }
 
 enum SimulatorRunStatus {

--- a/tests/admin-dashboard.test.ts
+++ b/tests/admin-dashboard.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { BusinessProvisioningStatus, ManagedTwilioStatus, SubscriptionStatus } from '@prisma/client';
+import { BusinessProvisioningStatus, ManagedTwilioStatus, OperatorEventStatus, SubscriptionStatus } from '@prisma/client';
 
 import {
+  buildAdminOnboardingConfidence,
   buildAdminBusinessEvents,
   buildAdminNextStep,
   canDeleteTestBusiness,
@@ -170,4 +171,81 @@ test('recent event synthesis prioritizes provisioning failures and owner alert f
   assert.equal(events[0]?.label, 'Provisioning');
   assert.equal(events.some((event) => event.label === 'Owner sms alert' && event.severity === 'error'), true);
   assert.equal(events.some((event) => event.label === 'Lead SMS' && event.severity === 'error'), true);
+});
+
+test('onboarding confidence distinguishes ready-for-test from ready-for-live', () => {
+  const readyForTest = buildAdminOnboardingConfidence({
+    business: createBusiness({
+      managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+      a2pApprovedAt: new Date('2026-04-17T00:00:00.000Z'),
+    }),
+    notificationSettings: createNotificationSettings(),
+    ownerConnected: true,
+    successfulLeadCount: 0,
+    operatorEvents: [],
+  });
+
+  assert.equal(readyForTest.state, 'ready_for_test');
+  assert.equal(readyForTest.readyForTest, true);
+  assert.equal(readyForTest.canSafelyMarkLive, false);
+  assert.match(readyForTest.nextAction, /test/i);
+
+  const readyForLive = buildAdminOnboardingConfidence({
+    business: createBusiness({
+      managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+      a2pApprovedAt: new Date('2026-04-17T00:00:00.000Z'),
+    }),
+    notificationSettings: createNotificationSettings(),
+    ownerConnected: true,
+    successfulLeadCount: 1,
+    operatorEvents: [
+      {
+        type: 'admin.test_sms_accepted',
+        status: OperatorEventStatus.SUCCESS,
+        createdAt: new Date('2026-04-17T12:00:00.000Z'),
+      },
+    ],
+  });
+
+  assert.equal(readyForLive.state, 'ready_to_go_live');
+  assert.equal(readyForLive.canSafelyMarkLive, true);
+  assert.equal(readyForLive.readinessLabel, 'Ready for live');
+});
+
+test('onboarding confidence stays honest when A2P is pending or live has warnings', () => {
+  const waitingOnA2p = buildAdminOnboardingConfidence({
+    business: createBusiness({
+      managedTwilioStatus: ManagedTwilioStatus.CAMPAIGN_SUBMITTED,
+      a2pApprovedAt: null,
+    }),
+    notificationSettings: createNotificationSettings(),
+    ownerConnected: true,
+    successfulLeadCount: 0,
+    operatorEvents: [],
+  });
+
+  assert.equal(waitingOnA2p.state, 'waiting_on_a2p');
+  assert.equal(waitingOnA2p.readinessLabel, 'Waiting on external approval');
+
+  const liveWithWarnings = buildAdminOnboardingConfidence({
+    business: createBusiness({
+      provisioningStatus: BusinessProvisioningStatus.LIVE,
+      managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+      a2pApprovedAt: new Date('2026-04-17T00:00:00.000Z'),
+    }),
+    notificationSettings: createNotificationSettings(),
+    ownerConnected: true,
+    successfulLeadCount: 0,
+    operatorEvents: [
+      {
+        type: 'admin.test_sms_failed',
+        status: OperatorEventStatus.FAILED,
+        createdAt: new Date('2026-04-17T12:00:00.000Z'),
+      },
+    ],
+  });
+
+  assert.equal(liveWithWarnings.state, 'live_with_warnings');
+  assert.equal(liveWithWarnings.canSafelyMarkLive, false);
+  assert.equal(liveWithWarnings.readinessLabel, 'Live with warnings');
 });

--- a/tests/admin-operator-routes.test.ts
+++ b/tests/admin-operator-routes.test.ts
@@ -15,13 +15,13 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminHome, /Fast onboard/);
   assert.match(adminHome, /Business triage board/);
   assert.match(adminHome, /Open customer leads/);
-  assert.match(adminDetail, /What should I do next\?/);
+  assert.match(adminDetail, /Onboarding confidence/);
   assert.match(adminDetail, /Business info/);
   assert.match(adminDetail, /Provisioning health/);
   assert.match(adminDetail, /Messaging \/ A2P readiness/);
   assert.match(adminDetail, /Automation settings/);
   assert.match(adminDetail, /Account \/ commercial state/);
-  assert.match(adminDetail, /Recent events \/ troubleshooting/);
+  assert.match(adminDetail, /Recent activity/);
   assert.match(adminDetail, /Advanced \/ rare actions/);
   assert.match(adminDetail, /Send test SMS/);
   assert.match(supportWorkspace, /support mode workspace/);

--- a/tests/operator-events.test.ts
+++ b/tests/operator-events.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { OperatorEventCategory, OperatorEventStatus } from '@prisma/client';
+
+import { db } from '../lib/db.ts';
+import { countTimelineFilters, listBusinessOperatorEvents, recordBusinessOperatorEvent } from '../lib/operator-events.ts';
+import { cleanupTenantFixtures, seedTenantFixtures } from './tenant-fixtures.ts';
+
+test('timeline filter counts group operator events into founder-facing buckets', () => {
+  const counts = countTimelineFilters([
+    { category: OperatorEventCategory.PROVISIONING, status: OperatorEventStatus.SUCCESS },
+    { category: OperatorEventCategory.MESSAGING, status: OperatorEventStatus.FAILED },
+    { category: OperatorEventCategory.WEBHOOKS, status: OperatorEventStatus.WARNING },
+    { category: OperatorEventCategory.ADMIN_ACTIONS, status: OperatorEventStatus.INFO },
+  ]);
+
+  assert.equal(counts.get('all'), 4);
+  assert.equal(counts.get('errors'), 2);
+  assert.equal(counts.get('provisioning'), 1);
+  assert.equal(counts.get('messaging'), 1);
+  assert.equal(counts.get('webhooks'), 1);
+  assert.equal(counts.get('admin'), 1);
+});
+
+test('business operator event reads stay business-scoped', async () => {
+  const fixtures = await seedTenantFixtures();
+
+  try {
+    await recordBusinessOperatorEvent({
+      businessId: fixtures.businessA.id,
+      type: 'admin.test_sms_accepted',
+      category: OperatorEventCategory.ADMIN_ACTIONS,
+      status: OperatorEventStatus.SUCCESS,
+      summary: 'Test SMS accepted by Twilio',
+      details: { destinationPhone: 'US***1234' },
+    });
+    await recordBusinessOperatorEvent({
+      businessId: fixtures.businessB.id,
+      type: 'webhooks.sync_failed',
+      category: OperatorEventCategory.WEBHOOKS,
+      status: OperatorEventStatus.FAILED,
+      summary: 'Webhook sync failed',
+      details: { error: 'Mismatch detected' },
+    });
+
+    const eventsForA = await listBusinessOperatorEvents(fixtures.businessA.id);
+    const eventsForB = await listBusinessOperatorEvents(fixtures.businessB.id);
+
+    assert.equal(eventsForA.length, 1);
+    assert.equal(eventsForA[0]?.businessId, fixtures.businessA.id);
+    assert.equal(eventsForA[0]?.summary, 'Test SMS accepted by Twilio');
+    assert.equal(eventsForB.length, 1);
+    assert.equal(eventsForB[0]?.businessId, fixtures.businessB.id);
+
+    const directLeak = await db.businessOperatorEvent.findMany({
+      where: { businessId: fixtures.businessA.id },
+      select: { businessId: true },
+    });
+    assert.deepEqual(directLeak.map((event) => event.businessId), [fixtures.businessA.id]);
+  } finally {
+    await cleanupTenantFixtures({
+      businessAId: fixtures.businessA.id,
+      businessBId: fixtures.businessB.id,
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add a business-scoped operator event model and safe event logging helper
- log high-value provisioning, webhook, messaging, voice, owner-alert, and admin lifecycle events
- replace synthetic recent-events guessing with a filtered business timeline and onboarding confidence gate

## Validation
- npm install
- npx prisma generate
- npx prisma migrate deploy
- npx prisma migrate status
- npm run env:check
- npm run preflight:providers
- npm run typecheck
- npm run lint
- npm run test
- npm run build