### PR TITLE
[codex] Improve admin business picker and test delete

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -12,8 +12,9 @@ import {
   syncBusinessTwilioWebhooks,
   updateBusinessProvisioningStatus,
 } from '@/lib/admin-provisioning';
+import { deleteDeletableTestBusiness } from '@/lib/admin-business-lifecycle';
 import { requireAdmin } from '@/lib/admin';
-import { canDeleteTestBusiness } from '@/lib/admin-dashboard';
+import { canDeleteTestBusiness, getDeleteTestBusinessBlockedReason } from '@/lib/admin-dashboard';
 import { logAuditEvent } from '@/lib/audit-log';
 import { db } from '@/lib/db';
 import { formatPhoneDetail, maskSid, recordBusinessOperatorEvent } from '@/lib/operator-events';
@@ -40,6 +41,50 @@ const DEFAULT_DEMO_FORWARDING_NUMBER = '+15005550001';
 function getString(formData: FormData, key: string) {
   const value = formData.get(key);
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function getAdminReturnPath(returnTo: string | null | undefined) {
+  const trimmed = returnTo?.trim() || '';
+  if (!trimmed.startsWith('/admin')) return null;
+  return trimmed;
+}
+
+function appendParamsToAdminPath(
+  path: string | null | undefined,
+  params: Record<string, string | number | boolean | null | undefined>,
+  fallback: string
+) {
+  const base = getAdminReturnPath(path);
+  if (!base) return fallback;
+
+  const url = new URL(base, 'http://callbackcloser.local');
+  for (const [key, value] of Object.entries(params)) {
+    if (value === null || value === undefined || value === '') continue;
+    url.searchParams.set(key, String(value));
+  }
+
+  const query = url.searchParams.toString();
+  return query ? `${url.pathname}?${query}` : url.pathname;
+}
+
+function clearBusinessSelectionFromReturnPath(
+  path: string | null | undefined,
+  params: Record<string, string | number | boolean | null | undefined>,
+  fallback: string
+) {
+  const base = getAdminReturnPath(path);
+  if (!base) return fallback;
+
+  const url = new URL(base, 'http://callbackcloser.local');
+  url.searchParams.delete('businessId');
+  url.searchParams.delete('q');
+  for (const [key, value] of Object.entries(params)) {
+    if (value === null || value === undefined || value === '') continue;
+    url.searchParams.set(key, String(value));
+  }
+
+  const query = url.searchParams.toString();
+  return query ? `${url.pathname}?${query}` : url.pathname;
 }
 
 function buildAdminBusinessRedirectPath(
@@ -183,7 +228,7 @@ export async function createDemoBusinessAction(formData: FormData) {
   });
 
   await revalidateAdminPaths(business.id);
-  redirect(`/admin?createdDemo=1&businessId=${encodeURIComponent(business.id)}`);
+  redirect(`/admin?createdDemo=1&createdBusinessId=${encodeURIComponent(business.id)}`);
 }
 
 export async function createAdminBusinessAction(formData: FormData) {
@@ -823,11 +868,17 @@ export async function archiveBusinessAction(formData: FormData) {
 
   const business = await loadBusinessForLifecycleAction(parsed.data.businessId);
   if (!business) {
-    redirect(`/admin?error=${encodeURIComponent('Business not found.')}`);
+    redirect(appendParamsToAdminPath(parsed.data.returnTo, { error: 'Business not found.' }, `/admin?error=${encodeURIComponent('Business not found.')}`));
   }
 
   if (parsed.data.confirmationName !== business.name) {
-    redirect(buildAdminBusinessRedirectPath(business.id, { error: 'Type the exact business name to archive it.' }));
+    redirect(
+      appendParamsToAdminPath(
+        parsed.data.returnTo,
+        { error: 'Type the exact business name to archive it.' },
+        buildAdminBusinessRedirectPath(business.id, { error: 'Type the exact business name to archive it.' })
+      )
+    );
   }
 
   await db.business.update({
@@ -866,7 +917,9 @@ export async function archiveBusinessAction(formData: FormData) {
   });
 
   await revalidateAdminPaths(business.id);
-  redirect(buildAdminBusinessRedirectPath(business.id, { archived: 1 }));
+  redirect(
+    appendParamsToAdminPath(parsed.data.returnTo, { archived: 1 }, buildAdminBusinessRedirectPath(business.id, { archived: 1 }))
+  );
 }
 
 export async function restoreBusinessAction(formData: FormData) {
@@ -879,11 +932,17 @@ export async function restoreBusinessAction(formData: FormData) {
 
   const business = await loadBusinessForLifecycleAction(parsed.data.businessId);
   if (!business) {
-    redirect(`/admin?error=${encodeURIComponent('Business not found.')}`);
+    redirect(appendParamsToAdminPath(parsed.data.returnTo, { error: 'Business not found.' }, `/admin?error=${encodeURIComponent('Business not found.')}`));
   }
 
   if (parsed.data.confirmationName !== business.name) {
-    redirect(buildAdminBusinessRedirectPath(business.id, { error: 'Type the exact business name to restore it.' }));
+    redirect(
+      appendParamsToAdminPath(
+        parsed.data.returnTo,
+        { error: 'Type the exact business name to restore it.' },
+        buildAdminBusinessRedirectPath(business.id, { error: 'Type the exact business name to restore it.' })
+      )
+    );
   }
 
   await db.business.update({
@@ -920,7 +979,9 @@ export async function restoreBusinessAction(formData: FormData) {
   });
 
   await revalidateAdminPaths(business.id);
-  redirect(buildAdminBusinessRedirectPath(business.id, { restored: 1 }));
+  redirect(
+    appendParamsToAdminPath(parsed.data.returnTo, { restored: 1 }, buildAdminBusinessRedirectPath(business.id, { restored: 1 }))
+  );
 }
 
 export async function deleteTestBusinessAction(formData: FormData) {
@@ -933,22 +994,33 @@ export async function deleteTestBusinessAction(formData: FormData) {
 
   const business = await loadBusinessForLifecycleAction(parsed.data.businessId);
   if (!business) {
-    redirect(`/admin?error=${encodeURIComponent('Business not found.')}`);
+    redirect(appendParamsToAdminPath(parsed.data.returnTo, { error: 'Business not found.' }, `/admin?error=${encodeURIComponent('Business not found.')}`));
   }
 
   if (parsed.data.confirmationName !== business.name) {
-    redirect(buildAdminBusinessRedirectPath(business.id, { error: 'Type the exact business name to delete it.' }));
-  }
-
-  if (!canDeleteTestBusiness(business)) {
     redirect(
-      buildAdminBusinessRedirectPath(business.id, {
-        error: 'Only archived test or demo businesses can be deleted from admin.',
-      })
+      appendParamsToAdminPath(
+        parsed.data.returnTo,
+        { error: 'Type the exact business name to delete it.' },
+        buildAdminBusinessRedirectPath(business.id, { error: 'Type the exact business name to delete it.' })
+      )
     );
   }
 
-  await db.business.delete({ where: { id: business.id } });
+  const deleteBlockedReason = getDeleteTestBusinessBlockedReason(business);
+  if (deleteBlockedReason || !canDeleteTestBusiness(business)) {
+    redirect(
+      appendParamsToAdminPath(
+        parsed.data.returnTo,
+        { error: deleteBlockedReason || 'Only archived demo/test businesses can be deleted.' },
+        buildAdminBusinessRedirectPath(business.id, {
+          error: deleteBlockedReason || 'Only archived demo/test businesses can be deleted.',
+        })
+      )
+    );
+  }
+
+  await deleteDeletableTestBusiness(business.id);
 
   logAuditEvent({
     event: 'admin_test_business_deleted',
@@ -965,5 +1037,5 @@ export async function deleteTestBusinessAction(formData: FormData) {
   });
 
   revalidatePath('/admin');
-  redirect('/admin?deleted=1');
+  redirect(clearBusinessSelectionFromReturnPath(parsed.data.returnTo, { deleted: 1 }, '/admin?deleted=1'));
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,19 +1,26 @@
 import Link from 'next/link';
 
 import {
+  archiveBusinessAction,
   createAdminBusinessAction,
   createDemoBusinessAction,
+  deleteTestBusinessAction,
   provisionBusinessAction,
   resyncBusinessWebhooksAction,
+  restoreBusinessAction,
   sendBusinessTestSmsAction,
 } from '@/app/admin/actions';
 import {
   adminBoardFilterOptions,
+  buildAdminBusinessPickerLabel,
   buildAdminNextStep,
+  canDeleteTestBusiness,
+  getDeleteTestBusinessBlockedReason,
   isBusinessArchived,
   matchesAdminBoardFilter,
   type AdminBoardFilter,
 } from '@/lib/admin-dashboard';
+import { AdminBusinessPicker } from '@/components/admin-business-picker';
 import { requireAdmin } from '@/lib/admin';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
@@ -72,17 +79,43 @@ function compactCopy(value: string, maxLength = 110) {
   return `${trimmed.slice(0, maxLength - 1)}…`;
 }
 
+function buildAdminBoardReturnPath(params: {
+  view: AdminBoardFilter;
+  selectedBusinessId?: string | null;
+  query?: string | null;
+}) {
+  const search = new URLSearchParams();
+
+  if (params.view && params.view !== 'all') {
+    search.set('view', params.view);
+  }
+
+  if (params.query) {
+    search.set('q', params.query);
+  }
+
+  if (params.selectedBusinessId) {
+    search.set('businessId', params.selectedBusinessId);
+  }
+
+  const query = search.toString();
+  return query ? `/admin?${query}` : '/admin';
+}
+
 export default async function AdminPage({ searchParams }: { searchParams?: Record<string, string | string[] | undefined> }) {
   const admin = await requireAdmin();
   const createdDemo = getQueryValue(searchParams, 'createdDemo') === '1';
-  const createdBusinessId = getQueryValue(searchParams, 'businessId');
+  const createdBusinessId = getQueryValue(searchParams, 'createdBusinessId');
+  const selectedBusinessId = getQueryValue(searchParams, 'businessId');
+  const archived = getQueryValue(searchParams, 'archived') === '1';
   const deleted = getQueryValue(searchParams, 'deleted') === '1';
   const error = getQueryValue(searchParams, 'error');
   const query = getQueryValue(searchParams, 'q')?.trim() || '';
+  const restored = getQueryValue(searchParams, 'restored') === '1';
   const view = (getQueryValue(searchParams, 'view') as AdminBoardFilter | null) || 'all';
   const adminBusiness = await db.business.findUnique({ where: { ownerClerkId: admin.userId } });
 
-  const [businesses, leadCounts, leadActivity, callActivity, messageActivity, notificationFailures, operatorSignals] = await Promise.all([
+  const [businesses, businessPickerOptions, leadCounts, leadActivity, callActivity, messageActivity, notificationFailures, operatorSignals] = await Promise.all([
     query
       ? searchBusinessesForAdmin(query)
       : db.business.findMany({
@@ -91,6 +124,22 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
             notificationSettings: true,
           },
         }),
+    db.business.findMany({
+      orderBy: [{ archivedAt: 'asc' }, { name: 'asc' }],
+      select: {
+        id: true,
+        name: true,
+        isTestBusiness: true,
+        archivedAt: true,
+        twilioPrimaryPhoneNumber: true,
+        twilioPhoneNumber: true,
+        notificationSettings: {
+          select: {
+            ownerEmail: true,
+          },
+        },
+      },
+    }),
     db.lead.groupBy({
       by: ['businessId'],
       _count: { _all: true },
@@ -239,8 +288,26 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   );
 
   const visibleRows = businessRows.filter((item) =>
-    matchesAdminBoardFilter(item.business, item.business.notificationSettings, item.ownerConnected, view)
+    selectedBusinessId
+      ? item.business.id === selectedBusinessId
+      : matchesAdminBoardFilter(item.business, item.business.notificationSettings, item.ownerConnected, view)
   );
+  const pickerOptions = businessPickerOptions.map((business) => ({
+    id: business.id,
+    label: buildAdminBusinessPickerLabel({
+      business,
+      notificationSettings: business.notificationSettings,
+    }),
+  }));
+  const selectedBusinessRow = selectedBusinessId ? businessRows.find((item) => item.business.id === selectedBusinessId) || null : null;
+  const selectedBusinessDeleteBlockedReason = selectedBusinessRow
+    ? getDeleteTestBusinessBlockedReason(selectedBusinessRow.business)
+    : null;
+  const boardReturnTo = buildAdminBoardReturnPath({
+    view,
+    selectedBusinessId,
+    query: selectedBusinessId ? null : query,
+  });
 
   const summaryStats = [
     { label: 'Needs attention', value: filterCounts.get('needs_attention') ?? 0 },
@@ -277,7 +344,9 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       </div>
 
       {error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{error}</div> : null}
-      {deleted ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Archived test business deleted.</div> : null}
+      {archived ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business archived. Permanent delete stays locked until the workspace is clearly demo/test.</div> : null}
+      {restored ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business restored to active triage.</div> : null}
+      {deleted ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Demo/test business deleted permanently.</div> : null}
       {createdDemo && createdBusinessId ? (
         <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">
           Demo business ready. Use <code className="rounded bg-background px-1 py-0.5">{createdBusinessId}</code> as `SIMULATOR_BUSINESS_ID`, or open the
@@ -402,29 +471,43 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
           <CardDescription>Compact rows with status, readiness, one clear attention signal, and the fastest next actions.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <form className="grid gap-3 md:grid-cols-[1fr_auto_auto]">
-            <Input
-              aria-label="Search businesses"
-              defaultValue={query}
-              name="q"
-              placeholder="Search business, owner email, business ID, Twilio number, or Twilio SID"
-            />
-            <input type="hidden" name="view" value={view} />
-            <Button type="submit" variant="outline">
-              Search
-            </Button>
-            {query ? (
-              <Link className={buttonVariants({ variant: 'ghost' })} href={`/admin?view=${encodeURIComponent(view)}`}>
-                Clear
-              </Link>
-            ) : null}
-          </form>
+          <div className="grid gap-4 lg:grid-cols-[1.2fr_1fr]">
+            <div className="rounded-xl border bg-background/80 p-4">
+              <AdminBusinessPicker options={pickerOptions} query={query || null} selectedBusinessId={selectedBusinessId} view={view} />
+            </div>
+            <form className="space-y-3 rounded-xl border border-dashed bg-background/80 p-4">
+              <div className="space-y-2">
+                <Label htmlFor="businessSearch">Search fallback</Label>
+                <Input
+                  aria-label="Search businesses"
+                  defaultValue={query}
+                  id="businessSearch"
+                  name="q"
+                  placeholder="Search business, owner email, business ID, Twilio number, or Twilio SID"
+                />
+              </div>
+              <input type="hidden" name="view" value={view} />
+              <div className="flex flex-wrap gap-2">
+                <Button type="submit" variant="outline">
+                  Search
+                </Button>
+                {query ? (
+                  <Link className={buttonVariants({ variant: 'ghost' })} href={buildAdminBoardReturnPath({ view })}>
+                    Clear search
+                  </Link>
+                ) : null}
+              </div>
+              <p className="text-xs text-muted-foreground">Use search only when you need an exact email, ID, Twilio number, or SID lookup.</p>
+            </form>
+          </div>
 
           <div className="flex flex-wrap gap-2">
             {adminBoardFilterOptions.map((option) => {
-              const href = query
-                ? `/admin?view=${encodeURIComponent(option.key)}&q=${encodeURIComponent(query)}`
-                : `/admin?view=${encodeURIComponent(option.key)}`;
+              const href = buildAdminBoardReturnPath({
+                view: option.key,
+                query: selectedBusinessId ? null : query,
+                selectedBusinessId,
+              });
               return (
                 <Link
                   key={option.key}
@@ -440,9 +523,117 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
             })}
           </div>
 
+          {selectedBusinessRow ? (
+            <Card className="border-primary/20 bg-primary/5">
+              <CardHeader className="gap-2">
+                <CardTitle className="text-xl">Selected business actions</CardTitle>
+                <CardDescription>
+                  Focused from the business picker. Archive stays the normal lifecycle action. Permanent delete only unlocks for archived demo/test
+                  workspaces.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-4 xl:grid-cols-[1.05fr_0.95fr]">
+                <div className="space-y-4 rounded-xl border bg-background/80 p-4 text-sm">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-base font-semibold">{selectedBusinessRow.business.name}</p>
+                    <Badge variant={selectedBusinessRow.overallStatus.variant}>{selectedBusinessRow.overallStatus.label}</Badge>
+                    {selectedBusinessRow.business.isTestBusiness ? <Badge variant="outline">Test</Badge> : null}
+                    {isBusinessArchived(selectedBusinessRow.business) ? <Badge variant="outline">Archived</Badge> : null}
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <p className="font-medium">Owner</p>
+                      <p className="mt-1 text-muted-foreground">
+                        {selectedBusinessRow.business.notificationSettings?.ownerEmail || selectedBusinessRow.business.ownerName || 'Owner details missing'}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="font-medium">Assigned number</p>
+                      <p className="mt-1 text-muted-foreground">
+                        {selectedBusinessRow.assignedNumber ? formatPhoneForDisplay(selectedBusinessRow.assignedNumber) : 'Not assigned yet'}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="font-medium">Latest attention signal</p>
+                      <p className="mt-1 text-muted-foreground">{selectedBusinessRow.attentionSignal}</p>
+                    </div>
+                    <div>
+                      <p className="font-medium">Current next step</p>
+                      <p className="mt-1 text-muted-foreground">{selectedBusinessRow.nextStep.actionLabel}</p>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Link className={buttonVariants({ size: 'sm' })} href={`/admin/${selectedBusinessRow.business.id}`}>
+                      Open business
+                    </Link>
+                    <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`/admin/${selectedBusinessRow.business.id}/workspace`}>
+                      Open workspace
+                    </Link>
+                    <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href={`/admin/${selectedBusinessRow.business.id}#advanced`}>
+                      Open full advanced controls
+                    </Link>
+                  </div>
+                </div>
+
+                <div className="space-y-4">
+                  {isBusinessArchived(selectedBusinessRow.business) ? (
+                    <form action={restoreBusinessAction} className="rounded-xl border bg-background/80 p-4 text-sm">
+                      <input type="hidden" name="businessId" value={selectedBusinessRow.business.id} />
+                      <input type="hidden" name="returnTo" value={boardReturnTo} />
+                      <div className="space-y-2">
+                        <Label htmlFor="restoreBusinessName">Type business name to restore</Label>
+                        <Input id="restoreBusinessName" name="confirmationName" placeholder={selectedBusinessRow.business.name} />
+                      </div>
+                      <Button className="mt-3" type="submit">
+                        Restore business
+                      </Button>
+                    </form>
+                  ) : (
+                    <form action={archiveBusinessAction} className="rounded-xl border bg-background/80 p-4 text-sm">
+                      <input type="hidden" name="businessId" value={selectedBusinessRow.business.id} />
+                      <input type="hidden" name="returnTo" value={boardReturnTo} />
+                      <div className="space-y-2">
+                        <Label htmlFor="archiveBusinessName">Type business name to archive</Label>
+                        <Input id="archiveBusinessName" name="confirmationName" placeholder={selectedBusinessRow.business.name} />
+                      </div>
+                      <p className="mt-2 text-xs text-muted-foreground">Archive is the normal lifecycle control for real customer businesses and the first safety step for demo/test cleanup.</p>
+                      <Button className="mt-3" type="submit" variant="outline">
+                        Archive business safely
+                      </Button>
+                    </form>
+                  )}
+
+                  {canDeleteTestBusiness(selectedBusinessRow.business) ? (
+                    <form action={deleteTestBusinessAction} className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm">
+                      <input type="hidden" name="businessId" value={selectedBusinessRow.business.id} />
+                      <input type="hidden" name="returnTo" value={boardReturnTo} />
+                      <div className="space-y-2">
+                        <Label htmlFor="deleteBusinessName">Type business name to permanently delete</Label>
+                        <Input id="deleteBusinessName" name="confirmationName" placeholder={selectedBusinessRow.business.name} />
+                      </div>
+                      <p className="mt-2 text-xs text-destructive">
+                        Permanent delete removes the business plus its leads, calls, messages, notification settings, owner notifications, operator
+                        events, simulator runs, and SMS consent records.
+                      </p>
+                      <Button className="mt-3" type="submit" variant="destructive">
+                        Delete demo/test business permanently
+                      </Button>
+                    </form>
+                  ) : (
+                    <div className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">
+                      {selectedBusinessDeleteBlockedReason || 'Delete stays unavailable for this business.'}
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ) : null}
+
           {visibleRows.length === 0 ? (
             <div className="rounded-xl border border-dashed p-6 text-sm text-muted-foreground">
-              No businesses matched this view. Try a different filter or search for the exact business ID, owner email, or Twilio number.
+              {selectedBusinessId
+                ? 'That business is no longer available on the board. Clear the selection and pick another workspace.'
+                : 'No businesses matched this view. Try a different filter or search for the exact business ID, owner email, or Twilio number.'}
             </div>
           ) : (
             <div className="overflow-hidden rounded-xl border">

--- a/components/admin-business-picker.tsx
+++ b/components/admin-business-picker.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
+
+type AdminBusinessPickerOption = {
+  id: string;
+  label: string;
+};
+
+function buildAdminBoardHref(params: { pathname: string; selectedBusinessId?: string | null; view?: string | null; query?: string | null }) {
+  const search = new URLSearchParams();
+
+  if (params.view) {
+    search.set('view', params.view);
+  }
+
+  if (params.query) {
+    search.set('q', params.query);
+  }
+
+  if (params.selectedBusinessId) {
+    search.set('businessId', params.selectedBusinessId);
+  }
+
+  const query = search.toString();
+  return query ? `${params.pathname}?${query}` : params.pathname;
+}
+
+export function AdminBusinessPicker({
+  options,
+  selectedBusinessId,
+  view,
+  query,
+}: {
+  options: AdminBusinessPickerOption[];
+  selectedBusinessId: string | null;
+  view: string | null;
+  query: string | null;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="business-picker">Jump to business</Label>
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Select
+          aria-label="Jump to business"
+          className="sm:flex-1"
+          id="business-picker"
+          onChange={(event) => {
+            const nextBusinessId = event.currentTarget.value || null;
+            router.replace(
+              buildAdminBoardHref({
+                pathname,
+                selectedBusinessId: nextBusinessId,
+                view,
+              })
+            );
+          }}
+          value={selectedBusinessId || ''}
+        >
+          <option value="">Choose a business instantly</option>
+          {options.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+        {selectedBusinessId ? (
+          <Button
+            onClick={() => {
+              router.replace(
+                buildAdminBoardHref({
+                  pathname,
+                  view,
+                  query,
+                })
+              );
+            }}
+            type="button"
+            variant="ghost"
+          >
+            Clear selection
+          </Button>
+        ) : null}
+      </div>
+      <p className="text-xs text-muted-foreground">Pick a business to focus the board immediately. Text search stays below for rare edge-case lookups.</p>
+    </div>
+  );
+}

--- a/lib/admin-business-lifecycle.ts
+++ b/lib/admin-business-lifecycle.ts
@@ -1,0 +1,33 @@
+import { canDeleteTestBusiness, getDeleteTestBusinessBlockedReason } from '@/lib/admin-dashboard';
+import { db } from '@/lib/db';
+
+export async function deleteDeletableTestBusiness(businessId: string) {
+  const business = await db.business.findUnique({
+    where: { id: businessId },
+    select: {
+      id: true,
+      name: true,
+      isTestBusiness: true,
+      ownerClerkId: true,
+      archivedAt: true,
+    },
+  });
+
+  if (!business) {
+    throw new Error('Business not found.');
+  }
+
+  const blockedReason = getDeleteTestBusinessBlockedReason(business);
+  if (blockedReason || !canDeleteTestBusiness(business)) {
+    throw new Error(blockedReason || 'Only archived demo/test businesses can be deleted.');
+  }
+
+  return db.business.delete({
+    where: { id: business.id },
+    select: {
+      id: true,
+      name: true,
+      isTestBusiness: true,
+    },
+  });
+}

--- a/lib/admin-dashboard.ts
+++ b/lib/admin-dashboard.ts
@@ -160,6 +160,36 @@ export function canDeleteTestBusiness(
   return isBusinessArchived(business) && (business.isTestBusiness || business.ownerClerkId === DEMO_OWNER_CLERK_ID);
 }
 
+export function getDeleteTestBusinessBlockedReason(
+  business: Pick<DashboardBusiness, 'isTestBusiness' | 'ownerClerkId' | 'archivedAt'>
+) {
+  if (!business.isTestBusiness && business.ownerClerkId !== DEMO_OWNER_CLERK_ID) {
+    return 'Only demo/test businesses can be deleted. Archive this business instead.';
+  }
+
+  if (!isBusinessArchived(business)) {
+    return 'Archive this business instead. Permanent delete only unlocks after archive.';
+  }
+
+  return null;
+}
+
+export function buildAdminBusinessPickerLabel(params: {
+  business: Pick<
+    DashboardBusiness,
+    'id' | 'name' | 'isTestBusiness' | 'archivedAt' | 'twilioPrimaryPhoneNumber' | 'twilioPhoneNumber'
+  >;
+  notificationSettings: Pick<DashboardNotificationSettings, 'ownerEmail'> | null;
+}) {
+  const secondaryLabel =
+    params.notificationSettings?.ownerEmail?.trim() || getManagedTextingNumber(params.business) || `ID ${params.business.id.slice(-6)}`;
+  const stateLabels = [params.business.isTestBusiness ? 'test' : null, isBusinessArchived(params.business) ? 'archived' : null].filter(Boolean);
+
+  return stateLabels.length > 0
+    ? `${params.business.name} - ${secondaryLabel} (${stateLabels.join(', ')})`
+    : `${params.business.name} - ${secondaryLabel}`;
+}
+
 export function getBusinessLifecycleLabel(
   business: Pick<DashboardBusiness, 'archivedAt' | 'provisioningStatus'>
 ) {

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -145,11 +145,13 @@ export const adminSendTestSmsSchema = z.object({
 export const adminArchiveBusinessSchema = z.object({
   businessId: z.string().min(1),
   confirmationName: z.string().trim().min(1),
+  returnTo: z.string().trim().optional().or(z.literal('')),
 });
 
 export const adminDeleteBusinessSchema = z.object({
   businessId: z.string().min(1),
   confirmationName: z.string().trim().min(1),
+  returnTo: z.string().trim().optional().or(z.literal('')),
 });
 
 export const businessTwilioAdminOverrideSchema = z.object({

--- a/tests/admin-business-lifecycle.test.ts
+++ b/tests/admin-business-lifecycle.test.ts
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+
+import { deleteDeletableTestBusiness } from '../lib/admin-business-lifecycle.ts';
+import { db } from '../lib/db.ts';
+
+function makeSeed(prefix: string) {
+  return `${prefix}-${randomUUID().slice(0, 8)}`;
+}
+
+async function createArchivedTestBusinessGraph(seed: string) {
+  const business = await db.business.create({
+    data: {
+      ownerClerkId: `owner-${seed}`,
+      name: `Demo Cleanup ${seed}`,
+      isTestBusiness: true,
+      archivedAt: new Date('2026-04-18T12:00:00.000Z'),
+      forwardingNumber: '+15125550100',
+      notifyPhone: '+15125550101',
+      missedCallSeconds: 20,
+      timezone: 'America/New_York',
+      serviceLabel1: 'Repair',
+      serviceLabel2: 'Install',
+      serviceLabel3: 'Maintenance',
+      notificationSettings: {
+        create: {
+          ownerEmail: `${seed}@example.com`,
+          ownerPhone: '+15125550101',
+        },
+      },
+    },
+  });
+
+  const call = await db.call.create({
+    data: {
+      businessId: business.id,
+      twilioCallSid: `CA${seed.replace(/-/g, '').padEnd(32, '0').slice(0, 32)}`,
+      fromPhone: '+15125550102',
+      fromPhoneNormalized: '+15125550102',
+      toPhone: '+15125550100',
+      toPhoneNormalized: '+15125550100',
+      status: 'completed',
+      answered: false,
+      missed: true,
+    },
+  });
+
+  const lead = await db.lead.create({
+    data: {
+      businessId: business.id,
+      callId: call.id,
+      callerPhone: '+15125550102',
+      callerPhoneNormalized: '+15125550102',
+      summary: 'Demo cleanup lead',
+    },
+  });
+
+  await db.message.create({
+    data: {
+      businessId: business.id,
+      leadId: lead.id,
+      direction: 'OUTBOUND',
+      participant: 'OWNER',
+      fromPhone: '+15125550100',
+      toPhone: '+15125550102',
+      body: 'Test cleanup message',
+    },
+  });
+
+  await db.ownerNotification.create({
+    data: {
+      businessId: business.id,
+      leadId: lead.id,
+      channel: 'SMS',
+      status: 'FAILED',
+      body: 'Owner alert failed',
+      error: 'simulated failure',
+    },
+  });
+
+  await db.businessOperatorEvent.create({
+    data: {
+      businessId: business.id,
+      type: 'admin.cleanup_test',
+      category: 'ADMIN_ACTIONS',
+      status: 'WARNING',
+      summary: 'Cleanup test event',
+    },
+  });
+
+  await db.smsConsent.create({
+    data: {
+      businessId: business.id,
+      phoneNormalized: '+15125550102',
+      phoneRawLastSeen: '+1 (512) 555-0102',
+    },
+  });
+
+  await db.simulatorRun.create({
+    data: {
+      publicId: `sim-${seed}`,
+      businessId: business.id,
+      leadId: lead.id,
+      callerPhone: '+15125550102',
+    },
+  });
+
+  return { business, call, lead };
+}
+
+test('deleteDeletableTestBusiness hard deletes an archived demo/test business and its dependent records', async () => {
+  const seed = makeSeed('delete-demo');
+  const { business, call, lead } = await createArchivedTestBusinessGraph(seed);
+
+  try {
+    await deleteDeletableTestBusiness(business.id);
+
+    const [
+      deletedBusiness,
+      deletedCall,
+      deletedLead,
+      deletedMessageCount,
+      deletedNotificationCount,
+      deletedSettings,
+      deletedOperatorEventCount,
+      deletedSimulatorRunCount,
+      deletedConsentCount,
+    ] = await Promise.all([
+      db.business.findUnique({ where: { id: business.id } }),
+      db.call.findUnique({ where: { id: call.id } }),
+      db.lead.findUnique({ where: { id: lead.id } }),
+      db.message.count({ where: { businessId: business.id } }),
+      db.ownerNotification.count({ where: { businessId: business.id } }),
+      db.businessNotificationSettings.findUnique({ where: { businessId: business.id } }),
+      db.businessOperatorEvent.count({ where: { businessId: business.id } }),
+      db.simulatorRun.count({ where: { businessId: business.id } }),
+      db.smsConsent.count({ where: { businessId: business.id } }),
+    ]);
+
+    assert.equal(deletedBusiness, null);
+    assert.equal(deletedCall, null);
+    assert.equal(deletedLead, null);
+    assert.equal(deletedMessageCount, 0);
+    assert.equal(deletedNotificationCount, 0);
+    assert.equal(deletedSettings, null);
+    assert.equal(deletedOperatorEventCount, 0);
+    assert.equal(deletedSimulatorRunCount, 0);
+    assert.equal(deletedConsentCount, 0);
+  } finally {
+    await db.business.deleteMany({ where: { ownerClerkId: `owner-${seed}` } });
+  }
+});
+
+test('deleteDeletableTestBusiness rejects real businesses and leaves them archive-only', async () => {
+  const seed = makeSeed('keep-real');
+  const business = await db.business.create({
+    data: {
+      ownerClerkId: `owner-${seed}`,
+      name: `Real Tenant ${seed}`,
+      isTestBusiness: false,
+      forwardingNumber: '+15125550110',
+      missedCallSeconds: 20,
+      timezone: 'America/New_York',
+      serviceLabel1: 'Repair',
+      serviceLabel2: 'Install',
+      serviceLabel3: 'Maintenance',
+    },
+  });
+
+  try {
+    await assert.rejects(
+      deleteDeletableTestBusiness(business.id),
+      /Only demo\/test businesses can be deleted|Archive this business instead/i
+    );
+
+    const stillExists = await db.business.findUnique({ where: { id: business.id } });
+    assert.equal(stillExists?.id, business.id);
+  } finally {
+    await db.business.deleteMany({ where: { id: business.id } });
+  }
+});

--- a/tests/admin-dashboard.test.ts
+++ b/tests/admin-dashboard.test.ts
@@ -4,10 +4,12 @@ import test from 'node:test';
 import { BusinessProvisioningStatus, ManagedTwilioStatus, OperatorEventStatus, SubscriptionStatus } from '@prisma/client';
 
 import {
+  buildAdminBusinessPickerLabel,
   buildAdminOnboardingConfidence,
   buildAdminBusinessEvents,
   buildAdminNextStep,
   canDeleteTestBusiness,
+  getDeleteTestBusinessBlockedReason,
   matchesAdminBoardFilter,
 } from '../lib/admin-dashboard.ts';
 
@@ -153,6 +155,42 @@ test('board filters and delete guard stay conservative', () => {
     canDeleteTestBusiness(createBusiness({ isTestBusiness: false, archivedAt: new Date('2026-04-16T00:00:00.000Z') })),
     false
   );
+  assert.equal(
+    getDeleteTestBusinessBlockedReason(createBusiness({ isTestBusiness: false, archivedAt: new Date('2026-04-16T00:00:00.000Z') })),
+    'Only demo/test businesses can be deleted. Archive this business instead.'
+  );
+  assert.equal(
+    getDeleteTestBusinessBlockedReason(createBusiness({ isTestBusiness: true })),
+    'Archive this business instead. Permanent delete only unlocks after archive.'
+  );
+});
+
+test('business picker labels keep the name primary and add a fast secondary identifier', () => {
+  const labelWithEmail = buildAdminBusinessPickerLabel({
+    business: createBusiness({
+      name: 'Search HVAC',
+    }),
+    notificationSettings: createNotificationSettings({
+      ownerEmail: 'owner@example.com',
+    }),
+  });
+
+  const labelWithFallbackId = buildAdminBusinessPickerLabel({
+    business: createBusiness({
+      id: 'biz_picker_123456',
+      name: 'Fallback Electric',
+      twilioPhoneNumber: null,
+      twilioPrimaryPhoneNumber: null,
+      isTestBusiness: true,
+      archivedAt: new Date('2026-04-16T00:00:00.000Z'),
+    }),
+    notificationSettings: createNotificationSettings({
+      ownerEmail: '',
+    }),
+  });
+
+  assert.equal(labelWithEmail, 'Search HVAC - owner@example.com');
+  assert.equal(labelWithFallbackId, 'Fallback Electric - ID 123456 (test, archived)');
 });
 
 test('recent event synthesis prioritizes provisioning failures and owner alert failures', () => {

--- a/tests/admin-operator-routes.test.ts
+++ b/tests/admin-operator-routes.test.ts
@@ -10,12 +10,17 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   const adminHome = read('app/admin/page.tsx');
   const adminDetail = read('app/admin/[businessId]/page.tsx');
   const supportWorkspace = read('app/admin/[businessId]/workspace/page.tsx');
+  const businessPicker = read('components/admin-business-picker.tsx');
 
   assert.match(adminHome, /Operator control panel/);
   assert.match(adminHome, /Fast onboard/);
   assert.match(adminHome, /Create workspace and start provisioning/);
   assert.match(adminHome, /Business triage board/);
+  assert.match(adminHome, /Delete demo\/test business permanently/);
+  assert.match(adminHome, /Type business name to permanently delete/);
   assert.match(adminHome, /Open customer leads/);
+  assert.match(businessPicker, /Jump to business/);
+  assert.match(businessPicker, /Clear selection/);
   assert.match(adminDetail, /Onboarding confidence/);
   assert.match(adminDetail, /Business info/);
   assert.match(adminDetail, /Provisioning health/);


### PR DESCRIPTION
## Summary
- make the admin triage board use a primary business picker so the founder can focus a workspace without typing
- keep free-text search as a secondary fallback for exact ID, email, number, and SID lookups
- surface archive/restore and safe hard-delete controls for the selected business directly on the board

## Root cause
- the board only offered a generic text search, which added friction for a small business list
- safe hard delete already existed in the detail page, but it was slower to reach and not exposed through the operator-focused triage flow

## What changed
- added a compact client-side business picker with clear-selection support
- added a selected-business action panel on `/admin` with typed confirmation for archive, restore, and permanent delete
- kept delete gated to archived demo/test businesses only, backed by the existing `isTestBusiness` / dedicated demo owner rules
- extracted the hard-delete path into a testable helper and added cascade-focused coverage

## Validation
- `npm install`
- `npx prisma generate`
- `npx prisma migrate status`
- `npm run env:check`
- `npm run preflight:providers`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`
