### PR TITLE
[codex] Fix admin support shortcut routing

### DIFF
--- a/app/admin/[businessId]/open-customer/route.ts
+++ b/app/admin/[businessId]/open-customer/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+
+import { ADMIN_CUSTOMER_BUSINESS_COOKIE } from '@/lib/admin-customer-context';
+import { resolveSafeAdminCustomerAppPath } from '@/lib/admin-customer-paths';
+import { getAdminSession } from '@/lib/admin';
+import { db } from '@/lib/db';
+
+export async function GET(request: Request, { params }: { params: { businessId: string } }) {
+  const adminSession = await getAdminSession();
+  const requestUrl = new URL(request.url);
+
+  if (!adminSession?.userId) {
+    return NextResponse.redirect(new URL('/sign-in', requestUrl));
+  }
+
+  if (!adminSession.isAdmin) {
+    return NextResponse.redirect(new URL('/app', requestUrl));
+  }
+
+  const business = await db.business.findUnique({
+    where: { id: params.businessId },
+    select: { id: true },
+  });
+
+  if (!business) {
+    return NextResponse.redirect(new URL('/admin?error=Business%20not%20found.', requestUrl));
+  }
+
+  const nextPath = resolveSafeAdminCustomerAppPath(requestUrl.searchParams.get('path'));
+  const response = NextResponse.redirect(new URL(nextPath, requestUrl));
+
+  response.cookies.set(ADMIN_CUSTOMER_BUSINESS_COOKIE, business.id, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/app',
+  });
+
+  return response;
+}

--- a/app/admin/[businessId]/page.tsx
+++ b/app/admin/[businessId]/page.tsx
@@ -13,6 +13,7 @@ import {
   sendBusinessTestSmsAction,
   setBusinessProvisioningStatusAction,
 } from '@/app/admin/actions';
+import { buildAdminCustomerOpenHref } from '@/lib/admin-customer-paths';
 import {
   buildAdminOnboardingConfidence,
   canDeleteTestBusiness,
@@ -180,9 +181,9 @@ function getOperatorEventDetails(value: unknown) {
 
 function buildOperatorEventRelatedHref(businessId: string, relatedEntityType: string | null, relatedEntityId: string | null) {
   if (!relatedEntityType || !relatedEntityId) return null;
-  if (relatedEntityType === 'lead') return `/admin/${businessId}/workspace#recent-leads`;
+  if (relatedEntityType === 'lead') return buildAdminCustomerOpenHref(businessId, `/app/leads/${relatedEntityId}`);
   if (relatedEntityType === 'message') return `/admin/${businessId}/workspace#recent-activity`;
-  if (relatedEntityType === 'call') return `/admin/${businessId}/workspace#call-flow-snapshot`;
+  if (relatedEntityType === 'call') return buildAdminCustomerOpenHref(businessId, '/app/call-flow');
   return null;
 }
 
@@ -495,11 +496,14 @@ export default async function AdminBusinessDetailPage({
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Link className={buttonVariants({ variant: 'default' })} href={`/admin/${business.id}/workspace`}>
+            <Link className={buttonVariants({ variant: 'default' })} href={buildAdminCustomerOpenHref(business.id, '/app')}>
               Open customer workspace
             </Link>
-            <Link className={buttonVariants({ variant: 'outline' })} href={`/admin/${business.id}/workspace#recent-leads`}>
+            <Link className={buttonVariants({ variant: 'outline' })} href={buildAdminCustomerOpenHref(business.id, '/app/leads?view=attention')}>
               Open customer leads
+            </Link>
+            <Link className={buttonVariants({ variant: 'outline' })} href={`/admin/${business.id}/workspace`}>
+              View support workspace snapshot
             </Link>
             <Link className={buttonVariants({ variant: 'outline' })} href="/admin">
               Back to board
@@ -670,21 +674,24 @@ export default async function AdminBusinessDetailPage({
         <Card className="bg-card/90">
           <CardHeader>
             <CardTitle>Support mode shortcuts</CardTitle>
-            <CardDescription>Safe customer-side entry points without impersonation or tenant bleed.</CardDescription>
+            <CardDescription>Open the real customer pages for this business, or choose the snapshot view when you only need read-only context.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid gap-2">
-              <Link className={buttonVariants({ variant: 'default', size: 'sm' })} href={`/admin/${business.id}/workspace`}>
+              <Link className={buttonVariants({ variant: 'default', size: 'sm' })} href={buildAdminCustomerOpenHref(business.id, '/app')}>
                 Open customer workspace
               </Link>
-              <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`/admin/${business.id}/workspace#recent-leads`}>
+              <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={buildAdminCustomerOpenHref(business.id, '/app/leads?view=attention')}>
                 Open customer leads
               </Link>
-              <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`/admin/${business.id}/workspace#settings-snapshot`}>
+              <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={buildAdminCustomerOpenHref(business.id, '/app/settings')}>
                 Open customer settings
               </Link>
-              <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`/admin/${business.id}/workspace#call-flow-snapshot`}>
+              <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={buildAdminCustomerOpenHref(business.id, '/app/call-flow')}>
                 Open customer call flow
+              </Link>
+              <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href={`/admin/${business.id}/workspace`}>
+                View support workspace snapshot
               </Link>
             </div>
 
@@ -711,7 +718,7 @@ export default async function AdminBusinessDetailPage({
             </form>
 
             <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground">
-              Support mode stays read-only. Use it to inspect leads, settings, and call flow quickly without weakening business isolation.
+              Support workspace snapshots stay read-only. The buttons above open the real customer pages in an admin-scoped customer mode so you can act without impersonation.
             </div>
           </CardContent>
         </Card>

--- a/app/admin/[businessId]/workspace/page.tsx
+++ b/app/admin/[businessId]/workspace/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
+import { buildAdminCustomerOpenHref } from '@/lib/admin-customer-paths';
 import { buildAdminNextStep } from '@/lib/admin-dashboard';
 import { requireAdmin } from '@/lib/admin';
 import { getAdminOwnerState } from '@/lib/admin-provisioning';
@@ -79,7 +80,7 @@ export default async function AdminBusinessWorkspacePage({ params }: { params: {
           <div>
             <h1 className="text-3xl font-semibold tracking-tight">{business.name} support mode workspace</h1>
             <p className="text-sm text-muted-foreground">
-              Read-only customer context so the founder can inspect leads, settings, and call flow without impersonation.
+              Read-only customer snapshot for fast inspection. Use the customer-mode buttons below when you need the real editable customer pages.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -96,7 +97,7 @@ export default async function AdminBusinessWorkspacePage({ params }: { params: {
       <Card className="border-primary/20 bg-primary/5">
         <CardHeader>
           <CardTitle>Support snapshot</CardTitle>
-          <CardDescription>Immediate health signal plus quick jumps into the customer context that matter most.</CardDescription>
+          <CardDescription>Immediate health signal plus clear separation between real customer pages and read-only snapshot sections.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
@@ -122,17 +123,32 @@ export default async function AdminBusinessWorkspacePage({ params }: { params: {
           </div>
 
           <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
-            <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href="#recent-leads">
+            <Link className={buttonVariants({ variant: 'default', size: 'sm' })} href={buildAdminCustomerOpenHref(business.id, '/app')}>
+              Open customer workspace
+            </Link>
+            <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={buildAdminCustomerOpenHref(business.id, '/app/leads?view=attention')}>
               Open customer leads
             </Link>
-            <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href="#settings-snapshot">
+            <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={buildAdminCustomerOpenHref(business.id, '/app/settings')}>
               Open customer settings
             </Link>
-            <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href="#call-flow-snapshot">
+            <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={buildAdminCustomerOpenHref(business.id, '/app/call-flow')}>
               Open customer call flow
             </Link>
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+            <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href="#recent-leads">
+              View leads snapshot
+            </Link>
+            <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href="#settings-snapshot">
+              View settings snapshot
+            </Link>
+            <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href="#call-flow-snapshot">
+              View call flow snapshot
+            </Link>
             <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href="#recent-activity">
-              Open recent activity
+              View recent activity snapshot
             </Link>
           </div>
         </CardContent>

--- a/app/admin/exit-customer-mode/route.ts
+++ b/app/admin/exit-customer-mode/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+
+import { ADMIN_CUSTOMER_BUSINESS_COOKIE } from '@/lib/admin-customer-context';
+import { getAdminSession } from '@/lib/admin';
+
+export async function GET(request: Request) {
+  const adminSession = await getAdminSession();
+  const requestUrl = new URL(request.url);
+
+  if (!adminSession?.userId) {
+    return NextResponse.redirect(new URL('/sign-in', requestUrl));
+  }
+
+  if (!adminSession.isAdmin) {
+    return NextResponse.redirect(new URL('/app', requestUrl));
+  }
+
+  const businessId = requestUrl.searchParams.get('businessId')?.trim();
+  const redirectPath = businessId ? `/admin/${businessId}` : '/admin';
+  const response = NextResponse.redirect(new URL(redirectPath, requestUrl));
+
+  response.cookies.set(ADMIN_CUSTOMER_BUSINESS_COOKIE, '', {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/app',
+    maxAge: 0,
+  });
+
+  return response;
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -10,6 +10,7 @@ import {
   restoreBusinessAction,
   sendBusinessTestSmsAction,
 } from '@/app/admin/actions';
+import { buildAdminCustomerOpenHref } from '@/lib/admin-customer-paths';
 import {
   adminBoardFilterOptions,
   buildAdminBusinessPickerLabel,
@@ -566,11 +567,23 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                     <Link className={buttonVariants({ size: 'sm' })} href={`/admin/${selectedBusinessRow.business.id}`}>
                       Open business
                     </Link>
-                    <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`/admin/${selectedBusinessRow.business.id}/workspace`}>
-                      Open workspace
+                    <Link
+                      className={buttonVariants({ variant: 'outline', size: 'sm' })}
+                      href={buildAdminCustomerOpenHref(selectedBusinessRow.business.id, '/app')}
+                    >
+                      Open customer workspace
+                    </Link>
+                    <Link
+                      className={buttonVariants({ variant: 'outline', size: 'sm' })}
+                      href={buildAdminCustomerOpenHref(selectedBusinessRow.business.id, '/app/settings')}
+                    >
+                      Open customer settings
                     </Link>
                     <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href={`/admin/${selectedBusinessRow.business.id}#advanced`}>
                       Open full advanced controls
+                    </Link>
+                    <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href={`/admin/${selectedBusinessRow.business.id}/workspace`}>
+                      View support workspace snapshot
                     </Link>
                   </div>
                 </div>
@@ -723,11 +736,17 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                       <Link className={buttonVariants({ size: 'sm' })} href={`/admin/${business.id}`}>
                         Open business
                       </Link>
-                      <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`/admin/${business.id}/workspace`}>
-                        Open workspace
+                      <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={buildAdminCustomerOpenHref(business.id, '/app')}>
+                        Open customer workspace
                       </Link>
-                      <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={`/admin/${business.id}/workspace#recent-leads`}>
+                      <Link
+                        className={buttonVariants({ variant: 'outline', size: 'sm' })}
+                        href={buildAdminCustomerOpenHref(business.id, '/app/leads?view=attention')}
+                      >
                         Open customer leads
+                      </Link>
+                      <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href={`/admin/${business.id}/workspace`}>
+                        View support workspace snapshot
                       </Link>
                       {!isBusinessArchived(business) ? (
                         <form action={provisionBusinessAction}>

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -1,7 +1,10 @@
 import { auth } from '@clerk/nextjs/server';
 import { redirect } from 'next/navigation';
+import Link from 'next/link';
 
 import { AppNav } from '@/components/app-nav';
+import { getAdminCustomerActingContext } from '@/lib/admin-customer-context';
+import { buildAdminCustomerExitHref } from '@/lib/admin-customer-paths';
 import { db } from '@/lib/db';
 import { getPortfolioDemoBusiness, isPortfolioDemoMode } from '@/lib/portfolio-demo';
 import { getCustomerSystemStatus } from '@/lib/system-status';
@@ -25,25 +28,48 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     );
   }
 
+  const adminCustomerContext = await getAdminCustomerActingContext();
   const { userId } = await auth();
   if (!userId) {
     redirect('/sign-in');
   }
 
-  const business = await db.business.findUnique({ where: { ownerClerkId: userId } });
+  const business = adminCustomerContext
+    ? adminCustomerContext.business
+    : await db.business.findUnique({ where: { ownerClerkId: userId } });
   const successfulLeadCount = business
     ? await db.lead.count({ where: { businessId: business.id, OR: [{ ownerNotifiedAt: { not: null } }, { notifiedAt: { not: null } }] } })
     : 0;
   const systemStatus = business ? getCustomerSystemStatus(business, successfulLeadCount) : null;
 
   return (
-    <div className="min-h-screen">
-      <AppNav
-        business={business}
-        systemStatusLabel={systemStatus?.label ?? 'Not live yet'}
-        systemStatusVariant={systemStatus?.badgeVariant ?? 'outline'}
-      />
-      <main className="container py-8">{children}</main>
-    </div>
-  );
+      <div className="min-h-screen">
+        <AppNav
+          business={business}
+          systemStatusLabel={systemStatus?.label ?? 'Not live yet'}
+          systemStatusVariant={systemStatus?.badgeVariant ?? 'outline'}
+        />
+        {adminCustomerContext && business ? (
+          <div className="border-b bg-primary/5">
+            <div className="container flex flex-col gap-3 py-3 text-sm lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <p className="font-medium">Admin customer mode</p>
+                <p className="text-muted-foreground">
+                  You are using the real customer pages for <span className="font-medium text-foreground">{business.name}</span>.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Link className="rounded-md border px-3 py-2 text-sm font-medium transition-colors hover:bg-background" href={`/admin/${business.id}`}>
+                  Back to operator controls
+                </Link>
+                <Link className="rounded-md border px-3 py-2 text-sm font-medium transition-colors hover:bg-background" href={buildAdminCustomerExitHref(business.id)}>
+                  Exit customer mode
+                </Link>
+              </div>
+            </div>
+          </div>
+        ) : null}
+        <main className="container py-8">{children}</main>
+      </div>
+    );
 }

--- a/app/app/settings/actions.ts
+++ b/app/app/settings/actions.ts
@@ -1,12 +1,12 @@
 'use server';
 
-import { auth, currentUser } from '@clerk/nextjs/server';
+import { currentUser } from '@clerk/nextjs/server';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 import { requireAdmin } from '@/lib/admin';
 import { logAuditEvent } from '@/lib/audit-log';
-import { getBusinessForOwnerClerkId } from '@/lib/business-access';
+import { requireBusiness } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { maskPhoneForAudit, normalizePhoneNumber, normalizePhoneNumberToE164 } from '@/lib/phone';
 import { getTwilioBusinessClient } from '@/lib/twilio-client';
@@ -16,11 +16,7 @@ import { syncTwilioIncomingPhoneNumberWebhooks } from '@/lib/twilio';
 import { businessSettingsSchema, businessTwilioAdminOverrideSchema, buyNumberSchema } from '@/lib/validators';
 
 async function getBusinessForOwner() {
-  const { userId } = await auth();
-  if (!userId) redirect('/sign-in');
-  const business = await getBusinessForOwnerClerkId(userId);
-  if (!business) redirect('/app/onboarding');
-  return business;
+  return requireBusiness();
 }
 
 async function saveBusinessTwilioNumber(businessId: string, params: { phoneNumber: string | null; phoneNumberSid: string; syncedAt: Date }) {

--- a/lib/admin-customer-context.ts
+++ b/lib/admin-customer-context.ts
@@ -1,0 +1,33 @@
+import { cookies } from 'next/headers';
+
+import { getAdminSession } from '@/lib/admin';
+import { resolveSafeAdminCustomerAppPath } from '@/lib/admin-customer-paths';
+import { db } from '@/lib/db';
+
+export const ADMIN_CUSTOMER_BUSINESS_COOKIE = 'cc_admin_customer_business';
+
+export async function getAdminCustomerActingContext() {
+  const actingBusinessId = cookies().get(ADMIN_CUSTOMER_BUSINESS_COOKIE)?.value?.trim();
+  if (!actingBusinessId) {
+    return null;
+  }
+
+  const adminSession = await getAdminSession();
+  if (!adminSession?.isAdmin) {
+    return null;
+  }
+
+  const business = await db.business.findUnique({
+    where: { id: actingBusinessId },
+  });
+
+  if (!business) {
+    return null;
+  }
+
+  return {
+    business,
+    adminUserId: adminSession.userId,
+    adminEmail: adminSession.email,
+  };
+}

--- a/lib/admin-customer-paths.ts
+++ b/lib/admin-customer-paths.ts
@@ -1,0 +1,23 @@
+export function resolveSafeAdminCustomerAppPath(value: string | null | undefined) {
+  const trimmed = value?.trim() || '';
+
+  if (!trimmed) return '/app';
+  if (!trimmed.startsWith('/app')) return '/app';
+  if (trimmed.startsWith('//')) return '/app';
+
+  return trimmed;
+}
+
+export function buildAdminCustomerOpenHref(businessId: string, path = '/app') {
+  const safePath = resolveSafeAdminCustomerAppPath(path);
+  if (safePath === '/app') {
+    return `/admin/${businessId}/open-customer`;
+  }
+
+  return `/admin/${businessId}/open-customer?path=${encodeURIComponent(safePath)}`;
+}
+
+export function buildAdminCustomerExitHref(businessId?: string | null) {
+  if (!businessId) return '/admin/exit-customer-mode';
+  return `/admin/exit-customer-mode?businessId=${encodeURIComponent(businessId)}`;
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,7 @@
 import { auth } from '@clerk/nextjs/server';
 import { redirect } from 'next/navigation';
 
+import { getAdminCustomerActingContext } from '@/lib/admin-customer-context';
 import { getBusinessForOwnerClerkId } from '@/lib/business-access';
 import { getPortfolioDemoAuth, getPortfolioDemoBusiness, isPortfolioDemoMode } from '@/lib/portfolio-demo';
 
@@ -21,6 +22,11 @@ export async function getCurrentBusiness() {
     return getPortfolioDemoBusiness();
   }
 
+  const adminCustomerContext = await getAdminCustomerActingContext();
+  if (adminCustomerContext) {
+    return adminCustomerContext.business;
+  }
+
   const { userId } = await auth();
   if (!userId) return null;
 
@@ -30,6 +36,11 @@ export async function getCurrentBusiness() {
 export async function requireBusiness() {
   if (isPortfolioDemoMode()) {
     return getPortfolioDemoBusiness();
+  }
+
+  const adminCustomerContext = await getAdminCustomerActingContext();
+  if (adminCustomerContext) {
+    return adminCustomerContext.business;
   }
 
   const { userId } = await requireAuth();

--- a/tests/admin-customer-context.test.ts
+++ b/tests/admin-customer-context.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildAdminCustomerExitHref,
+  buildAdminCustomerOpenHref,
+  resolveSafeAdminCustomerAppPath,
+} from '../lib/admin-customer-paths.ts';
+
+test('admin customer app paths stay scoped to /app routes', () => {
+  assert.equal(resolveSafeAdminCustomerAppPath('/app/settings'), '/app/settings');
+  assert.equal(resolveSafeAdminCustomerAppPath('/app/leads?view=attention'), '/app/leads?view=attention');
+  assert.equal(resolveSafeAdminCustomerAppPath(''), '/app');
+  assert.equal(resolveSafeAdminCustomerAppPath('/admin'), '/app');
+  assert.equal(resolveSafeAdminCustomerAppPath('//evil.example.com'), '/app');
+});
+
+test('admin customer open and exit href builders stay predictable', () => {
+  assert.equal(buildAdminCustomerOpenHref('biz_123'), '/admin/biz_123/open-customer');
+  assert.equal(
+    buildAdminCustomerOpenHref('biz_123', '/app/settings'),
+    '/admin/biz_123/open-customer?path=%2Fapp%2Fsettings'
+  );
+  assert.equal(
+    buildAdminCustomerOpenHref('biz_123', '/app/leads?view=attention'),
+    '/admin/biz_123/open-customer?path=%2Fapp%2Fleads%3Fview%3Dattention'
+  );
+  assert.equal(buildAdminCustomerExitHref('biz_123'), '/admin/exit-customer-mode?businessId=biz_123');
+  assert.equal(buildAdminCustomerExitHref(), '/admin/exit-customer-mode');
+});

--- a/tests/admin-operator-routes.test.ts
+++ b/tests/admin-operator-routes.test.ts
@@ -11,14 +11,17 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   const adminDetail = read('app/admin/[businessId]/page.tsx');
   const supportWorkspace = read('app/admin/[businessId]/workspace/page.tsx');
   const businessPicker = read('components/admin-business-picker.tsx');
+  const appLayout = read('app/app/layout.tsx');
 
   assert.match(adminHome, /Operator control panel/);
   assert.match(adminHome, /Fast onboard/);
   assert.match(adminHome, /Create workspace and start provisioning/);
   assert.match(adminHome, /Business triage board/);
+  assert.match(adminHome, /Open customer workspace/);
   assert.match(adminHome, /Delete demo\/test business permanently/);
   assert.match(adminHome, /Type business name to permanently delete/);
   assert.match(adminHome, /Open customer leads/);
+  assert.match(adminHome, /View support workspace snapshot/);
   assert.match(businessPicker, /Jump to business/);
   assert.match(businessPicker, /Clear selection/);
   assert.match(adminDetail, /Onboarding confidence/);
@@ -32,8 +35,17 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminDetail, /Invite owner by email/);
   assert.match(adminDetail, /Connect existing owner/);
   assert.match(adminDetail, /Send test SMS/);
+  assert.match(adminDetail, /Open customer settings/);
+  assert.match(adminDetail, /Open customer call flow/);
+  assert.match(adminDetail, /View support workspace snapshot/);
   assert.doesNotMatch(adminDetail, /Connect or invite owner/);
   assert.match(supportWorkspace, /support mode workspace/);
+  assert.match(supportWorkspace, /Open customer workspace/);
+  assert.match(supportWorkspace, /View leads snapshot/);
+  assert.match(supportWorkspace, /View settings snapshot/);
+  assert.match(supportWorkspace, /View call flow snapshot/);
   assert.match(supportWorkspace, /Customer settings snapshot/);
   assert.match(supportWorkspace, /Customer call flow snapshot/);
+  assert.match(appLayout, /Admin customer mode/);
+  assert.match(appLayout, /Exit customer mode/);
 });

--- a/tests/tenant-isolation-wiring.test.ts
+++ b/tests/tenant-isolation-wiring.test.ts
@@ -30,7 +30,7 @@ test('protected app surfaces use shared tenant-scoped access helpers', () => {
   assert.match(conversationsPage, /getConversationDetailForBusiness/);
   assert.match(leadActions, /updateLeadStatusForBusiness/);
   assert.match(settingsPage, /getBusinessNotificationSettingsForBusiness/);
-  assert.match(settingsActions, /getBusinessForOwnerClerkId/);
+  assert.match(settingsActions, /requireBusiness/);
   assert.match(billingPage, /getBillingUsageSnapshotForBusiness/);
   assert.match(recordingRoute, /getLeadRecordingForOwnerClerkId/);
 });


### PR DESCRIPTION
## Summary
- fix admin/support shortcuts that said they opened customer pages but actually landed on read-only snapshot views
- add a validated admin customer-mode handoff so admin can open the real `/app/...` experience for a selected business without impersonation
- rename remaining snapshot navigation so read-only pages are clearly labeled as snapshots

## Root cause
- admin shortcuts were wired to `/admin/[businessId]/workspace` and in-page snapshot anchors even when their labels said `Open customer ...`
- the labels implied editable customer pages, but the destination was intentionally read-only support context
- that mismatch forced extra clicks and made onboarding/support work slower for the operator

## What changed
- added admin customer-mode routes that set an admin-only acting-business context and redirect into the real customer app
- updated admin board, admin business detail, and support workspace buttons so `Open customer ...` links now open the real customer app pages
- kept the existing support workspace as read-only, but renamed snapshot navigation to `View ... snapshot`
- added an app banner with `Back to operator controls` and `Exit customer mode`
- updated settings actions to resolve the current business through the shared `requireBusiness` path so admin customer mode can edit settings safely

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`
