### PR TITLE
Add bulk test/demo business reset tool

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -13,6 +13,11 @@ import {
 } from '@/lib/admin-provisioning';
 import { requireAdmin } from '@/lib/admin';
 import { canDeleteTestBusiness } from '@/lib/admin-dashboard';
+import {
+  bulkDeleteTestDemoBusinesses,
+  BULK_TEST_DATA_RESET_CONFIRMATION,
+  DEMO_OWNER_CLERK_ID,
+} from '@/lib/admin-test-data-reset';
 import { logAuditEvent } from '@/lib/audit-log';
 import { db } from '@/lib/db';
 import { formatPhoneDetail, maskSid, recordBusinessOperatorEvent } from '@/lib/operator-events';
@@ -20,6 +25,7 @@ import { maskPhoneForAudit, normalizePhoneNumber, normalizePhoneNumberToE164 } f
 import { sendAndPersistOutboundMessage } from '@/lib/twilio-messaging';
 import {
   adminArchiveBusinessSchema,
+  adminBulkDeleteTestBusinessesSchema,
   adminBusinessDraftSchema,
   adminDeleteBusinessSchema,
   adminSendTestSmsSchema,
@@ -30,7 +36,6 @@ import {
   adminWebhookSyncSchema,
 } from '@/lib/validators';
 
-const DEMO_OWNER_CLERK_ID = 'simulator_demo_callbackcloser';
 const DEFAULT_DEMO_NAME = 'CallbackCloser Demo';
 const DEFAULT_DEMO_TEXTING_NUMBER = '+15005550006';
 const DEFAULT_DEMO_FORWARDING_NUMBER = '+15005550001';
@@ -939,4 +944,39 @@ export async function deleteTestBusinessAction(formData: FormData) {
 
   revalidatePath('/admin');
   redirect('/admin?deleted=1');
+}
+
+export async function bulkDeleteTestBusinessesAction(formData: FormData) {
+  const admin = await requireAdmin();
+
+  const parsed = adminBulkDeleteTestBusinessesSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    redirect(`/admin?error=${encodeURIComponent(parsed.error.issues[0]?.message || 'Invalid reset request.')}`);
+  }
+
+  try {
+    const result = await bulkDeleteTestDemoBusinesses({
+      confirmation: parsed.data.confirmationText,
+    });
+
+    logAuditEvent({
+      event: 'admin_test_businesses_bulk_deleted',
+      actorType: 'user',
+      actorId: admin.userId,
+      targetType: 'business_collection',
+      targetId: 'test_demo_businesses',
+      metadata: {
+        actorEmail: admin.email,
+        deletedCount: result.deletedCount,
+        deletedBusinessNames: result.deletedBusinessNames,
+        confirmationText: BULK_TEST_DATA_RESET_CONFIRMATION,
+      },
+    });
+
+    revalidatePath('/admin');
+    redirect(`/admin?resetDeleted=${encodeURIComponent(String(result.deletedCount))}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to delete test/demo businesses.';
+    redirect(`/admin?error=${encodeURIComponent(message)}`);
+  }
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,12 +1,17 @@
 import Link from 'next/link';
 
 import {
+  bulkDeleteTestBusinessesAction,
   createAdminBusinessAction,
   createDemoBusinessAction,
   provisionBusinessAction,
   resyncBusinessWebhooksAction,
   sendBusinessTestSmsAction,
 } from '@/app/admin/actions';
+import {
+  BULK_TEST_DATA_RESET_CONFIRMATION,
+  listTestDemoBusinessesForReset,
+} from '@/lib/admin-test-data-reset';
 import {
   adminBoardFilterOptions,
   buildAdminNextStep,
@@ -77,12 +82,13 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   const createdDemo = getQueryValue(searchParams, 'createdDemo') === '1';
   const createdBusinessId = getQueryValue(searchParams, 'businessId');
   const deleted = getQueryValue(searchParams, 'deleted') === '1';
+  const resetDeleted = Number(getQueryValue(searchParams, 'resetDeleted') || '0');
   const error = getQueryValue(searchParams, 'error');
   const query = getQueryValue(searchParams, 'q')?.trim() || '';
   const view = (getQueryValue(searchParams, 'view') as AdminBoardFilter | null) || 'all';
   const adminBusiness = await db.business.findUnique({ where: { ownerClerkId: admin.userId } });
 
-  const [businesses, leadCounts, leadActivity, callActivity, messageActivity, operatorSignals] = await Promise.all([
+  const [businesses, leadCounts, leadActivity, callActivity, messageActivity, operatorSignals, resettableBusinesses] = await Promise.all([
     query
       ? searchBusinessesForAdmin(query)
       : db.business.findMany({
@@ -121,6 +127,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       },
       take: 600,
     }),
+    listTestDemoBusinessesForReset(),
   ]);
 
   const leadCountMap = new Map(leadCounts.map((item) => [item.businessId, item._count._all]));
@@ -222,6 +229,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
     { label: 'Live', value: filterCounts.get('live') ?? 0 },
     { label: 'Archived', value: filterCounts.get('archived') ?? 0 },
   ];
+  const resettableBusinessPreview = resettableBusinesses.slice(0, 4).map((business) => business.name);
 
   return (
     <div className="container space-y-6 py-8">
@@ -252,6 +260,11 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
 
       {error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{error}</div> : null}
       {deleted ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Archived test business deleted.</div> : null}
+      {Number.isFinite(resetDeleted) && resetDeleted > 0 ? (
+        <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">
+          Deleted {resetDeleted} test/demo {resetDeleted === 1 ? 'business' : 'businesses'}.
+        </div>
+      ) : null}
       {createdDemo && createdBusinessId ? (
         <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">
           Demo business ready. Use <code className="rounded bg-background px-1 py-0.5">{createdBusinessId}</code> as `SIMULATOR_BUSINESS_ID`, or open the
@@ -365,6 +378,51 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
           </CardContent>
         </Card>
       </div>
+
+      <Card className="border-destructive/30 bg-destructive/5">
+        <CardHeader>
+          <CardTitle>Reset test data</CardTitle>
+          <CardDescription>
+            Founder/admin-only destructive cleanup. This removes every current test/demo business and its business-owned data so you can restart from a clean slate.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+          <div className="rounded-xl border bg-background/80 p-4 text-sm">
+            <p className="font-medium text-foreground">
+              {resettableBusinesses.length} test/demo {resettableBusinesses.length === 1 ? 'business' : 'businesses'} eligible for deletion
+            </p>
+            <p className="mt-2 text-muted-foreground">
+              Only businesses marked as test/demo or the dedicated simulator demo workspace are included. Real customer businesses stay untouched.
+            </p>
+            {resettableBusinessPreview.length > 0 ? (
+              <p className="mt-3 text-muted-foreground">
+                Preview: {resettableBusinessPreview.join(', ')}
+                {resettableBusinesses.length > resettableBusinessPreview.length ? ` and ${resettableBusinesses.length - resettableBusinessPreview.length} more.` : '.'}
+              </p>
+            ) : (
+              <p className="mt-3 text-muted-foreground">No test/demo businesses are currently eligible for cleanup.</p>
+            )}
+          </div>
+
+          <form action={bulkDeleteTestBusinessesAction} className="rounded-xl border border-destructive/30 bg-background/80 p-4">
+            <div className="space-y-2">
+              <Label htmlFor="confirmationText">Type {BULK_TEST_DATA_RESET_CONFIRMATION}</Label>
+              <Input
+                id="confirmationText"
+                name="confirmationText"
+                autoComplete="off"
+                placeholder={BULK_TEST_DATA_RESET_CONFIRMATION}
+              />
+            </div>
+            <p className="mt-3 text-xs text-muted-foreground">
+              This is irreversible. Deleting a business also removes its business-scoped leads, calls, messages, notifications, operator events, settings, and related demo data through the existing schema cascades.
+            </p>
+            <Button className="mt-4" type="submit" variant="destructive" disabled={resettableBusinesses.length === 0}>
+              Delete all test/demo businesses
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
 
       <Card className="bg-card/90">
         <CardHeader>

--- a/lib/admin-dashboard.ts
+++ b/lib/admin-dashboard.ts
@@ -11,6 +11,7 @@ import {
   type OwnerNotification,
 } from '@prisma/client';
 
+import { isTestDemoBusiness } from '@/lib/admin-test-data-reset';
 import { getManagedTextingNumber, getManagedTwilioStatusSummary } from '@/lib/managed-twilio-status';
 import { formatMessageStatus, isMessageDeliveryIssueStatus } from '@/lib/lead-presenters';
 
@@ -143,8 +144,6 @@ export const adminBoardFilterOptions: AdminBoardFilterOption[] = [
   { key: 'archived', label: 'Archived' },
 ];
 
-const DEMO_OWNER_CLERK_ID = 'simulator_demo_callbackcloser';
-
 export function isBusinessArchived(business: Pick<DashboardBusiness, 'archivedAt'>) {
   return Boolean(business.archivedAt);
 }
@@ -158,7 +157,7 @@ export function isBusinessAutomationPaused(
 export function canDeleteTestBusiness(
   business: Pick<DashboardBusiness, 'isTestBusiness' | 'ownerClerkId' | 'archivedAt'>
 ) {
-  return isBusinessArchived(business) && (business.isTestBusiness || business.ownerClerkId === DEMO_OWNER_CLERK_ID);
+  return isBusinessArchived(business) && isTestDemoBusiness(business);
 }
 
 export function getBusinessLifecycleLabel(

--- a/lib/admin-test-data-reset.ts
+++ b/lib/admin-test-data-reset.ts
@@ -1,0 +1,77 @@
+import type { Business, Prisma } from '@prisma/client';
+
+import { db } from '@/lib/db';
+
+export const DEMO_OWNER_CLERK_ID = 'simulator_demo_callbackcloser';
+export const BULK_TEST_DATA_RESET_CONFIRMATION = 'DELETE TEST BUSINESSES';
+
+type TestDemoBusinessMarker = Pick<Business, 'isTestBusiness' | 'ownerClerkId'>;
+
+export type TestDemoBusinessResetCandidate = Pick<Business, 'id' | 'name' | 'isTestBusiness' | 'ownerClerkId' | 'archivedAt'>;
+
+function normalizeConfirmation(value: string | null | undefined) {
+  return value?.trim().toUpperCase() || '';
+}
+
+export function isTestDemoBusiness(business: TestDemoBusinessMarker) {
+  return business.isTestBusiness || business.ownerClerkId === DEMO_OWNER_CLERK_ID;
+}
+
+export function buildTestDemoBusinessWhere(): Prisma.BusinessWhereInput {
+  return {
+    OR: [{ isTestBusiness: true }, { ownerClerkId: DEMO_OWNER_CLERK_ID }],
+  };
+}
+
+export async function listTestDemoBusinessesForReset(candidateIds?: string[]) {
+  return db.business.findMany({
+    where: {
+      AND: [
+        buildTestDemoBusinessWhere(),
+        candidateIds?.length
+          ? {
+              id: {
+                in: candidateIds,
+              },
+            }
+          : {},
+      ],
+    },
+    orderBy: [{ isTestBusiness: 'desc' }, { updatedAt: 'desc' }],
+    select: {
+      id: true,
+      name: true,
+      isTestBusiness: true,
+      ownerClerkId: true,
+      archivedAt: true,
+    },
+  });
+}
+
+export async function bulkDeleteTestDemoBusinesses(params: { confirmation: string; candidateIds?: string[] }) {
+  if (normalizeConfirmation(params.confirmation) !== BULK_TEST_DATA_RESET_CONFIRMATION) {
+    throw new Error(`Type ${BULK_TEST_DATA_RESET_CONFIRMATION} to confirm deleting all test/demo businesses.`);
+  }
+
+  const candidates = await listTestDemoBusinessesForReset(params.candidateIds);
+  const candidateIds = candidates.map((business) => business.id);
+  if (candidateIds.length === 0) {
+    return {
+      deletedCount: 0,
+      deletedBusinessNames: [] as string[],
+    };
+  }
+
+  const result = await db.business.deleteMany({
+    where: {
+      id: {
+        in: candidateIds,
+      },
+    },
+  });
+
+  return {
+    deletedCount: result.count,
+    deletedBusinessNames: candidates.map((business) => business.name),
+  };
+}

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -140,6 +140,10 @@ export const adminDeleteBusinessSchema = z.object({
   confirmationName: z.string().trim().min(1),
 });
 
+export const adminBulkDeleteTestBusinessesSchema = z.object({
+  confirmationText: z.string().trim().min(1),
+});
+
 export const businessTwilioAdminOverrideSchema = z.object({
   twilioPhoneNumber: z.string().trim().max(30).optional().or(z.literal('')),
   twilioPhoneNumberSid: z.string().trim().max(64).optional().or(z.literal('')),

--- a/tests/admin-operator-routes.test.ts
+++ b/tests/admin-operator-routes.test.ts
@@ -10,11 +10,17 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   const adminHome = read('app/admin/page.tsx');
   const adminDetail = read('app/admin/[businessId]/page.tsx');
   const supportWorkspace = read('app/admin/[businessId]/workspace/page.tsx');
+  const adminActions = read('app/admin/actions.ts');
 
   assert.match(adminHome, /Operator control panel/);
   assert.match(adminHome, /Fast onboard/);
+  assert.match(adminHome, /Reset test data/);
+  assert.match(adminHome, /Delete all test\/demo businesses/);
+  assert.match(adminHome, /BULK_TEST_DATA_RESET_CONFIRMATION/);
   assert.match(adminHome, /Business triage board/);
   assert.match(adminHome, /Open customer leads/);
+  assert.match(adminActions, /export async function bulkDeleteTestBusinessesAction/);
+  assert.match(adminActions, /const admin = await requireAdmin\(\)/);
   assert.match(adminDetail, /Onboarding confidence/);
   assert.match(adminDetail, /Business info/);
   assert.match(adminDetail, /Provisioning health/);

--- a/tests/admin-test-data-reset.test.ts
+++ b/tests/admin-test-data-reset.test.ts
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+
+import {
+  bulkDeleteTestDemoBusinesses,
+  BULK_TEST_DATA_RESET_CONFIRMATION,
+  DEMO_OWNER_CLERK_ID,
+  isTestDemoBusiness,
+} from '../lib/admin-test-data-reset.ts';
+import { db } from '../lib/db.ts';
+
+function uniqueDigits(seed: string) {
+  const digits = seed.replace(/\D/g, '').padEnd(10, '7');
+  return digits.slice(-10);
+}
+
+function makePhone(seed: string, suffix: string) {
+  return `+1${uniqueDigits(`${seed}${suffix}`)}`;
+}
+
+function makeSid(prefix: string, seed: string) {
+  const normalized = seed.replace(/-/g, '').padEnd(32, '0');
+  return `${prefix}${normalized.slice(0, 32)}`;
+}
+
+async function seedResetCandidateBusiness(params: { seed: string; testBusiness: boolean }) {
+  const now = new Date('2026-04-20T12:00:00.000Z');
+  const ownerClerkId = `owner_${params.seed}`;
+  const business = await db.business.create({
+    data: {
+      ownerClerkId,
+      name: `Reset Candidate ${params.seed.slice(0, 6)}`,
+      isTestBusiness: params.testBusiness,
+      forwardingNumber: makePhone(params.seed, '100'),
+      notifyPhone: makePhone(params.seed, '200'),
+      missedCallSeconds: 20,
+      timezone: 'America/New_York',
+      serviceLabel1: 'Repair',
+      serviceLabel2: 'Install',
+      serviceLabel3: 'Maintenance',
+      twilioPhoneNumber: makePhone(params.seed, '300'),
+      twilioPrimaryPhoneNumber: makePhone(params.seed, '300'),
+      twilioPhoneNumberSid: makeSid('PN', `${params.seed}phone`),
+      twilioPrimaryNumberSid: makeSid('PX', `${params.seed}primary`),
+      twilioMessagingServiceSid: makeSid('MG', `${params.seed}service`),
+      twilioSubaccountSid: makeSid('AC', `${params.seed}subaccount`),
+      ownerInviteSentAt: now,
+      notificationSettings: {
+        create: {
+          ownerEmail: `owner-${params.seed.slice(0, 8)}@example.com`,
+          ownerPhone: makePhone(params.seed, '200'),
+        },
+      },
+    },
+  });
+
+  const call = await db.call.create({
+    data: {
+      businessId: business.id,
+      twilioCallSid: makeSid('CA', `${params.seed}call`),
+      fromPhone: makePhone(params.seed, '400'),
+      fromPhoneNormalized: makePhone(params.seed, '400'),
+      toPhone: business.twilioPrimaryPhoneNumber!,
+      toPhoneNormalized: business.twilioPrimaryPhoneNumber!,
+      status: 'MISSED',
+      missed: true,
+    },
+  });
+
+  const lead = await db.lead.create({
+    data: {
+      businessId: business.id,
+      callId: call.id,
+      callerPhone: call.fromPhone,
+      callerPhoneNormalized: call.fromPhoneNormalized,
+      summary: 'Reset candidate lead',
+    },
+  });
+
+  await db.message.create({
+    data: {
+      businessId: business.id,
+      leadId: lead.id,
+      direction: 'OUTBOUND',
+      participant: 'LEAD',
+      fromPhone: business.twilioPrimaryPhoneNumber!,
+      toPhone: lead.callerPhoneNormalized,
+      body: 'Reset candidate outbound message',
+    },
+  });
+
+  await db.ownerNotification.create({
+    data: {
+      businessId: business.id,
+      leadId: lead.id,
+      channel: 'SMS',
+      destination: makePhone(params.seed, '200'),
+      body: 'Reset candidate owner notification',
+    },
+  });
+
+  await db.businessOperatorEvent.create({
+    data: {
+      businessId: business.id,
+      type: 'admin.reset_candidate_created',
+      category: 'ADMIN_ACTIONS',
+      status: 'INFO',
+      summary: 'Reset candidate created',
+    },
+  });
+
+  await db.simulatorRun.create({
+    data: {
+      businessId: business.id,
+      leadId: lead.id,
+      publicId: `sim_${params.seed.replace(/-/g, '')}`,
+      callerPhone: lead.callerPhoneNormalized,
+    },
+  });
+
+  await db.smsConsent.create({
+    data: {
+      businessId: business.id,
+      phoneNormalized: lead.callerPhoneNormalized,
+      phoneRawLastSeen: lead.callerPhone,
+      optedOut: false,
+    },
+  });
+
+  return { business, call, lead };
+}
+
+test('bulkDeleteTestDemoBusinesses deletes only test/demo businesses and cascades business-owned data', async () => {
+  const seed = randomUUID();
+  const preservedSeed = randomUUID();
+  const deletable = await seedResetCandidateBusiness({ seed, testBusiness: true });
+  const preserved = await seedResetCandidateBusiness({ seed: preservedSeed, testBusiness: false });
+
+  try {
+    const result = await bulkDeleteTestDemoBusinesses({
+      confirmation: BULK_TEST_DATA_RESET_CONFIRMATION,
+      candidateIds: [deletable.business.id, preserved.business.id],
+    });
+
+    assert.equal(result.deletedCount >= 1, true);
+    assert.equal(result.deletedBusinessNames.includes(deletable.business.name), true);
+
+    assert.equal(await db.business.findUnique({ where: { id: deletable.business.id } }), null);
+    assert.equal(await db.call.findUnique({ where: { id: deletable.call.id } }), null);
+    assert.equal(await db.lead.findUnique({ where: { id: deletable.lead.id } }), null);
+    assert.equal(await db.message.count({ where: { businessId: deletable.business.id } }), 0);
+    assert.equal(await db.ownerNotification.count({ where: { businessId: deletable.business.id } }), 0);
+    assert.equal(await db.businessOperatorEvent.count({ where: { businessId: deletable.business.id } }), 0);
+    assert.equal(await db.businessNotificationSettings.count({ where: { businessId: deletable.business.id } }), 0);
+    assert.equal(await db.simulatorRun.count({ where: { businessId: deletable.business.id } }), 0);
+    assert.equal(await db.smsConsent.count({ where: { businessId: deletable.business.id } }), 0);
+
+    assert.notEqual(await db.business.findUnique({ where: { id: preserved.business.id } }), null);
+    assert.equal(await db.message.count({ where: { businessId: preserved.business.id } }) > 0, true);
+  } finally {
+    await db.business.deleteMany({ where: { id: { in: [deletable.business.id, preserved.business.id] } } });
+  }
+});
+
+test('isTestDemoBusiness includes the dedicated demo workspace even without the test flag', () => {
+  assert.equal(
+    isTestDemoBusiness({
+      isTestBusiness: false,
+      ownerClerkId: DEMO_OWNER_CLERK_ID,
+    }),
+    true
+  );
+});
+
+test('bulkDeleteTestDemoBusinesses requires explicit confirmation and preserves data when confirmation is wrong', async () => {
+  const seed = randomUUID();
+  const businessRecord = await seedResetCandidateBusiness({ seed, testBusiness: true });
+
+  try {
+    await assert.rejects(
+      bulkDeleteTestDemoBusinesses({
+        confirmation: 'delete please',
+        candidateIds: [businessRecord.business.id],
+      }),
+      /DELETE TEST BUSINESSES/
+    );
+
+    assert.notEqual(await db.business.findUnique({ where: { id: businessRecord.business.id } }), null);
+  } finally {
+    await db.business.deleteMany({ where: { id: businessRecord.business.id } });
+  }
+});


### PR DESCRIPTION
## Summary
- add a founder/admin-only reset tool that bulk deletes only test/demo businesses
- keep real businesses protected by the existing archive-first philosophy
- add UI and tests for confirmation, scope safety, and cascade cleanup

## Validation
- npm install
- npm run env:check
- npm run typecheck
- npm run lint
- npm run test
- npm run build