### PR TITLE
Fix owner invite acceptance auto-link flow

### DIFF
--- a/app/admin/[businessId]/page.tsx
+++ b/app/admin/[businessId]/page.tsx
@@ -388,12 +388,14 @@ export default async function AdminBusinessDetailPage({
     business,
     notificationSettings: business.notificationSettings,
     ownerConnected: ownerState.connected,
+    ownerStatus: ownerState.status,
     webhookSnapshot,
   });
   const onboardingConfidence = buildAdminOnboardingConfidence({
     business,
     notificationSettings: business.notificationSettings,
     ownerConnected: ownerState.connected,
+    ownerStatus: ownerState.status,
     successfulLeadCount,
     operatorEvents: operatorEvents.map((event) => ({
       type: event.type,
@@ -523,7 +525,7 @@ export default async function AdminBusinessDetailPage({
           {ownerStateMessage === 'connected'
             ? 'Owner account connected.'
             : ownerStateMessage === 'invited'
-              ? 'Owner invite sent. Re-run owner connection after the invite is accepted.'
+              ? 'Owner invite sent. After the invite is accepted, CallbackCloser will auto-link the owner on first sign-in.'
               : 'Owner state updated.'}
         </div>
       ) : null}
@@ -569,6 +571,16 @@ export default async function AdminBusinessDetailPage({
                     <Link className={buttonVariants({ size: 'sm' })} href="#advanced">
                       Resume automation
                     </Link>
+                  ) : ownerState.accountReady && ownerState.clerkUserId && ownerState.email ? (
+                    <form action={connectBusinessOwnerAction}>
+                      <input type="hidden" name="businessId" value={business.id} />
+                      <input type="hidden" name="ownerEmail" value={ownerState.email} />
+                      <input type="hidden" name="ownerName" value={ownerState.name || business.ownerName || ''} />
+                      <input type="hidden" name="ownerClerkId" value={ownerState.clerkUserId} />
+                      <Button size="sm" type="submit">
+                        Connect accepted owner
+                      </Button>
+                    </form>
                   ) : !ownerState.connected ? (
                     <Link className={buttonVariants({ size: 'sm' })} href="#business-info">
                       Connect owner
@@ -756,8 +768,24 @@ export default async function AdminBusinessDetailPage({
             <div className="rounded-xl border bg-background/80 p-4">
               <div className="flex flex-wrap items-center gap-2">
                 <p className="font-medium">{ownerState.name || business.ownerName || 'Owner not named yet'}</p>
-                <Badge variant={ownerState.connected ? 'success' : ownerState.pending ? 'outline' : 'destructive'}>
-                  {ownerState.connected ? 'Connected' : ownerState.pending ? 'Pending invite' : 'Needs connection'}
+                <Badge
+                  variant={
+                    ownerState.connected
+                      ? 'success'
+                      : ownerState.accountReady
+                        ? 'secondary'
+                        : ownerState.pending
+                          ? 'outline'
+                          : 'destructive'
+                  }
+                >
+                  {ownerState.connected
+                    ? 'Connected'
+                    : ownerState.accountReady
+                      ? 'Account ready'
+                      : ownerState.pending
+                        ? 'Pending invite'
+                        : 'Needs repair'}
                 </Badge>
               </div>
               <p className="mt-2 text-sm text-muted-foreground">
@@ -765,6 +793,7 @@ export default async function AdminBusinessDetailPage({
               </p>
               {ownerState.clerkUserId ? <p className="mt-2 text-xs text-muted-foreground">{ownerState.clerkUserId}</p> : null}
               {ownerState.invitedAt ? <p className="mt-2 text-xs text-muted-foreground">Invite sent {formatDateTime(ownerState.invitedAt)}</p> : null}
+              <p className="mt-2 text-sm text-muted-foreground">{ownerState.detail}</p>
             </div>
 
             <form action={connectBusinessOwnerAction} className="grid gap-4 md:grid-cols-2 rounded-xl border bg-background/80 p-4">
@@ -779,11 +808,15 @@ export default async function AdminBusinessDetailPage({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="ownerClerkId">Existing Clerk user ID</Label>
-                <Input id="ownerClerkId" name="ownerClerkId" defaultValue={ownerState.connected ? ownerState.clerkUserId || '' : ''} />
+                <Input
+                  id="ownerClerkId"
+                  name="ownerClerkId"
+                  defaultValue={ownerState.connected || ownerState.accountReady || ownerState.needsRepair ? ownerState.clerkUserId || '' : ''}
+                />
               </div>
               <div className="md:col-span-2">
                 <Button type="submit" variant="outline">
-                  Connect or invite owner
+                  {ownerState.accountReady ? 'Connect accepted owner' : 'Connect or invite owner'}
                 </Button>
               </div>
             </form>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -207,13 +207,13 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
     adminBoardFilterOptions.map((option) => [
       option.key,
       businessRows.filter((item) =>
-        matchesAdminBoardFilter(item.business, item.business.notificationSettings, item.ownerConnected, option.key)
+        matchesAdminBoardFilter(item.business, item.business.notificationSettings, item.ownerConnected, undefined, option.key)
       ).length,
     ])
   );
 
   const visibleRows = businessRows.filter((item) =>
-    matchesAdminBoardFilter(item.business, item.business.notificationSettings, item.ownerConnected, view)
+    matchesAdminBoardFilter(item.business, item.business.notificationSettings, item.ownerConnected, undefined, view)
   );
 
   const summaryStats = [

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 
 import { AppNav } from '@/components/app-nav';
 import { db } from '@/lib/db';
+import { getCurrentBusiness } from '@/lib/auth';
 import { getPortfolioDemoBusiness, isPortfolioDemoMode } from '@/lib/portfolio-demo';
 import { getCustomerSystemStatus } from '@/lib/system-status';
 
@@ -30,7 +31,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     redirect('/sign-in');
   }
 
-  const business = await db.business.findUnique({ where: { ownerClerkId: userId } });
+  const business = await getCurrentBusiness();
   const successfulLeadCount = business
     ? await db.lead.count({ where: { businessId: business.id, OR: [{ ownerNotifiedAt: { not: null } }, { notifiedAt: { not: null } }] } })
     : 0;

--- a/app/app/onboarding/page.tsx
+++ b/app/app/onboarding/page.tsx
@@ -34,7 +34,9 @@ export default async function OnboardingPage({
   const existing = await db.business.findUnique({ where: { ownerClerkId: userId } });
   if (existing) redirect('/app/leads');
   const error = typeof searchParams?.error === 'string' ? searchParams.error : undefined;
+  const ownerState = typeof searchParams?.ownerState === 'string' ? searchParams.ownerState : undefined;
   const nextPath = resolveSafeNextPath(typeof searchParams?.next === 'string' ? searchParams.next : undefined);
+  const ownerRepairMode = ownerState === 'needs_repair';
 
   const checklistItems = [
     {
@@ -95,8 +97,12 @@ export default async function OnboardingPage({
 
       <Card>
         <CardHeader>
-          <CardTitle>Business profile and defaults</CardTitle>
-          <CardDescription>Set the core business details so we can get your missed-call coverage live fast.</CardDescription>
+          <CardTitle>{ownerRepairMode ? 'Owner access needs admin repair' : 'Business profile and defaults'}</CardTitle>
+          <CardDescription>
+            {ownerRepairMode
+              ? 'Your Clerk account exists, but the business still needs to be linked by an admin before setup can continue.'
+              : 'Set the core business details so we can get your missed-call coverage live fast.'}
+          </CardDescription>
         </CardHeader>
         <CardContent>
           {error ? (
@@ -104,45 +110,52 @@ export default async function OnboardingPage({
               {error}
             </div>
           ) : null}
-          <form action={saveOnboardingAction} className="grid gap-4 sm:grid-cols-2">
-            <input type="hidden" name="next" value={nextPath} />
-            <div className="sm:col-span-2">
-              <Label htmlFor="name">Business name</Label>
-              <Input id="name" name="name" required placeholder="Acme Plumbing" />
+          {ownerRepairMode ? (
+            <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground">
+              CallbackCloser found your owner account, but the business link needs repair before this workspace can open. Ask the admin to use
+              the visible <span className="font-medium text-foreground">Connect accepted owner</span> action in the admin business page.
             </div>
-            <div>
-              <Label htmlFor="forwardingNumber">Forwarding number</Label>
-              <Input id="forwardingNumber" name="forwardingNumber" required placeholder="+15551234567" />
-            </div>
-            <div>
-              <Label htmlFor="notifyPhone">Owner notify phone</Label>
-              <Input id="notifyPhone" name="notifyPhone" placeholder="+15559876543" />
-              <p className="mt-1 text-xs text-muted-foreground">Recommended. Ready-to-close lead summaries are sent here.</p>
-            </div>
-            <div>
-              <Label htmlFor="missedCallSeconds">Missed-call timeout (seconds)</Label>
-              <Input id="missedCallSeconds" name="missedCallSeconds" type="number" min={5} max={90} defaultValue={20} required />
-            </div>
-            <div>
-              <Label htmlFor="timezone">Timezone</Label>
-              <Input id="timezone" name="timezone" defaultValue="America/New_York" required />
-            </div>
-            <div>
-              <Label htmlFor="serviceLabel1">Service option 1</Label>
-              <Input id="serviceLabel1" name="serviceLabel1" defaultValue="Repair" required />
-            </div>
-            <div>
-              <Label htmlFor="serviceLabel2">Service option 2</Label>
-              <Input id="serviceLabel2" name="serviceLabel2" defaultValue="Install" required />
-            </div>
-            <div>
-              <Label htmlFor="serviceLabel3">Service option 3</Label>
-              <Input id="serviceLabel3" name="serviceLabel3" defaultValue="Maintenance" required />
-            </div>
-            <div className="sm:col-span-2 pt-2">
-              <Button type="submit">Create Business and Continue Setup</Button>
-            </div>
-          </form>
+          ) : (
+            <form action={saveOnboardingAction} className="grid gap-4 sm:grid-cols-2">
+              <input type="hidden" name="next" value={nextPath} />
+              <div className="sm:col-span-2">
+                <Label htmlFor="name">Business name</Label>
+                <Input id="name" name="name" required placeholder="Acme Plumbing" />
+              </div>
+              <div>
+                <Label htmlFor="forwardingNumber">Forwarding number</Label>
+                <Input id="forwardingNumber" name="forwardingNumber" required placeholder="+15551234567" />
+              </div>
+              <div>
+                <Label htmlFor="notifyPhone">Owner notify phone</Label>
+                <Input id="notifyPhone" name="notifyPhone" placeholder="+15559876543" />
+                <p className="mt-1 text-xs text-muted-foreground">Recommended. Ready-to-close lead summaries are sent here.</p>
+              </div>
+              <div>
+                <Label htmlFor="missedCallSeconds">Missed-call timeout (seconds)</Label>
+                <Input id="missedCallSeconds" name="missedCallSeconds" type="number" min={5} max={90} defaultValue={20} required />
+              </div>
+              <div>
+                <Label htmlFor="timezone">Timezone</Label>
+                <Input id="timezone" name="timezone" defaultValue="America/New_York" required />
+              </div>
+              <div>
+                <Label htmlFor="serviceLabel1">Service option 1</Label>
+                <Input id="serviceLabel1" name="serviceLabel1" defaultValue="Repair" required />
+              </div>
+              <div>
+                <Label htmlFor="serviceLabel2">Service option 2</Label>
+                <Input id="serviceLabel2" name="serviceLabel2" defaultValue="Install" required />
+              </div>
+              <div>
+                <Label htmlFor="serviceLabel3">Service option 3</Label>
+                <Input id="serviceLabel3" name="serviceLabel3" defaultValue="Maintenance" required />
+              </div>
+              <div className="sm:col-span-2 pt-2">
+                <Button type="submit">Create Business and Continue Setup</Button>
+              </div>
+            </form>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/lib/admin-dashboard.ts
+++ b/lib/admin-dashboard.ts
@@ -11,6 +11,7 @@ import {
   type OwnerNotification,
 } from '@prisma/client';
 
+import type { OwnerLinkStatus } from '@/lib/business-owner-link';
 import { getManagedTextingNumber, getManagedTwilioStatusSummary } from '@/lib/managed-twilio-status';
 import { formatMessageStatus, isMessageDeliveryIssueStatus } from '@/lib/lead-presenters';
 
@@ -185,12 +186,14 @@ export function buildAdminNextStep(params: {
   business: DashboardBusiness;
   notificationSettings: DashboardNotificationSettings | null;
   ownerConnected: boolean;
+  ownerStatus?: OwnerLinkStatus;
 }): AdminNextStep {
   const { business, notificationSettings, ownerConnected } = params;
   const managedSummary = getManagedTwilioStatusSummary(business);
   const ownerEmail = notificationSettings?.ownerEmail?.trim() || null;
   const ownerPhone = notificationSettings?.ownerPhone?.trim() || business.notifyPhone || null;
   const hasTextingNumber = Boolean(getManagedTextingNumber(business) && (business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid));
+  const ownerStatus = params.ownerStatus ?? (ownerConnected ? 'connected' : 'pending_invite');
 
   if (isBusinessArchived(business)) {
     return {
@@ -228,14 +231,32 @@ export function buildAdminNextStep(params: {
     };
   }
 
-  if (!ownerConnected) {
+  if (ownerStatus === 'needs_repair') {
     return {
-      title: 'Owner account still needs connection',
-      detail: ownerEmail
-        ? 'The business is saved, but the Clerk owner is not attached yet. Re-run the owner connection flow from admin.'
-        : 'Add the owner email first, then connect or invite the owner.',
+      title: 'Owner link needs repair',
+      detail: 'The accepted Clerk owner account could not be linked cleanly. Reconnect the accepted owner from admin.',
       tone: 'attention',
       actionLabel: 'Connect owner',
+    };
+  }
+
+  if (ownerStatus === 'account_ready') {
+    return {
+      title: 'Accepted owner is ready to connect',
+      detail: 'A matching Clerk owner account already exists. Use the one-click connect action to finish the link.',
+      tone: 'pending',
+      actionLabel: 'Connect accepted owner',
+    };
+  }
+
+  if (!ownerConnected) {
+    return {
+      title: 'Owner invitation is still pending',
+      detail: ownerEmail
+        ? 'The business is saved, but the owner has not completed the Clerk invite yet.'
+        : 'Add the owner email first, then connect or invite the owner.',
+      tone: 'pending',
+      actionLabel: 'Wait for acceptance',
     };
   }
 
@@ -373,12 +394,14 @@ export function buildAdminOnboardingConfidence(params: {
   business: DashboardBusiness;
   notificationSettings: DashboardNotificationSettings | null;
   ownerConnected: boolean;
+  ownerStatus?: OwnerLinkStatus;
   successfulLeadCount: number;
   operatorEvents: Array<{ type: string; status: OperatorEventStatus; createdAt: Date }>;
 }) {
   const { business, notificationSettings, ownerConnected, successfulLeadCount, operatorEvents } = params;
   const managedSummary = getManagedTwilioStatusSummary(business);
-  const nextStep = buildAdminNextStep({ business, notificationSettings, ownerConnected });
+  const ownerStatus = params.ownerStatus ?? (ownerConnected ? 'connected' : 'pending_invite');
+  const nextStep = buildAdminNextStep({ business, notificationSettings, ownerConnected, ownerStatus });
   const ownerEmail = notificationSettings?.ownerEmail?.trim() || null;
   const ownerPhone = notificationSettings?.ownerPhone?.trim() || business.notifyPhone || null;
   const hasProfile = Boolean(business.name.trim() && business.forwardingNumber.trim());
@@ -464,7 +487,15 @@ export function buildAdminOnboardingConfidence(params: {
       label: 'Owner connected',
       complete: ownerConnected,
       variant: milestoneVariant({ complete: ownerConnected, blocking: true }),
-      detail: ownerConnected ? 'A Clerk owner is linked to this business.' : ownerEmail ? 'Owner invite or attachment still needs to finish.' : 'Add the owner email and connect the owner account.',
+      detail: ownerConnected
+        ? 'A Clerk owner is linked to this business.'
+        : ownerStatus === 'account_ready'
+          ? 'Accepted owner account found in Clerk. Finish the one-click connect step.'
+          : ownerStatus === 'needs_repair'
+            ? 'Accepted owner exists, but the business link needs repair before setup can continue.'
+            : ownerEmail
+              ? 'Owner invitation is still pending acceptance in Clerk.'
+              : 'Add the owner email and connect the owner account.',
     },
     {
       key: 'owner_alerts',
@@ -632,12 +663,13 @@ export function matchesAdminBoardFilter(
   business: DashboardBusiness,
   notificationSettings: DashboardNotificationSettings | null,
   ownerConnected: boolean,
+  ownerStatus: OwnerLinkStatus | undefined,
   filter: AdminBoardFilter
 ) {
   if (filter === 'all') return true;
 
   const managedSummary = getManagedTwilioStatusSummary(business);
-  const nextStep = buildAdminNextStep({ business, notificationSettings, ownerConnected });
+  const nextStep = buildAdminNextStep({ business, notificationSettings, ownerConnected, ownerStatus });
   const archived = isBusinessArchived(business);
   const paused = isBusinessAutomationPaused(business) && !archived;
 

--- a/lib/admin-provisioning-presenters.ts
+++ b/lib/admin-provisioning-presenters.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import { BusinessProvisioningStatus, type Business, type BusinessNotificationSettings } from '@prisma/client';
 
+import type { OwnerLinkStatus } from '@/lib/business-owner-link';
 import { getManagedTwilioStatusSummary } from '@/lib/managed-twilio-status';
 import { normalizePhoneNumber } from '@/lib/phone';
 
@@ -67,6 +68,7 @@ type ProvisioningChecklistInput = {
   business: AdminBusinessSummary;
   notificationSettings: NotificationSettingsSummary | null;
   ownerConnected: boolean;
+  ownerStatus?: OwnerLinkStatus;
   webhookSnapshot: TwilioWebhookSnapshot | null;
 };
 
@@ -106,12 +108,24 @@ export function buildAdminProvisioningChecklist({
   business,
   notificationSettings,
   ownerConnected,
+  ownerStatus,
   webhookSnapshot,
 }: ProvisioningChecklistInput): AdminProvisioningChecklistItem[] {
   const ownerEmail = notificationSettings?.ownerEmail?.trim() || null;
   const ownerPhone = normalizePhoneNumber(notificationSettings?.ownerPhone || business.notifyPhone || '') || null;
   const messagingServiceReady = Boolean(business.twilioMessagingServiceSid);
   const managedSummary = getManagedTwilioStatusSummary(business);
+  const effectiveOwnerStatus = ownerStatus ?? (ownerConnected ? 'connected' : 'pending_invite');
+  const ownerAccountDetail =
+    effectiveOwnerStatus === 'connected'
+      ? 'A Clerk user is linked to this business.'
+      : effectiveOwnerStatus === 'account_ready'
+        ? 'Accepted owner account found in Clerk. Connect the accepted owner to finish the link.'
+        : effectiveOwnerStatus === 'needs_repair'
+          ? 'Owner link needs repair. Reconnect the accepted owner from the admin owner card.'
+          : ownerEmail
+            ? 'Owner invitation is still pending acceptance in Clerk.'
+            : 'Add an owner email and connect or invite the owner.';
 
   return [
     {
@@ -124,11 +138,7 @@ export function buildAdminProvisioningChecklist({
       key: 'owner_account',
       label: 'Owner account connected',
       complete: ownerConnected,
-      detail: ownerConnected
-        ? 'A Clerk user is linked to this business.'
-        : ownerEmail
-          ? 'Owner account is still pending. Connect the Clerk user or resend the invite.'
-          : 'Add an owner email and connect or invite the owner.',
+      detail: ownerAccountDetail,
     },
     {
       key: 'owner_alerts',

--- a/lib/admin-provisioning.ts
+++ b/lib/admin-provisioning.ts
@@ -7,6 +7,7 @@ import {
   type TwilioWebhookSnapshot,
 } from '@/lib/admin-provisioning-presenters';
 import { ensureBusinessNotificationSettings } from '@/lib/business-notification-settings';
+import { findClerkUserByEmail, getOwnerLinkStateForBusiness, type OwnerLinkState } from '@/lib/business-owner-link';
 import { db } from '@/lib/db';
 import { getConfiguredAppBaseUrl } from '@/lib/env.server';
 import {
@@ -24,12 +25,16 @@ import { getTwilioBusinessClient, hasTwilioClientEnv } from '@/lib/twilio-client
 import { getTwilioWebhookConfig, syncTwilioIncomingPhoneNumberWebhooks, type TwilioWebhookSyncOptions } from '@/lib/twilio';
 
 export type AdminOwnerState = {
-  connected: boolean;
-  pending: boolean;
+  connected: OwnerLinkState['connected'];
+  pending: OwnerLinkState['pending'];
+  accountReady: OwnerLinkState['accountReady'];
+  needsRepair: OwnerLinkState['needsRepair'];
+  status: OwnerLinkState['status'];
   invitedAt: Date | null;
   clerkUserId: string | null;
   name: string | null;
   email: string | null;
+  detail: string;
 };
 
 export {
@@ -41,63 +46,11 @@ export {
 } from '@/lib/admin-provisioning-presenters';
 export type { AdminProvisioningChecklistItem } from '@/lib/admin-provisioning-presenters';
 
-export async function findClerkUserByEmail(email: string) {
-  const normalized = email.trim().toLowerCase();
-  if (!normalized) return null;
-
-  const client = await clerkClient();
-  const result = await client.users.getUserList({
-    emailAddress: [normalized],
-    limit: 1,
-  });
-
-  return result.data[0] ?? null;
-}
-
 export async function getAdminOwnerState(
-  business: Pick<Business, 'ownerClerkId' | 'ownerName' | 'ownerInviteSentAt'>,
+  business: Pick<Business, 'id' | 'ownerClerkId' | 'ownerName' | 'ownerInviteSentAt'>,
   notificationSettings: Pick<BusinessNotificationSettings, 'ownerEmail'> | null
 ): Promise<AdminOwnerState> {
-  const ownerEmail = notificationSettings?.ownerEmail?.trim().toLowerCase() || null;
-
-  if (isPendingOwnerClerkId(business.ownerClerkId)) {
-    return {
-      connected: false,
-      pending: true,
-      invitedAt: business.ownerInviteSentAt,
-      clerkUserId: null,
-      name: business.ownerName?.trim() || null,
-      email: ownerEmail,
-    };
-  }
-
-  try {
-    const client = await clerkClient();
-    const user = await client.users.getUser(business.ownerClerkId);
-    const primaryEmail =
-      user.primaryEmailAddressId
-        ? user.emailAddresses.find((emailAddress) => emailAddress.id === user.primaryEmailAddressId)?.emailAddress
-        : user.emailAddresses[0]?.emailAddress;
-    const fullName = [user.firstName, user.lastName].filter(Boolean).join(' ').trim() || business.ownerName?.trim() || null;
-
-    return {
-      connected: true,
-      pending: false,
-      invitedAt: business.ownerInviteSentAt,
-      clerkUserId: user.id,
-      name: fullName,
-      email: primaryEmail?.trim().toLowerCase() || ownerEmail,
-    };
-  } catch {
-    return {
-      connected: false,
-      pending: false,
-      invitedAt: business.ownerInviteSentAt,
-      clerkUserId: business.ownerClerkId,
-      name: business.ownerName?.trim() || null,
-      email: ownerEmail,
-    };
-  }
+  return getOwnerLinkStateForBusiness(business, notificationSettings);
 }
 
 async function assertOwnerNotAttachedElsewhere(ownerClerkId: string, businessId: string) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,8 +1,39 @@
-import { auth } from '@clerk/nextjs/server';
+import { auth, currentUser } from '@clerk/nextjs/server';
 import { redirect } from 'next/navigation';
 
+import { autoLinkPendingBusinessOwner, getClerkUserDisplayName, getClerkUserEmailAddresses } from '@/lib/business-owner-link';
 import { getBusinessForOwnerClerkId } from '@/lib/business-access';
 import { getPortfolioDemoAuth, getPortfolioDemoBusiness, isPortfolioDemoMode } from '@/lib/portfolio-demo';
+
+async function resolveBusinessForAuthenticatedOwner(userId: string) {
+  const existingBusiness = await getBusinessForOwnerClerkId(userId);
+  if (existingBusiness) {
+    return {
+      business: existingBusiness,
+      ownerLinkStatus: 'connected' as const,
+    };
+  }
+
+  const user = await currentUser();
+  const result = await autoLinkPendingBusinessOwner({
+    clerkUserId: userId,
+    emailAddresses: getClerkUserEmailAddresses(user),
+    ownerName: getClerkUserDisplayName(user),
+  });
+
+  if (result.status === 'connected') {
+    const business = await getBusinessForOwnerClerkId(userId);
+    return {
+      business,
+      ownerLinkStatus: 'connected' as const,
+    };
+  }
+
+  return {
+    business: null,
+    ownerLinkStatus: result.status,
+  };
+}
 
 export async function requireAuth() {
   if (isPortfolioDemoMode()) {
@@ -24,7 +55,8 @@ export async function getCurrentBusiness() {
   const { userId } = await auth();
   if (!userId) return null;
 
-  return getBusinessForOwnerClerkId(userId);
+  const { business } = await resolveBusinessForAuthenticatedOwner(userId);
+  return business;
 }
 
 export async function requireBusiness() {
@@ -33,8 +65,12 @@ export async function requireBusiness() {
   }
 
   const { userId } = await requireAuth();
-  const business = await getBusinessForOwnerClerkId(userId);
+  const { business, ownerLinkStatus } = await resolveBusinessForAuthenticatedOwner(userId);
   if (!business) {
+    if (ownerLinkStatus === 'needs_repair') {
+      redirect('/app/onboarding?ownerState=needs_repair');
+    }
+
     redirect('/app/onboarding');
   }
   return business;

--- a/lib/business-owner-link.ts
+++ b/lib/business-owner-link.ts
@@ -1,0 +1,360 @@
+import { clerkClient } from '@clerk/nextjs/server';
+import { BusinessProvisioningStatus, type Business, type BusinessNotificationSettings } from '@prisma/client';
+
+import { isPendingOwnerClerkId, PENDING_OWNER_PREFIX } from '@/lib/admin-provisioning-presenters';
+import { ensureBusinessNotificationSettings } from '@/lib/business-notification-settings';
+import { db } from '@/lib/db';
+import { recordBusinessOperatorEvent } from '@/lib/operator-events';
+
+type ClerkEmailAddressLike = {
+  id?: string | null;
+  emailAddress?: string | null;
+};
+
+type ClerkUserLike = {
+  id?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  primaryEmailAddressId?: string | null;
+  emailAddresses?: ClerkEmailAddressLike[] | null;
+};
+
+type OwnerStateBusiness = Pick<Business, 'id' | 'ownerClerkId' | 'ownerName' | 'ownerInviteSentAt'>;
+
+type SyncOwnerBusiness = Pick<
+  Business,
+  'id' | 'name' | 'ownerClerkId' | 'ownerName' | 'ownerInviteSentAt' | 'notifyPhone' | 'provisioningStatus' | 'provisioningError'
+> & {
+  notificationSettings: Pick<BusinessNotificationSettings, 'ownerEmail'> | null;
+};
+
+export type OwnerLinkStatus = 'pending_invite' | 'account_ready' | 'connected' | 'needs_repair';
+
+export type OwnerLinkState = {
+  status: OwnerLinkStatus;
+  connected: boolean;
+  pending: boolean;
+  accountReady: boolean;
+  needsRepair: boolean;
+  invitedAt: Date | null;
+  clerkUserId: string | null;
+  name: string | null;
+  email: string | null;
+  detail: string;
+};
+
+export type OwnerAutoLinkResult =
+  | { status: 'connected'; businessId: string }
+  | { status: 'needs_repair'; businessId: string | null; reason: string }
+  | { status: 'no_match'; reason: string };
+
+function normalizeEmail(value: string | null | undefined) {
+  return value?.trim().toLowerCase() || null;
+}
+
+function normalizeEmailList(values: Array<string | null | undefined>) {
+  return Array.from(new Set(values.map((value) => normalizeEmail(value)).filter((value): value is string => Boolean(value))));
+}
+
+function getPrimaryEmailAddress(user: ClerkUserLike | null | undefined) {
+  if (!user?.emailAddresses?.length) {
+    return null;
+  }
+
+  const primary = user.primaryEmailAddressId
+    ? user.emailAddresses.find((emailAddress) => emailAddress.id === user.primaryEmailAddressId)?.emailAddress
+    : user.emailAddresses[0]?.emailAddress;
+
+  return normalizeEmail(primary);
+}
+
+function getDisplayName(user: ClerkUserLike | null | undefined, fallbackName: string | null = null) {
+  const name = [user?.firstName, user?.lastName].filter(Boolean).join(' ').trim();
+  return name || fallbackName || null;
+}
+
+function buildOwnerLinkState(input: {
+  status: OwnerLinkStatus;
+  invitedAt: Date | null;
+  clerkUserId?: string | null;
+  name?: string | null;
+  email?: string | null;
+  detail: string;
+}) {
+  return {
+    status: input.status,
+    connected: input.status === 'connected',
+    pending: input.status === 'pending_invite',
+    accountReady: input.status === 'account_ready',
+    needsRepair: input.status === 'needs_repair',
+    invitedAt: input.invitedAt,
+    clerkUserId: input.clerkUserId ?? null,
+    name: input.name ?? null,
+    email: input.email ?? null,
+    detail: input.detail,
+  } satisfies OwnerLinkState;
+}
+
+function shouldClearOwnerProvisioningError(message: string | null | undefined) {
+  const normalized = message?.trim().toLowerCase() || '';
+  if (!normalized) return false;
+
+  return normalized.includes('owner') || normalized.includes('clerk') || normalized.includes('invite');
+}
+
+async function countOtherPendingBusinessesForOwnerEmail(businessId: string, ownerEmail: string) {
+  return db.business.count({
+    where: {
+      id: { not: businessId },
+      ownerClerkId: { startsWith: PENDING_OWNER_PREFIX },
+      notificationSettings: {
+        is: {
+          ownerEmail,
+        },
+      },
+    },
+  });
+}
+
+async function findExistingBusinessForOwnerClerkId(ownerClerkId: string) {
+  return db.business.findUnique({
+    where: { ownerClerkId },
+    select: { id: true, name: true },
+  });
+}
+
+async function buildPendingOwnerState(
+  business: OwnerStateBusiness & { id: string },
+  ownerEmail: string | null
+): Promise<OwnerLinkState> {
+  if (!ownerEmail) {
+    return buildOwnerLinkState({
+      status: 'pending_invite',
+      invitedAt: business.ownerInviteSentAt,
+      name: business.ownerName?.trim() || null,
+      email: null,
+      detail: 'Owner invite is pending, but the invited email is missing from notification settings.',
+    });
+  }
+
+  const matchedUser = await findClerkUserByEmail(ownerEmail);
+  if (!matchedUser) {
+    return buildOwnerLinkState({
+      status: 'pending_invite',
+      invitedAt: business.ownerInviteSentAt,
+      name: business.ownerName?.trim() || null,
+      email: ownerEmail,
+      detail: 'Owner invite is still pending acceptance in Clerk.',
+    });
+  }
+
+  const [attachedBusiness, duplicatePendingCount] = await Promise.all([
+    findExistingBusinessForOwnerClerkId(matchedUser.id),
+    countOtherPendingBusinessesForOwnerEmail(business.id, ownerEmail),
+  ]);
+
+  const primaryEmail = getPrimaryEmailAddress(matchedUser) || ownerEmail;
+  const displayName = getDisplayName(matchedUser, business.ownerName?.trim() || null);
+
+  if (attachedBusiness && attachedBusiness.id !== business.id) {
+    return buildOwnerLinkState({
+      status: 'needs_repair',
+      invitedAt: business.ownerInviteSentAt,
+      clerkUserId: matchedUser.id,
+      name: displayName,
+      email: primaryEmail,
+      detail: `Accepted owner exists in Clerk, but that user is already attached to ${attachedBusiness.name}.`,
+    });
+  }
+
+  if (duplicatePendingCount > 0) {
+    return buildOwnerLinkState({
+      status: 'needs_repair',
+      invitedAt: business.ownerInviteSentAt,
+      clerkUserId: matchedUser.id,
+      name: displayName,
+      email: primaryEmail,
+      detail: 'Accepted owner exists in Clerk, but multiple pending businesses still share that invited email.',
+    });
+  }
+
+  return buildOwnerLinkState({
+    status: 'account_ready',
+    invitedAt: business.ownerInviteSentAt,
+    clerkUserId: matchedUser.id,
+    name: displayName,
+    email: primaryEmail,
+    detail: 'Accepted owner account was found in Clerk and is ready to connect.',
+  });
+}
+
+export function getClerkUserEmailAddresses(user: ClerkUserLike | null | undefined) {
+  return normalizeEmailList((user?.emailAddresses || []).map((emailAddress) => emailAddress.emailAddress));
+}
+
+export function getClerkUserDisplayName(user: ClerkUserLike | null | undefined, fallbackName: string | null = null) {
+  return getDisplayName(user, fallbackName);
+}
+
+export async function findClerkUserByEmail(email: string) {
+  const normalized = normalizeEmail(email);
+  if (!normalized) return null;
+
+  const client = await clerkClient();
+  const result = await client.users.getUserList({
+    emailAddress: [normalized],
+    limit: 1,
+  });
+
+  return result.data[0] ?? null;
+}
+
+export async function getOwnerLinkStateForBusiness(
+  business: OwnerStateBusiness,
+  notificationSettings: Pick<BusinessNotificationSettings, 'ownerEmail'> | null
+): Promise<OwnerLinkState> {
+  const ownerEmail = normalizeEmail(notificationSettings?.ownerEmail);
+
+  if (isPendingOwnerClerkId(business.ownerClerkId)) {
+    return buildPendingOwnerState(business, ownerEmail);
+  }
+
+  try {
+    const client = await clerkClient();
+    const user = await client.users.getUser(business.ownerClerkId);
+
+    return buildOwnerLinkState({
+      status: 'connected',
+      invitedAt: business.ownerInviteSentAt,
+      clerkUserId: user.id,
+      name: getDisplayName(user, business.ownerName?.trim() || null),
+      email: getPrimaryEmailAddress(user) || ownerEmail,
+      detail: 'A Clerk owner is linked to this business.',
+    });
+  } catch {
+    const matchedUser = ownerEmail ? await findClerkUserByEmail(ownerEmail) : null;
+
+    return buildOwnerLinkState({
+      status: 'needs_repair',
+      invitedAt: business.ownerInviteSentAt,
+      clerkUserId: matchedUser?.id || business.ownerClerkId,
+      name: getDisplayName(matchedUser, business.ownerName?.trim() || null),
+      email: getPrimaryEmailAddress(matchedUser) || ownerEmail,
+      detail: matchedUser
+        ? 'A Clerk owner account was found for the invited email, but the saved owner link is stale and needs repair.'
+        : 'The saved Clerk owner link could not be verified and needs repair.',
+    });
+  }
+}
+
+export async function autoLinkPendingBusinessOwner(params: {
+  clerkUserId: string;
+  emailAddresses: string[];
+  ownerName?: string | null;
+}) {
+  const ownerEmails = normalizeEmailList(params.emailAddresses);
+  if (!params.clerkUserId.trim() || ownerEmails.length === 0) {
+    return { status: 'no_match', reason: 'No verified Clerk email address was available for owner auto-linking.' } satisfies OwnerAutoLinkResult;
+  }
+
+  const existingBusiness = await findExistingBusinessForOwnerClerkId(params.clerkUserId);
+  if (existingBusiness) {
+    return { status: 'connected', businessId: existingBusiness.id } satisfies OwnerAutoLinkResult;
+  }
+
+  const matchingBusinesses = await db.business.findMany({
+    where: {
+      ownerClerkId: { startsWith: PENDING_OWNER_PREFIX },
+      notificationSettings: {
+        is: {
+          ownerEmail: {
+            in: ownerEmails,
+          },
+        },
+      },
+    },
+    include: {
+      notificationSettings: {
+        select: {
+          ownerEmail: true,
+        },
+      },
+    },
+    orderBy: {
+      ownerInviteSentAt: 'desc',
+    },
+  });
+
+  if (matchingBusinesses.length === 0) {
+    return { status: 'no_match', reason: 'No pending owner invitation matched the authenticated Clerk email address.' } satisfies OwnerAutoLinkResult;
+  }
+
+  if (matchingBusinesses.length > 1) {
+    return {
+      status: 'needs_repair',
+      businessId: null,
+      reason: 'Multiple pending businesses matched the accepted owner email. Manual admin repair is required.',
+    } satisfies OwnerAutoLinkResult;
+  }
+
+  const business = matchingBusinesses[0] as SyncOwnerBusiness;
+  const ownerEmail = normalizeEmail(business.notificationSettings?.ownerEmail) || ownerEmails[0];
+  const ownerName = params.ownerName?.trim() || business.ownerName?.trim() || null;
+  const clearOwnerError = shouldClearOwnerProvisioningError(business.provisioningError);
+
+  await db.business.update({
+    where: { id: business.id },
+    data: {
+      ownerClerkId: params.clerkUserId,
+      ownerName,
+      ownerInviteSentAt: null,
+      ...(clearOwnerError
+        ? {
+            provisioningStatus:
+              business.provisioningStatus === BusinessProvisioningStatus.NEEDS_ATTENTION
+                ? BusinessProvisioningStatus.ONBOARDING
+                : business.provisioningStatus,
+            provisioningError: null,
+          }
+        : {}),
+    },
+  });
+
+  await ensureBusinessNotificationSettings(
+    {
+      id: business.id,
+      ownerClerkId: params.clerkUserId,
+      notifyPhone: business.notifyPhone,
+    },
+    {
+      ownerEmail,
+    }
+  );
+
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'onboarding.owner_invite_accepted',
+    category: 'ONBOARDING',
+    status: 'SUCCESS',
+    summary: 'Owner invitation accepted in Clerk',
+    details: {
+      ownerClerkId: params.clerkUserId,
+      ownerEmail,
+    },
+  });
+
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'onboarding.owner_connected',
+    category: 'ONBOARDING',
+    status: 'SUCCESS',
+    summary: 'Owner connected to business',
+    details: {
+      ownerClerkId: params.clerkUserId,
+      ownerEmail,
+      autoLinked: true,
+    },
+  });
+
+  return { status: 'connected', businessId: business.id } satisfies OwnerAutoLinkResult;
+}

--- a/tests/admin-dashboard.test.ts
+++ b/tests/admin-dashboard.test.ts
@@ -103,6 +103,49 @@ test('next-step guidance stays explicit for owner setup and pending A2P review',
   assert.equal(missingOwnerContact.title, 'Owner contact info is missing');
   assert.equal(missingOwnerContact.actionLabel, 'Save owner contact info');
 
+  const pendingOwnerInvite = buildAdminNextStep({
+    business: createBusiness({
+      notifyPhone: null,
+      twilioSubaccountSid: null,
+      twilioMessagingServiceSid: null,
+      twilioPrimaryNumberSid: null,
+      twilioPhoneNumberSid: null,
+      twilioPrimaryPhoneNumber: null,
+      twilioPhoneNumber: null,
+      managedTwilioStatus: ManagedTwilioStatus.DRAFT,
+    }),
+    notificationSettings: createNotificationSettings({
+      ownerPhone: null,
+      ownerEmail: 'owner@example.com',
+    }),
+    ownerConnected: false,
+    ownerStatus: 'pending_invite',
+  });
+
+  assert.equal(pendingOwnerInvite.title, 'Owner invitation is still pending');
+  assert.equal(pendingOwnerInvite.tone, 'pending');
+
+  const acceptedOwnerReady = buildAdminNextStep({
+    business: createBusiness({
+      notifyPhone: null,
+      twilioSubaccountSid: null,
+      twilioMessagingServiceSid: null,
+      twilioPrimaryNumberSid: null,
+      twilioPhoneNumberSid: null,
+      twilioPrimaryPhoneNumber: null,
+      twilioPhoneNumber: null,
+      managedTwilioStatus: ManagedTwilioStatus.DRAFT,
+    }),
+    notificationSettings: createNotificationSettings({
+      ownerPhone: null,
+    }),
+    ownerConnected: false,
+    ownerStatus: 'account_ready',
+  });
+
+  assert.equal(acceptedOwnerReady.title, 'Accepted owner is ready to connect');
+  assert.equal(acceptedOwnerReady.actionLabel, 'Connect accepted owner');
+
   const pendingA2p = buildAdminNextStep({
     business: createBusiness({
       managedTwilioStatus: ManagedTwilioStatus.CAMPAIGN_SUBMITTED,
@@ -124,11 +167,11 @@ test('board filters and delete guard stay conservative', () => {
 
   assert.equal(canDeleteTestBusiness(pausedTestBusiness), true);
   assert.equal(
-    matchesAdminBoardFilter(pausedTestBusiness, createNotificationSettings(), true, 'archived'),
+    matchesAdminBoardFilter(pausedTestBusiness, createNotificationSettings(), true, undefined, 'archived'),
     true
   );
   assert.equal(
-    matchesAdminBoardFilter(createBusiness(), createNotificationSettings(), true, 'pending_a2p'),
+    matchesAdminBoardFilter(createBusiness(), createNotificationSettings(), true, undefined, 'pending_a2p'),
     true
   );
   assert.equal(
@@ -190,6 +233,27 @@ test('onboarding confidence distinguishes ready-for-test from ready-for-live', (
   assert.equal(readyForTest.readyForTest, true);
   assert.equal(readyForTest.canSafelyMarkLive, false);
   assert.match(readyForTest.nextAction, /test/i);
+
+  const acceptedOwnerPendingConnect = buildAdminOnboardingConfidence({
+    business: createBusiness({
+      twilioSubaccountSid: null,
+      twilioMessagingServiceSid: null,
+      twilioPrimaryNumberSid: null,
+      twilioPhoneNumberSid: null,
+      twilioPrimaryPhoneNumber: null,
+      twilioPhoneNumber: null,
+      managedTwilioStatus: ManagedTwilioStatus.DRAFT,
+    }),
+    notificationSettings: createNotificationSettings(),
+    ownerConnected: false,
+    ownerStatus: 'account_ready',
+    successfulLeadCount: 0,
+    operatorEvents: [],
+  });
+
+  const ownerMilestone = acceptedOwnerPendingConnect.milestones.find((item) => item.key === 'owner_connected');
+  assert.equal(acceptedOwnerPendingConnect.state, 'in_setup');
+  assert.match(ownerMilestone?.detail || '', /accepted owner account found/i);
 
   const readyForLive = buildAdminOnboardingConfidence({
     business: createBusiness({

--- a/tests/admin-provisioning.test.ts
+++ b/tests/admin-provisioning.test.ts
@@ -89,6 +89,29 @@ test('admin provisioning checklist surfaces incomplete rollout steps clearly', (
   assert.equal(a2pStep?.complete, false);
 });
 
+test('admin provisioning checklist distinguishes accepted owner from a truly pending invite', () => {
+  const checklist = buildAdminProvisioningChecklist({
+    business: createBusiness({
+      ownerClerkId: buildPendingOwnerClerkId(),
+    }),
+    notificationSettings: {
+      ownerPhone: null,
+      ownerEmail: 'owner@example.com',
+      notifySms: true,
+      notifyEmail: true,
+      notifyInApp: true,
+      urgentOnly: false,
+    },
+    ownerConnected: false,
+    ownerStatus: 'account_ready',
+    webhookSnapshot: null,
+  });
+
+  const ownerStep = checklist.find((item) => item.key === 'owner_account');
+  assert.equal(ownerStep?.complete, false);
+  assert.match(ownerStep?.detail || '', /accepted owner account found in Clerk/i);
+});
+
 test('admin provisioning checklist shows completed rollout when owner, messaging, and webhooks are ready', () => {
   const checklist = buildAdminProvisioningChecklist({
     business: createBusiness({

--- a/tests/business-owner-link.test.ts
+++ b/tests/business-owner-link.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+
+import { BusinessProvisioningStatus } from '@prisma/client';
+
+import { buildPendingOwnerClerkId } from '../lib/admin-provisioning-presenters.ts';
+import { autoLinkPendingBusinessOwner } from '../lib/business-owner-link.ts';
+import { db } from '../lib/db.ts';
+
+function createOwnerEmail(seed: string) {
+  return `owner-${seed.slice(0, 8)}@example.com`;
+}
+
+test('autoLinkPendingBusinessOwner links an accepted owner and clears owner-specific admin blockers', async () => {
+  const seed = randomUUID();
+  const ownerEmail = createOwnerEmail(seed);
+  const business = await db.business.create({
+    data: {
+      ownerClerkId: buildPendingOwnerClerkId(),
+      ownerName: 'Casey Owner',
+      name: `Auto Link HVAC ${seed.slice(0, 6)}`,
+      forwardingNumber: '+15125550100',
+      notifyPhone: '+15125550101',
+      provisioningStatus: BusinessProvisioningStatus.NEEDS_ATTENTION,
+      provisioningError: 'Owner setup failed after business creation',
+      ownerInviteSentAt: new Date('2026-04-20T12:00:00.000Z'),
+      notificationSettings: {
+        create: {
+          ownerEmail,
+          ownerPhone: '+15125550101',
+        },
+      },
+    },
+    include: {
+      notificationSettings: true,
+    },
+  });
+
+  try {
+    const result = await autoLinkPendingBusinessOwner({
+      clerkUserId: `user_${seed.replace(/-/g, '')}`,
+      emailAddresses: [ownerEmail],
+      ownerName: 'Casey Accepted',
+    });
+
+    assert.equal(result.status, 'connected');
+    assert.equal(result.businessId, business.id);
+
+    const refreshed = await db.business.findUniqueOrThrow({
+      where: { id: business.id },
+      include: {
+        notificationSettings: true,
+      },
+    });
+    const operatorEvents = await db.businessOperatorEvent.findMany({
+      where: { businessId: business.id },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    assert.equal(refreshed.ownerClerkId, `user_${seed.replace(/-/g, '')}`);
+    assert.equal(refreshed.ownerName, 'Casey Accepted');
+    assert.equal(refreshed.ownerInviteSentAt, null);
+    assert.equal(refreshed.provisioningStatus, BusinessProvisioningStatus.ONBOARDING);
+    assert.equal(refreshed.provisioningError, null);
+    assert.equal(refreshed.notificationSettings?.ownerEmail, ownerEmail);
+    assert.equal(operatorEvents.some((event) => event.type === 'onboarding.owner_invite_accepted'), true);
+    assert.equal(operatorEvents.some((event) => event.type === 'onboarding.owner_connected'), true);
+  } finally {
+    await db.business.delete({ where: { id: business.id } });
+  }
+});
+
+test('autoLinkPendingBusinessOwner surfaces repair when multiple pending businesses share the invited email', async () => {
+  const seed = randomUUID();
+  const ownerEmail = createOwnerEmail(seed);
+  const businessIds: string[] = [];
+
+  try {
+    for (const suffix of ['a', 'b']) {
+      const business = await db.business.create({
+        data: {
+          ownerClerkId: buildPendingOwnerClerkId(),
+          ownerName: `Casey Owner ${suffix.toUpperCase()}`,
+          name: `Repair ${suffix.toUpperCase()} ${seed.slice(0, 6)}`,
+          forwardingNumber: '+15125550200',
+          ownerInviteSentAt: new Date('2026-04-20T12:00:00.000Z'),
+          notificationSettings: {
+            create: {
+              ownerEmail,
+            },
+          },
+        },
+      });
+      businessIds.push(business.id);
+    }
+
+    const result = await autoLinkPendingBusinessOwner({
+      clerkUserId: `user_${seed.replace(/-/g, '')}`,
+      emailAddresses: [ownerEmail],
+      ownerName: 'Casey Accepted',
+    });
+
+    assert.equal(result.status, 'needs_repair');
+    assert.match(result.reason, /multiple pending businesses/i);
+
+    const refreshed = await db.business.findMany({
+      where: { id: { in: businessIds } },
+      orderBy: { id: 'asc' },
+    });
+
+    assert.equal(refreshed.every((business) => business.ownerClerkId.startsWith('pending_owner_')), true);
+  } finally {
+    await db.business.deleteMany({ where: { id: { in: businessIds } } });
+  }
+});


### PR DESCRIPTION
## Summary
- auto-link accepted Clerk owner accounts to pending businesses on first authenticated app load
- add explicit admin owner states for pending invite, account ready, connected, and needs repair
- add a visible one-click repair path plus tests for accepted-owner linking and ambiguity handling

## Validation
- npm install
- npm run env:check
- npm run typecheck
- npm run lint
- npm run test
- npm run build