### PR TITLE
Fix bulk delete NEXT_REDIRECT handling

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -954,6 +954,8 @@ export async function bulkDeleteTestBusinessesAction(formData: FormData) {
     redirect(`/admin?error=${encodeURIComponent(parsed.error.issues[0]?.message || 'Invalid reset request.')}`);
   }
 
+  let redirectPath = '/admin';
+
   try {
     const result = await bulkDeleteTestDemoBusinesses({
       confirmation: parsed.data.confirmationText,
@@ -974,9 +976,15 @@ export async function bulkDeleteTestBusinessesAction(formData: FormData) {
     });
 
     revalidatePath('/admin');
-    redirect(`/admin?resetDeleted=${encodeURIComponent(String(result.deletedCount))}`);
+
+    redirectPath =
+      result.deletedCount > 0
+        ? `/admin?resetResult=deleted&resetDeleted=${encodeURIComponent(String(result.deletedCount))}`
+        : '/admin?resetResult=noop&resetDeleted=0';
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unable to delete test/demo businesses.';
-    redirect(`/admin?error=${encodeURIComponent(message)}`);
+    redirectPath = `/admin?error=${encodeURIComponent(message)}`;
   }
+
+  redirect(redirectPath);
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -82,6 +82,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   const createdDemo = getQueryValue(searchParams, 'createdDemo') === '1';
   const createdBusinessId = getQueryValue(searchParams, 'businessId');
   const deleted = getQueryValue(searchParams, 'deleted') === '1';
+  const resetResult = getQueryValue(searchParams, 'resetResult');
   const resetDeleted = Number(getQueryValue(searchParams, 'resetDeleted') || '0');
   const error = getQueryValue(searchParams, 'error');
   const query = getQueryValue(searchParams, 'q')?.trim() || '';
@@ -260,9 +261,14 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
 
       {error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{error}</div> : null}
       {deleted ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Archived test business deleted.</div> : null}
-      {Number.isFinite(resetDeleted) && resetDeleted > 0 ? (
+      {resetResult === 'deleted' && Number.isFinite(resetDeleted) ? (
         <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">
           Deleted {resetDeleted} test/demo {resetDeleted === 1 ? 'business' : 'businesses'}.
+        </div>
+      ) : null}
+      {resetResult === 'noop' ? (
+        <div className="rounded-md border bg-background/80 p-3 text-sm text-muted-foreground">
+          No test/demo businesses were eligible for deletion.
         </div>
       ) : null}
       {createdDemo && createdBusinessId ? (

--- a/tests/admin-bulk-delete-action.test.ts
+++ b/tests/admin-bulk-delete-action.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+function read(path: string) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+test('bulk delete action keeps redirect outside the try/catch and returns plain admin UI states', () => {
+  const actions = read('app/admin/actions.ts');
+  const adminPage = read('app/admin/page.tsx');
+
+  const actionSection = actions.slice(actions.indexOf('export async function bulkDeleteTestBusinessesAction'));
+  const catchStart = actionSection.indexOf('} catch (error) {');
+  const finalRedirectStart = actionSection.lastIndexOf('\n\n  redirect(redirectPath);');
+  const catchSection = actionSection.slice(catchStart, finalRedirectStart);
+
+  assert.match(actions, /export async function bulkDeleteTestBusinessesAction/);
+  assert.match(actions, /let redirectPath = '\/admin'/);
+  assert.match(actions, /redirectPath = `\/admin\?error=\$\{encodeURIComponent\(message\)\}`/);
+  assert.match(actions, /redirect\(redirectPath\);/);
+  assert.notEqual(catchStart, -1);
+  assert.notEqual(finalRedirectStart, -1);
+  assert.doesNotMatch(catchSection, /redirect\(/);
+
+  assert.match(adminPage, /resetResult === 'deleted'/);
+  assert.match(adminPage, /Deleted \{resetDeleted\} test\/demo/);
+  assert.match(adminPage, /resetResult === 'noop'/);
+  assert.match(adminPage, /No test\/demo businesses were eligible for deletion/);
+});


### PR DESCRIPTION
## Summary
- keep the bulk delete server action redirect outside the try/catch
- return plain admin success, noop, and error states instead of surfacing NEXT_REDIRECT
- add a regression test that locks the redirect handling in place

## Testing
- npm install
- npm run env:check
- npm run typecheck
- npm run lint
- npm run test
- npm run build