### PR TITLE
[codex] Add admin operator visibility timeline

### DIFF
--- a/app/admin/[businessId]/page.tsx
+++ b/app/admin/[businessId]/page.tsx
@@ -13,6 +13,7 @@ import {
   sendBusinessTestSmsAction,
   setBusinessProvisioningStatusAction,
 } from '@/app/admin/actions';
+import { AdminBusinessActivityTimeline } from '@/components/admin-business-activity-timeline';
 import { TwilioSetupChecklist } from '@/components/twilio-setup-checklist';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
@@ -21,12 +22,25 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { buildAdminCustomerOpenHref } from '@/lib/admin-customer-paths';
-import { getAdminTestSmsConfidenceState, isBusinessArchived } from '@/lib/admin-dashboard';
+import { isBusinessArchived } from '@/lib/admin-dashboard';
+import {
+  buildAdminBusinessIssue,
+  buildAdminTestSmsTruth,
+  getOperatorToneBadgeVariant,
+} from '@/lib/admin-operator-visibility';
 import { getAdminOwnerState, getTwilioWebhookSnapshot, listAdminTwilioNumbers } from '@/lib/admin-provisioning';
 import { requireAdmin } from '@/lib/admin';
 import { TwilioSetupTone, buildTwilioSetupFlow, twilioAccountModeOptions, twilioNumberSetupModeOptions } from '@/lib/twilio-setup';
 import { db } from '@/lib/db';
+import { formatDateTime } from '@/lib/lead-presenters';
 import { getManagedTextingNumber, managedTwilioStatusLabels } from '@/lib/managed-twilio-status';
+import {
+  businessTimelineFilterOptions,
+  countTimelineFilters,
+  listBusinessOperatorEvents,
+  matchesTimelineFilter,
+  type BusinessTimelineFilter,
+} from '@/lib/operator-events';
 import { formatPhoneForDisplay } from '@/lib/phone';
 
 type AdminTwilioDefaults = {
@@ -47,6 +61,18 @@ type AdminTwilioDefaults = {
 function getQueryValue(searchParams: Record<string, string | string[] | undefined> | undefined, key: string) {
   const value = searchParams?.[key];
   return typeof value === 'string' ? value : null;
+}
+
+function getTimelineFilter(searchParams: Record<string, string | string[] | undefined> | undefined): BusinessTimelineFilter {
+  const value = getQueryValue(searchParams, 'timeline');
+  if (value && businessTimelineFilterOptions.some((option) => option.key === value)) {
+    return value as BusinessTimelineFilter;
+  }
+  return 'all';
+}
+
+function buildTimelineFilterPath(businessId: string, filter: BusinessTimelineFilter) {
+  return filter === 'all' ? `/admin/${businessId}` : `/admin/${businessId}?timeline=${encodeURIComponent(filter)}`;
 }
 
 function HiddenAdminTwilioFields({
@@ -95,32 +121,25 @@ export default async function AdminBusinessDetailPage({
         OR: [{ ownerNotifiedAt: { not: null } }, { notifiedAt: { not: null } }],
       },
     }),
-    db.businessOperatorEvent.findMany({
-      where: {
-        businessId: params.businessId,
-        type: {
-          startsWith: 'admin.test_sms_',
-        },
-      },
-      orderBy: { createdAt: 'desc' },
-      take: 20,
-      select: {
-        type: true,
-        status: true,
-        createdAt: true,
-      },
-    }),
+    listBusinessOperatorEvents(params.businessId, 'all', 120),
   ]);
 
   if (!business) notFound();
 
+  const timelineFilter = getTimelineFilter(searchParams);
+  const testSmsTruth = buildAdminTestSmsTruth(operatorEvents);
   const [ownerState, webhookSnapshot, availableNumbers] = await Promise.all([
     getAdminOwnerState(business, business.notificationSettings),
     getTwilioWebhookSnapshot(business),
     listAdminTwilioNumbers(business),
   ]);
 
-  const testSmsState = getAdminTestSmsConfidenceState(operatorEvents);
+  const testSmsState =
+    testSmsTruth.state === 'not_run'
+      ? 'not_started'
+      : testSmsTruth.state === 'pending'
+        ? 'pending_delivery'
+        : testSmsTruth.state;
   const managedTextingNumber = getManagedTextingNumber(business);
   const setupFlow = buildTwilioSetupFlow({
     business,
@@ -130,6 +149,23 @@ export default async function AdminBusinessDetailPage({
     testSmsState,
     webhookSnapshot,
   });
+  const lastIssue = buildAdminBusinessIssue({
+    events: operatorEvents,
+    currentStep: {
+      stepKey: setupFlow.banner.stepKey,
+      title: setupFlow.banner.title,
+      detail: setupFlow.banner.detail,
+      tone: setupFlow.banner.tone,
+    },
+  });
+  const timelineCounts = countTimelineFilters(operatorEvents);
+  const visibleTimelineEvents = operatorEvents.filter((event) => matchesTimelineFilter(event, timelineFilter));
+  const timelineFilterLinks = businessTimelineFilterOptions.map((option) => ({
+    key: option.key,
+    label: option.label,
+    href: buildTimelineFilterPath(business.id, option.key),
+    count: timelineCounts.get(option.key) ?? 0,
+  }));
   const defaults: AdminTwilioDefaults = {
     businessId: business.id,
     twilioAccountMode: business.twilioAccountMode,
@@ -650,6 +686,90 @@ export default async function AdminBusinessDetailPage({
       {archived ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business archived safely. Automation is paused.</div> : null}
       {restored ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business restored and ready for review.</div> : null}
       {error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{error}</div> : null}
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        <Card className="border-primary/20 bg-primary/5">
+          <CardHeader className="pb-3">
+            <CardDescription>Last issue</CardDescription>
+            <CardTitle className="text-lg">{lastIssue.summary}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant={getOperatorToneBadgeVariant(lastIssue.tone)}>
+                {lastIssue.state === 'healthy' ? 'Healthy' : lastIssue.statusLabel || 'Needs attention'}
+              </Badge>
+              {lastIssue.categoryLabel ? <Badge variant="outline">{lastIssue.categoryLabel}</Badge> : null}
+              {lastIssue.eventType ? <code className="rounded bg-background px-2 py-1 text-xs">{lastIssue.eventType}</code> : null}
+            </div>
+            <p className="text-muted-foreground">{lastIssue.detail}</p>
+            <p className="text-xs text-muted-foreground">
+              {lastIssue.createdAt ? `Recorded ${formatDateTime(lastIssue.createdAt)}` : 'Derived from the current business state.'}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-card/90">
+          <CardHeader className="pb-3">
+            <CardDescription>Test SMS truth</CardDescription>
+            <CardTitle className="text-lg">{testSmsTruth.summary}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant={getOperatorToneBadgeVariant(testSmsTruth.tone)}>{testSmsTruth.label}</Badge>
+              {testSmsTruth.eventType ? <code className="rounded bg-background px-2 py-1 text-xs">{testSmsTruth.eventType}</code> : null}
+            </div>
+            <p className="text-muted-foreground">{testSmsTruth.detail}</p>
+            <p className="text-xs text-muted-foreground">
+              {testSmsTruth.lastAttemptAt ? `Last attempt ${formatDateTime(testSmsTruth.lastAttemptAt)}` : 'No test SMS attempt recorded yet.'}
+            </p>
+            <form action={sendBusinessTestSmsAction} className="space-y-3">
+              <input type="hidden" name="businessId" value={business.id} />
+              <div className="space-y-2">
+                <Label htmlFor="adminOperatorTestSmsDestination">Test SMS destination</Label>
+                <Input
+                  id="adminOperatorTestSmsDestination"
+                  name="destinationPhone"
+                  defaultValue={business.notificationSettings?.ownerPhone || business.notifyPhone || ''}
+                  placeholder="+15551234567"
+                />
+              </div>
+              <Button size="sm" type="submit">
+                {testSmsTruth.state === 'not_run' ? 'Send test SMS' : 'Retry test SMS'}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-card/90">
+          <CardHeader className="pb-3">
+            <CardDescription>Current step</CardDescription>
+            <CardTitle className="text-lg">{setupFlow.banner.title}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant={getBadgeVariant(setupFlow.banner.tone)}>
+                {setupFlow.banner.tone === 'success'
+                  ? 'Ready'
+                  : setupFlow.banner.tone === 'attention'
+                    ? 'Blocked'
+                    : setupFlow.banner.tone === 'pending'
+                      ? 'Pending'
+                      : 'In review'}
+              </Badge>
+              <code className="rounded bg-background px-2 py-1 text-xs">{setupFlow.banner.stepKey}</code>
+            </div>
+            <p className="text-muted-foreground">{setupFlow.banner.detail}</p>
+            <p className="text-xs text-muted-foreground">
+              This section stays stable so PR #2 can attach guided remediation and manual field entry to the same step key.
+            </p>
+            <div>{bannerAction}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div id="recent-activity">
+        <AdminBusinessActivityTimeline events={visibleTimelineEvents} activeFilter={timelineFilter} filterLinks={timelineFilterLinks} />
+      </div>
 
       <div id="admin-twilio-setup">
         <TwilioSetupChecklist

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -22,6 +22,7 @@ import {
   DEMO_OWNER_CLERK_ID,
 } from '@/lib/admin-test-data-reset';
 import { logAuditEvent } from '@/lib/audit-log';
+import { buildTwilioSetupUpdateEventMetadata } from '@/lib/admin-operator-visibility';
 import { db } from '@/lib/db';
 import { formatPhoneDetail, maskSid, recordBusinessOperatorEvent } from '@/lib/operator-events';
 import { maskPhoneForAudit, normalizePhoneNumber, normalizePhoneNumberToE164 } from '@/lib/phone';
@@ -754,13 +755,16 @@ export async function saveAdminTwilioSetupAction(formData: FormData) {
   });
 
   if (changedFields.length > 0) {
+    const setupUpdateEvent = buildTwilioSetupUpdateEventMetadata(changedFields);
     await recordBusinessOperatorEvent({
       businessId: data.businessId,
       type: 'admin.twilio_setup_updated',
       category: 'ONBOARDING',
       status: 'INFO',
-      summary: 'Twilio setup flow updated',
+      summary: setupUpdateEvent.summary,
       details: {
+        remediationStepKey: setupUpdateEvent.primaryStepKey,
+        remediationStepKeys: setupUpdateEvent.stepKeys,
         changedFields: buildChangedFieldMetadata(changedFields),
       },
     });
@@ -1015,7 +1019,7 @@ export async function sendBusinessTestSmsAction(formData: FormData) {
       type: 'admin.test_sms_initiated',
       category: 'ADMIN_ACTIONS',
       status: 'PENDING',
-      summary: 'Test SMS initiated',
+      summary: 'Test SMS requested',
       details: {
         destinationPhone: formatPhoneDetail(destinationPhone),
         fromPhone: formatPhoneDetail(fromPhone),

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -23,6 +23,11 @@ import {
   matchesAdminBoardFilter,
   type AdminBoardFilter,
 } from '@/lib/admin-dashboard';
+import {
+  buildAdminBusinessIssue,
+  buildAdminTestSmsTruth,
+  getOperatorToneBadgeVariant,
+} from '@/lib/admin-operator-visibility';
 import { AdminBusinessPicker } from '@/components/admin-business-picker';
 import { requireAdmin } from '@/lib/admin';
 import { Badge } from '@/components/ui/badge';
@@ -33,7 +38,7 @@ import { Label } from '@/components/ui/label';
 import { isPendingOwnerClerkId } from '@/lib/admin-provisioning';
 import { searchBusinessesForAdmin } from '@/lib/business';
 import { db } from '@/lib/db';
-import { formatDateTime, formatRelativeTime } from '@/lib/lead-presenters';
+import { formatRelativeTime } from '@/lib/lead-presenters';
 import { getManagedTextingNumber, getManagedTwilioStatusSummary } from '@/lib/managed-twilio-status';
 import { OperatorEventStatus } from '@prisma/client';
 import { formatPhoneForDisplay } from '@/lib/phone';
@@ -120,7 +125,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   const view = (getQueryValue(searchParams, 'view') as AdminBoardFilter | null) || 'all';
   const adminBusiness = await db.business.findUnique({ where: { ownerClerkId: admin.userId } });
 
-  const [businesses, businessPickerOptions, leadCounts, leadActivity, callActivity, messageActivity, notificationFailures, operatorSignals, resettableBusinesses] = await Promise.all([
+  const [businesses, businessPickerOptions, leadCounts, leadActivity, callActivity, messageActivity, latestOperatorIssues, latestTestSmsEvents, operatorSignals, resettableBusinesses] = await Promise.all([
     query
       ? searchBusinessesForAdmin(query)
       : db.business.findMany({
@@ -162,18 +167,36 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       by: ['businessId'],
       _max: { createdAt: true },
     }),
-    db.ownerNotification.findMany({
+    db.businessOperatorEvent.findMany({
       where: {
-        status: { in: ['FAILED', 'SKIPPED'] },
+        status: { in: [OperatorEventStatus.FAILED, OperatorEventStatus.WARNING] },
       },
       orderBy: { createdAt: 'desc' },
       select: {
         businessId: true,
         status: true,
-        error: true,
+        summary: true,
+        type: true,
+        category: true,
+        detailsJson: true,
         createdAt: true,
       },
-      take: 200,
+      take: 600,
+    }),
+    db.businessOperatorEvent.findMany({
+      where: {
+        type: { startsWith: 'admin.test_sms_' },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        businessId: true,
+        type: true,
+        status: true,
+        summary: true,
+        detailsJson: true,
+        createdAt: true,
+      },
+      take: 600,
     }),
     db.businessOperatorEvent.findMany({
       where: {
@@ -195,12 +218,33 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   );
   const callActivityMap = new Map(callActivity.map((item) => [item.businessId, item._max.createdAt]));
   const messageActivityMap = new Map(messageActivity.map((item) => [item.businessId, item._max.createdAt]));
-  const notificationFailureMap = new Map<string, { status: string; error: string | null; createdAt: Date }>();
+  const latestIssueMap = new Map<
+    string,
+    {
+      businessId: string;
+      type: string;
+      category: (typeof latestOperatorIssues)[number]['category'];
+      status: (typeof latestOperatorIssues)[number]['status'];
+      summary: string;
+      detailsJson: (typeof latestOperatorIssues)[number]['detailsJson'];
+      createdAt: Date;
+    }
+  >();
+  const testSmsEventMap = new Map<string, Array<(typeof latestTestSmsEvents)[number]>>();
   const operatorSignalMap = new Map<string, { failed: number; warning: number }>();
 
-  for (const failure of notificationFailures) {
-    if (!notificationFailureMap.has(failure.businessId)) {
-      notificationFailureMap.set(failure.businessId, failure);
+  for (const issue of latestOperatorIssues) {
+    if (!latestIssueMap.has(issue.businessId)) {
+      latestIssueMap.set(issue.businessId, issue);
+    }
+  }
+
+  for (const event of latestTestSmsEvents) {
+    const existing = testSmsEventMap.get(event.businessId) || [];
+    existing.push(event);
+    testSmsEventMap.set(event.businessId, existing);
+    if (existing.length >= 6) {
+      testSmsEventMap.set(event.businessId, existing.slice(0, 6));
     }
   }
 
@@ -243,7 +287,6 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       callActivityMap.get(business.id),
       messageActivityMap.get(business.id)
     );
-    const latestFailure = notificationFailureMap.get(business.id);
     const assignedNumber = getManagedTextingNumber(business);
     const archived = isBusinessArchived(business);
     const paused = !archived && business.provisioningStatus === 'PAUSED';
@@ -258,11 +301,22 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       attentionRequired: managedSummary.attentionRequired,
       complianceStarted: managedSummary.complianceStarted,
     });
-    const attentionSignal = latestFailure
-      ? compactCopy(`${latestFailure.error || `${latestFailure.status.toLowerCase()} owner notification`} on ${formatDateTime(latestFailure.createdAt)}.`)
-      : nextStep.tone === 'healthy'
-        ? 'Healthy. No immediate operator action needed.'
-        : compactCopy(`${nextStep.title}. ${nextStep.detail}`);
+    const lastIssue = buildAdminBusinessIssue({
+      events: latestIssueMap.has(business.id) ? [latestIssueMap.get(business.id)!] : [],
+      currentStep: {
+        stepKey: null,
+        title: nextStep.title,
+        detail: nextStep.detail,
+        tone: nextStep.tone === 'attention' ? 'attention' : nextStep.tone === 'pending' ? 'pending' : 'success',
+      },
+    });
+    const testSmsTruth = buildAdminTestSmsTruth(testSmsEventMap.get(business.id) || []);
+    const attentionSignal =
+      lastIssue.state === 'issue'
+        ? compactCopy(`${lastIssue.summary}. ${lastIssue.detail}`)
+        : nextStep.tone === 'healthy'
+          ? 'Healthy. No immediate operator action needed.'
+          : compactCopy(`${nextStep.title}. ${nextStep.detail}`);
     const operatorSignals = operatorSignalMap.get(business.id) || { failed: 0, warning: 0 };
 
     return {
@@ -275,11 +329,12 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       leadCount: leadCountMap.get(business.id) ?? 0,
       assignedNumber,
       lastActivityAt,
-      latestFailure,
+      lastIssue,
       overallStatus,
       a2pState,
       attentionSignal,
       operatorSignals,
+      testSmsTruth,
       canSendTestSms: Boolean(assignedNumber && (business.notificationSettings?.ownerPhone || business.notifyPhone)),
     };
   });
@@ -605,12 +660,16 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                       </p>
                     </div>
                     <div>
-                      <p className="font-medium">Latest attention signal</p>
+                      <p className="font-medium">Last issue</p>
                       <p className="mt-1 text-muted-foreground">{selectedBusinessRow.attentionSignal}</p>
                     </div>
                     <div>
-                      <p className="font-medium">Current next step</p>
-                      <p className="mt-1 text-muted-foreground">{selectedBusinessRow.nextStep.actionLabel}</p>
+                      <p className="font-medium">Test SMS</p>
+                      <div className="mt-1 flex flex-wrap gap-2">
+                        <Badge variant={getOperatorToneBadgeVariant(selectedBusinessRow.testSmsTruth.tone)}>
+                          {selectedBusinessRow.testSmsTruth.label}
+                        </Badge>
+                      </div>
                     </div>
                   </div>
                   <div className="flex flex-wrap gap-2">
@@ -710,11 +769,12 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                   leadCount,
                   assignedNumber,
                   lastActivityAt,
-                  latestFailure,
+                  lastIssue,
                   overallStatus,
                   a2pState,
                   attentionSignal,
                   operatorSignals,
+                  testSmsTruth,
                   canSendTestSms,
                 }) => (
                   <div key={business.id} className="grid gap-4 border-t bg-background/80 px-5 py-4 first:border-t-0 xl:grid-cols-[1.7fr_1fr_1.15fr_0.95fr_1.3fr]">
@@ -728,8 +788,8 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                         {isBusinessArchived(business) ? <Badge variant="outline">Archived</Badge> : null}
                       </div>
                       <div className="space-y-1 text-sm">
-                        <p className="font-medium">Needs attention signal</p>
-                        <p className={cn('text-muted-foreground', latestFailure ? 'text-destructive' : '')}>{attentionSignal}</p>
+                        <p className="font-medium">Last issue</p>
+                        <p className={cn('text-muted-foreground', lastIssue.state === 'issue' ? 'text-destructive' : '')}>{attentionSignal}</p>
                       </div>
                       <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
                         <span>{business.id}</span>
@@ -774,12 +834,16 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                       <p className="font-medium">Next action</p>
                       <p>{nextStep.actionLabel}</p>
                       <p className="text-muted-foreground">{nextStep.title}</p>
+                      <div className="flex flex-wrap gap-2">
+                        <Badge variant={getOperatorToneBadgeVariant(testSmsTruth.tone)}>Test SMS {testSmsTruth.label}</Badge>
+                        {lastIssue.state === 'issue' ? <Badge variant={getOperatorToneBadgeVariant(lastIssue.tone)}>Needs attention</Badge> : null}
+                      </div>
                       {business.twilioWebhookSyncedAt ? (
                         <p className="text-xs text-muted-foreground">Webhook sync {formatRelativeTime(business.twilioWebhookSyncedAt)}</p>
                       ) : (
                         <p className="text-xs text-muted-foreground">Webhook sync still needed</p>
                       )}
-                      {latestFailure ? <p className="text-xs text-destructive">Latest issue recorded {formatRelativeTime(latestFailure.createdAt)}</p> : null}
+                      {lastIssue.createdAt ? <p className="text-xs text-destructive">Latest issue recorded {formatRelativeTime(lastIssue.createdAt)}</p> : null}
                     </div>
 
                     <div className="flex flex-wrap content-start gap-2">

--- a/app/app/settings/actions.ts
+++ b/app/app/settings/actions.ts
@@ -326,7 +326,7 @@ export async function sendBusinessTwilioTestSmsAction(formData: FormData) {
       type: 'admin.test_sms_initiated',
       category: 'ADMIN_ACTIONS',
       status: 'PENDING',
-      summary: 'Test SMS initiated',
+      summary: 'Test SMS requested',
       details: {
         destinationPhone: formatPhoneDetail(destinationPhone),
         fromPhone: formatPhoneDetail(fromPhone),

--- a/components/admin-business-activity-timeline.tsx
+++ b/components/admin-business-activity-timeline.tsx
@@ -1,0 +1,129 @@
+import type { ReactNode } from 'react';
+import type { BusinessOperatorEvent } from '@prisma/client';
+import { operatorEventCategoryLabels, operatorEventStatusLabels, type BusinessTimelineFilter } from '@/lib/operator-events';
+
+import {
+  getOperatorEventCategoryBadgeVariant,
+  getOperatorEventStatusBadgeVariant,
+} from '@/lib/admin-operator-visibility';
+import { formatDateTime } from '@/lib/lead-presenters';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
+
+type TimelineEvent = Pick<
+  BusinessOperatorEvent,
+  'id' | 'type' | 'category' | 'status' | 'summary' | 'detailsJson' | 'createdAt' | 'relatedEntityType' | 'relatedEntityId'
+>;
+
+function formatDetailLabel(key: string) {
+  return key
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function renderJsonValue(value: unknown): ReactNode {
+  if (value === null || value === undefined) return <span className="text-muted-foreground">-</span>;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return <span className="break-words">{String(value)}</span>;
+  }
+
+  if (Array.isArray(value)) {
+    return (
+      <div className="space-y-2">
+        {value.map((item, index) => (
+          <div key={index} className="rounded-md border bg-background/70 p-2">
+            {renderJsonValue(item)}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (typeof value === 'object') {
+    return (
+      <div className="grid gap-2 sm:grid-cols-2">
+        {Object.entries(value as Record<string, unknown>).map(([key, nestedValue]) => (
+          <div key={key} className="rounded-md border bg-background/70 p-2">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{formatDetailLabel(key)}</p>
+            <div className="mt-1 text-sm">{renderJsonValue(nestedValue)}</div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return <span>{String(value)}</span>;
+}
+
+export function AdminBusinessActivityTimeline({
+  events,
+  activeFilter,
+  filterLinks,
+}: {
+  events: TimelineEvent[];
+  activeFilter: BusinessTimelineFilter;
+  filterLinks: Array<{ key: BusinessTimelineFilter; label: string; href: string; count: number }>;
+}) {
+  return (
+    <Card className="bg-card/90">
+      <CardHeader className="space-y-4">
+        <div className="space-y-1">
+          <CardTitle>Recent activity</CardTitle>
+          <CardDescription>Business-scoped operator events, newest first, with the exact status and step type that produced each signal.</CardDescription>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {filterLinks.map((filter) => (
+            <Link
+              key={filter.key}
+              className={cn(
+                buttonVariants({ size: 'sm', variant: filter.key === activeFilter ? 'default' : 'outline' }),
+                filter.key === activeFilter && 'pointer-events-none'
+              )}
+              href={filter.href}
+            >
+              {filter.label} ({filter.count})
+            </Link>
+          ))}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {events.length === 0 ? (
+          <div className="rounded-xl border border-dashed p-6 text-sm text-muted-foreground">No business events match this filter yet.</div>
+        ) : (
+          <div className="space-y-3">
+            {events.map((event) => (
+              <details key={event.id} className="rounded-xl border bg-background/80 p-4">
+                <summary className="cursor-pointer list-none">
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant={getOperatorEventStatusBadgeVariant(event.status)}>{operatorEventStatusLabels[event.status]}</Badge>
+                        <Badge variant={getOperatorEventCategoryBadgeVariant(event.category)}>{operatorEventCategoryLabels[event.category]}</Badge>
+                        <code className="rounded bg-muted px-2 py-1 text-xs">{event.type}</code>
+                      </div>
+                      <p className="font-medium">{event.summary}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatDateTime(event.createdAt)}
+                        {event.relatedEntityType && event.relatedEntityId
+                          ? ` • ${event.relatedEntityType} ${event.relatedEntityId.slice(-8)}`
+                          : ''}
+                      </p>
+                    </div>
+                    <span className="text-xs text-muted-foreground">Expand details</span>
+                  </div>
+                </summary>
+                <div className="mt-4 space-y-3 border-t pt-4">
+                  {event.detailsJson ? renderJsonValue(event.detailsJson) : <p className="text-sm text-muted-foreground">No extra details recorded.</p>}
+                </div>
+              </details>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/admin-operator-visibility.ts
+++ b/lib/admin-operator-visibility.ts
@@ -1,0 +1,269 @@
+import { OperatorEventCategory, OperatorEventStatus, type BusinessOperatorEvent } from '@prisma/client';
+
+import { formatMessageStatus } from '@/lib/lead-presenters';
+import { operatorEventCategoryLabels, operatorEventStatusLabels } from '@/lib/operator-events';
+import type { TwilioSetupStepKey, TwilioSetupTone } from '@/lib/twilio-setup';
+
+type IssueEventRecord = Pick<BusinessOperatorEvent, 'type' | 'category' | 'status' | 'summary' | 'detailsJson' | 'createdAt'>;
+type TestSmsEventRecord = Pick<BusinessOperatorEvent, 'type' | 'status' | 'summary' | 'detailsJson' | 'createdAt'>;
+
+type CurrentStepSignal = {
+  stepKey: TwilioSetupStepKey | null;
+  title: string;
+  detail: string;
+  tone: TwilioSetupTone;
+};
+
+export type AdminTestSmsTruthState = 'not_run' | 'pending' | 'delivered' | 'failed';
+
+export type AdminTestSmsTruth = {
+  state: AdminTestSmsTruthState;
+  label: string;
+  tone: 'neutral' | 'pending' | 'success' | 'attention';
+  summary: string;
+  detail: string;
+  reason: string | null;
+  lastAttemptAt: Date | null;
+  eventType: string | null;
+};
+
+export type AdminBusinessIssue = {
+  state: 'healthy' | 'issue';
+  tone: 'neutral' | 'pending' | 'attention';
+  summary: string;
+  detail: string;
+  createdAt: Date | null;
+  categoryLabel: string | null;
+  statusLabel: string | null;
+  eventType: string | null;
+  remediationStepKey: TwilioSetupStepKey | null;
+};
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getDetailString(details: unknown, key: string) {
+  if (!isJsonObject(details)) return null;
+  const value = details[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function getDetailReason(details: unknown) {
+  const errorMessage = getDetailString(details, 'errorMessage');
+  if (errorMessage) return errorMessage;
+
+  const error = getDetailString(details, 'error');
+  if (error) return error;
+
+  const nextStep = getDetailString(details, 'nextStep');
+  if (nextStep) return nextStep;
+
+  const reason = getDetailString(details, 'reason');
+  if (reason) return reason.replace(/_/g, ' ');
+
+  const messageStatus = getDetailString(details, 'messageStatus');
+  if (messageStatus) return formatMessageStatus(messageStatus) || messageStatus;
+
+  const errorCode = getDetailString(details, 'errorCode');
+  if (errorCode) return `Twilio error ${errorCode}`;
+
+  return null;
+}
+
+function isTestSmsEvent(event: Pick<BusinessOperatorEvent, 'type'>) {
+  return event.type.startsWith('admin.test_sms_');
+}
+
+function isOpenIssueStatus(status: OperatorEventStatus) {
+  return status === OperatorEventStatus.FAILED || status === OperatorEventStatus.WARNING;
+}
+
+function getTestSmsState(event: Pick<BusinessOperatorEvent, 'type'> | null): AdminTestSmsTruthState {
+  if (!event) return 'not_run';
+  if (event.type === 'admin.test_sms_delivered') return 'delivered';
+  if (
+    event.type === 'admin.test_sms_failed' ||
+    event.type === 'admin.test_sms_suppressed' ||
+    event.type === 'admin.test_sms_delivery_failed'
+  ) {
+    return 'failed';
+  }
+  return 'pending';
+}
+
+export function buildAdminTestSmsTruth(events: TestSmsEventRecord[]): AdminTestSmsTruth {
+  const latestEvent = events
+    .filter((event) => isTestSmsEvent(event))
+    .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime())[0] || null;
+
+  const state = getTestSmsState(latestEvent);
+  const reason = latestEvent ? getDetailReason(latestEvent.detailsJson) : null;
+
+  if (!latestEvent) {
+    return {
+      state,
+      label: 'Not run',
+      tone: 'neutral',
+      summary: 'No admin test SMS recorded',
+      detail: 'Run a test SMS from this page before treating delivery as proven.',
+      reason: null,
+      lastAttemptAt: null,
+      eventType: null,
+    };
+  }
+
+  if (state === 'delivered') {
+    return {
+      state,
+      label: 'Delivered',
+      tone: 'success',
+      summary: latestEvent.summary,
+      detail: reason ? `Delivery confirmed. ${reason}.` : 'Delivery confirmed by the Twilio status callback.',
+      reason,
+      lastAttemptAt: latestEvent.createdAt,
+      eventType: latestEvent.type,
+    };
+  }
+
+  if (state === 'failed') {
+    return {
+      state,
+      label: 'Failed',
+      tone: 'attention',
+      summary: latestEvent.summary,
+      detail: reason ? `The latest test SMS did not complete cleanly: ${reason}.` : 'The latest test SMS did not complete cleanly.',
+      reason,
+      lastAttemptAt: latestEvent.createdAt,
+      eventType: latestEvent.type,
+    };
+  }
+
+  return {
+    state,
+    label: 'Pending delivery',
+    tone: 'pending',
+    summary: latestEvent.summary,
+    detail:
+      latestEvent.type === 'admin.test_sms_accepted'
+        ? 'Twilio accepted the latest test SMS, but delivery is not confirmed yet.'
+        : 'The latest test SMS request started, but the final delivery result is not known yet.',
+    reason,
+    lastAttemptAt: latestEvent.createdAt,
+    eventType: latestEvent.type,
+  };
+}
+
+export function buildAdminBusinessIssue(params: {
+  events: IssueEventRecord[];
+  currentStep: CurrentStepSignal;
+}): AdminBusinessIssue {
+  const latestIssueEvent = params.events
+    .filter((event) => isOpenIssueStatus(event.status))
+    .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime())[0];
+
+  if (latestIssueEvent) {
+    return {
+      state: 'issue',
+      tone: 'attention',
+      summary: latestIssueEvent.summary,
+      detail: getDetailReason(latestIssueEvent.detailsJson) || `${operatorEventCategoryLabels[latestIssueEvent.category]} requires attention.`,
+      createdAt: latestIssueEvent.createdAt,
+      categoryLabel: operatorEventCategoryLabels[latestIssueEvent.category],
+      statusLabel: operatorEventStatusLabels[latestIssueEvent.status],
+      eventType: latestIssueEvent.type,
+      remediationStepKey: null,
+    };
+  }
+
+  if (params.currentStep.tone === 'attention' || params.currentStep.tone === 'pending') {
+    return {
+      state: 'issue',
+      tone: params.currentStep.tone === 'attention' ? 'attention' : 'pending',
+      summary: params.currentStep.title,
+      detail: params.currentStep.detail,
+      createdAt: null,
+      categoryLabel: 'Current step',
+      statusLabel: params.currentStep.tone === 'attention' ? 'Warning' : 'Pending',
+      eventType: null,
+      remediationStepKey: params.currentStep.stepKey,
+    };
+  }
+
+  return {
+    state: 'healthy',
+    tone: 'neutral',
+    summary: 'No open issues recorded',
+    detail: 'Recent business events do not show an unresolved failure or blocker right now.',
+    createdAt: null,
+    categoryLabel: null,
+    statusLabel: null,
+    eventType: null,
+    remediationStepKey: null,
+  };
+}
+
+export function getOperatorToneBadgeVariant(tone: 'neutral' | 'pending' | 'success' | 'attention') {
+  if (tone === 'success') return 'success' as const;
+  if (tone === 'attention') return 'destructive' as const;
+  if (tone === 'pending') return 'outline' as const;
+  return 'secondary' as const;
+}
+
+export function getOperatorEventStatusBadgeVariant(status: OperatorEventStatus) {
+  if (status === OperatorEventStatus.SUCCESS) return 'success' as const;
+  if (status === OperatorEventStatus.FAILED) return 'destructive' as const;
+  if (status === OperatorEventStatus.WARNING) return 'destructive' as const;
+  if (status === OperatorEventStatus.PENDING) return 'outline' as const;
+  return 'secondary' as const;
+}
+
+export function getOperatorEventCategoryBadgeVariant(category: OperatorEventCategory) {
+  if (category === OperatorEventCategory.ERRORS) return 'destructive' as const;
+  if (category === OperatorEventCategory.WEBHOOKS) return 'outline' as const;
+  if (category === OperatorEventCategory.ADMIN_ACTIONS) return 'secondary' as const;
+  return 'outline' as const;
+}
+
+const stepKeyByChangedField: Partial<Record<string, TwilioSetupStepKey>> = {
+  twilioAccountMode: 'account_mode',
+  twilioNumberSetupMode: 'number_path',
+  twilioSubaccountSid: 'account_ready',
+  twilioMessagingServiceSid: 'messaging_service_ready',
+  twilioPhoneNumber: 'number_assigned',
+  twilioPhoneNumberSid: 'number_assigned',
+  a2pCustomerProfileSid: 'a2p_status_recorded',
+  a2pBrandSid: 'a2p_status_recorded',
+  a2pCampaignSid: 'a2p_status_recorded',
+  a2pFailureReason: 'a2p_status_recorded',
+  managedTwilioStatus: 'a2p_status_recorded',
+};
+
+const stepSummaryByKey: Record<TwilioSetupStepKey, string> = {
+  owner_connected: 'Owner connection updated',
+  account_mode: 'Twilio account mode updated',
+  number_path: 'Twilio number path updated',
+  account_ready: 'Twilio account target updated',
+  messaging_service_ready: 'Messaging Service details updated',
+  number_assigned: 'Business number mapping updated',
+  voice_webhook_synced: 'Voice webhook step updated',
+  sms_webhook_synced: 'SMS webhook step updated',
+  status_callback_synced: 'Status callback step updated',
+  a2p_status_recorded: 'A2P status updated',
+  test_sms_delivered: 'Test SMS step updated',
+  missed_call_validated: 'Missed-call validation updated',
+  safe_to_mark_live: 'Live gate updated',
+};
+
+export function buildTwilioSetupUpdateEventMetadata(changedFields: Array<{ key: string; label: string }>) {
+  const stepKeys = Array.from(
+    new Set(changedFields.map((field) => stepKeyByChangedField[field.key]).filter((value): value is TwilioSetupStepKey => Boolean(value)))
+  );
+  const primaryStepKey = stepKeys[0] ?? null;
+
+  return {
+    primaryStepKey,
+    stepKeys,
+    summary: primaryStepKey ? stepSummaryByKey[primaryStepKey] : 'Twilio setup details updated',
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3637,6 +3637,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/tests/admin-operator-routes.test.ts
+++ b/tests/admin-operator-routes.test.ts
@@ -9,6 +9,7 @@ function read(path: string) {
 test('admin routes expose support workspace and safe lifecycle controls', () => {
   const adminHome = read('app/admin/page.tsx');
   const adminDetail = read('app/admin/[businessId]/page.tsx');
+  const activityTimeline = read('components/admin-business-activity-timeline.tsx');
   const supportWorkspace = read('app/admin/[businessId]/workspace/page.tsx');
   const adminActions = read('app/admin/actions.ts');
   const businessPicker = read('components/admin-business-picker.tsx');
@@ -21,6 +22,8 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminHome, /Delete all test\/demo businesses/);
   assert.match(adminHome, /BULK_TEST_DATA_RESET_CONFIRMATION/);
   assert.match(adminHome, /Business triage board/);
+  assert.match(adminHome, /Last issue/);
+  assert.match(adminHome, /Test SMS/);
   assert.match(adminHome, /Open customer workspace/);
   assert.match(adminHome, /Delete demo\/test business permanently/);
   assert.match(adminHome, /Type business name to permanently delete/);
@@ -34,6 +37,9 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminDetail, /Twilio setup control panel/);
   assert.match(adminDetail, /main Twilio account or business subaccount/i);
   assert.match(adminDetail, /CallbackCloser Twilio launch flow/);
+  assert.match(adminDetail, /Last issue/);
+  assert.match(adminDetail, /Test SMS truth/);
+  assert.match(adminDetail, /Current step/);
   assert.match(adminDetail, /Mark live/);
   assert.match(adminDetail, /Advanced/);
   assert.match(adminDetail, /Invite owner by email/);
@@ -42,6 +48,8 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminDetail, /Open customer settings/);
   assert.match(adminDetail, /Open customer call flow/);
   assert.match(adminDetail, /View support workspace snapshot/);
+  assert.match(activityTimeline, /Recent activity/);
+  assert.match(activityTimeline, /Expand details/);
   assert.doesNotMatch(adminDetail, /Connect or invite owner/);
   assert.match(supportWorkspace, /support mode workspace/);
   assert.match(supportWorkspace, /Open customer workspace/);

--- a/tests/admin-operator-visibility.test.ts
+++ b/tests/admin-operator-visibility.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { OperatorEventCategory, OperatorEventStatus } from '@prisma/client';
+
+import {
+  buildAdminBusinessIssue,
+  buildAdminTestSmsTruth,
+  buildTwilioSetupUpdateEventMetadata,
+} from '../lib/admin-operator-visibility.ts';
+
+test('admin test SMS truth stays explicit across not-run, pending, delivered, and failed states', () => {
+  assert.equal(buildAdminTestSmsTruth([]).state, 'not_run');
+
+  assert.equal(
+    buildAdminTestSmsTruth([
+      {
+        type: 'admin.test_sms_accepted',
+        status: OperatorEventStatus.SUCCESS,
+        summary: 'Test SMS accepted by Twilio',
+        detailsJson: null,
+        createdAt: new Date('2026-04-20T12:00:00.000Z'),
+      },
+    ]).state,
+    'pending'
+  );
+
+  assert.equal(
+    buildAdminTestSmsTruth([
+      {
+        type: 'admin.test_sms_delivered',
+        status: OperatorEventStatus.SUCCESS,
+        summary: 'Test SMS delivered',
+        detailsJson: { messageStatus: 'delivered' },
+        createdAt: new Date('2026-04-20T12:01:00.000Z'),
+      },
+    ]).state,
+    'delivered'
+  );
+
+  const failed = buildAdminTestSmsTruth([
+    {
+      type: 'admin.test_sms_delivery_failed',
+      status: OperatorEventStatus.FAILED,
+      summary: 'Test SMS delivery failed',
+      detailsJson: { errorMessage: 'Carrier rejected the destination.' },
+      createdAt: new Date('2026-04-20T12:02:00.000Z'),
+    },
+  ]);
+
+  assert.equal(failed.state, 'failed');
+  assert.match(failed.detail, /Carrier rejected the destination/i);
+});
+
+test('admin business issue prefers the latest recorded issue and falls back to the current blocker', () => {
+  const eventIssue = buildAdminBusinessIssue({
+    events: [
+      {
+        type: 'webhooks.sync_failed',
+        category: OperatorEventCategory.WEBHOOKS,
+        status: OperatorEventStatus.FAILED,
+        summary: 'Webhook sync failed',
+        detailsJson: { error: 'Callback URL mismatch.' },
+        createdAt: new Date('2026-04-20T12:02:00.000Z'),
+      },
+    ],
+    currentStep: {
+      stepKey: 'messaging_service_ready',
+      title: 'Messaging Service missing',
+      detail: 'Save or create a Messaging Service before sending live SMS.',
+      tone: 'attention',
+    },
+  });
+
+  assert.equal(eventIssue.summary, 'Webhook sync failed');
+  assert.equal(eventIssue.eventType, 'webhooks.sync_failed');
+
+  const fallbackIssue = buildAdminBusinessIssue({
+    events: [],
+    currentStep: {
+      stepKey: 'messaging_service_ready',
+      title: 'Messaging Service missing',
+      detail: 'Save or create a Messaging Service before sending live SMS.',
+      tone: 'attention',
+    },
+  });
+
+  assert.equal(fallbackIssue.summary, 'Messaging Service missing');
+  assert.equal(fallbackIssue.remediationStepKey, 'messaging_service_ready');
+});
+
+test('twilio setup update metadata stays specific enough for future remediation panels', () => {
+  const messagingServiceUpdate = buildTwilioSetupUpdateEventMetadata([
+    { key: 'twilioMessagingServiceSid', label: 'Messaging Service SID' },
+  ]);
+  assert.equal(messagingServiceUpdate.primaryStepKey, 'messaging_service_ready');
+  assert.equal(messagingServiceUpdate.summary, 'Messaging Service details updated');
+
+  const mixedUpdate = buildTwilioSetupUpdateEventMetadata([
+    { key: 'twilioAccountMode', label: 'Twilio account mode' },
+    { key: 'twilioPhoneNumber', label: 'Twilio number' },
+  ]);
+  assert.deepEqual(mixedUpdate.stepKeys, ['account_mode', 'number_assigned']);
+});

--- a/tests/operator-events.test.ts
+++ b/tests/operator-events.test.ts
@@ -65,3 +65,38 @@ test('business operator event reads stay business-scoped', async () => {
     });
   }
 });
+
+test('operator events redact secret-like detail keys before persistence', async () => {
+  const fixtures = await seedTenantFixtures();
+
+  try {
+    const created = await recordBusinessOperatorEvent({
+      businessId: fixtures.businessA.id,
+      type: 'admin.twilio_setup_updated',
+      category: OperatorEventCategory.ADMIN_ACTIONS,
+      status: OperatorEventStatus.INFO,
+      summary: 'Twilio setup updated',
+      details: {
+        webhookUrl: 'https://example.com/webhook',
+        authToken: 'secret-token-value',
+        normalNote: 'Safe to show',
+      },
+    });
+
+    const stored = await db.businessOperatorEvent.findUniqueOrThrow({
+      where: { id: created!.id },
+      select: { detailsJson: true },
+    });
+
+    assert.deepEqual(stored.detailsJson, {
+      webhookUrl: '[redacted]',
+      authToken: '[redacted]',
+      normalNote: 'Safe to show',
+    });
+  } finally {
+    await cleanupTenantFixtures({
+      businessAId: fixtures.businessA.id,
+      businessBId: fixtures.businessB.id,
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- add business-scoped admin visibility cards for last issue, test SMS truth, and current step
- add a recent activity timeline with status/category/type badges, timestamps, filters, and expandable safe details
- surface recent issue and test-SMS signals on the admin triage board

## Root cause

The codebase already recorded many business-scoped operator events, but the admin business page barely surfaced them. Founders could not see the latest failure, the actual test-SMS delivery state, or the order of business events without digging through raw state and callbacks.

## What changed

- added `lib/admin-operator-visibility.ts` to derive founder-facing issue/test-SMS visibility and step metadata from existing `businessOperatorEvent` records
- added `components/admin-business-activity-timeline.tsx` for the business-scoped timeline UI
- updated `app/admin/[businessId]/page.tsx` to show last issue, test SMS truth, current step, and recent activity above the existing Twilio setup flow
- updated `app/admin/page.tsx` to use recent failed/warning events and test-SMS truth for better triage signals
- made manual Twilio setup update events step-specific enough to support PR #2 remediation panels and manual SID entry flows
- added tests for visibility helpers, route/UI strings, and secret redaction in operator-event details

## Validation

- `npm install`
- `npm run env:check`
- `npm run preflight:providers`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`
