### PR TITLE
Admin PR3: tighten onboarding confidence and daily ops

### DIFF
--- a/app/admin/[businessId]/page.tsx
+++ b/app/admin/[businessId]/page.tsx
@@ -3,11 +3,13 @@ import { notFound } from 'next/navigation';
 
 import {
   archiveBusinessAction,
+  confirmMissedCallValidationAction,
   connectExistingBusinessOwnerAction,
   createBusinessMessagingServiceAction,
   createBusinessTwilioSubaccountAction,
   deleteTestBusinessAction,
   inviteBusinessOwnerAction,
+  markBusinessLiveAction,
   provisionBusinessAction,
   resyncBusinessWebhooksAction,
   restoreBusinessAction,
@@ -24,9 +26,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
 import { buildAdminCustomerOpenHref } from '@/lib/admin-customer-paths';
+import { buildAdminOnboardingConfidence, isBusinessArchived } from '@/lib/admin-dashboard';
+import { buildAdminMissedCallValidationTruth, buildAdminOperationalProofs } from '@/lib/admin-operator-proof';
 import { buildAdminNextStepGuide, buildAdminSetupPanels } from '@/lib/admin-setup-remediation';
-import { isBusinessArchived } from '@/lib/admin-dashboard';
 import {
   buildAdminBusinessIssue,
   buildAdminTestSmsTruth,
@@ -182,6 +186,11 @@ export default async function AdminBusinessDetailPage({
         ? 'pending_delivery'
         : testSmsTruth.state;
   const managedTextingNumber = getManagedTextingNumber(business);
+  const ownerContact = business.notificationSettings?.ownerPhone || business.notifyPhone || null;
+  const missedCallValidation = buildAdminMissedCallValidationTruth({
+    events: operatorEvents,
+    successfulLeadCount,
+  });
   const setupFlow = buildTwilioSetupFlow({
     business,
     notificationSettings: business.notificationSettings,
@@ -189,6 +198,42 @@ export default async function AdminBusinessDetailPage({
     successfulLeadCount,
     testSmsState,
     webhookSnapshot,
+    missedCallValidation: {
+      complete: missedCallValidation.countsAsLaunchProof,
+      stateLabel: missedCallValidation.label,
+      detail: missedCallValidation.detail,
+      tone:
+        missedCallValidation.tone === 'success'
+          ? 'success'
+          : missedCallValidation.tone === 'attention'
+            ? 'attention'
+            : missedCallValidation.tone === 'pending'
+              ? 'pending'
+              : 'neutral',
+    },
+  });
+  const onboardingConfidence = buildAdminOnboardingConfidence({
+    business,
+    notificationSettings: business.notificationSettings,
+    ownerConnected: ownerState.connected,
+    successfulLeadCount,
+    operatorEvents,
+    webhookSnapshot,
+    missedCallValidation,
+  });
+  const { goLiveDecision, proofs } = buildAdminOperationalProofs({
+    ownerConnected: ownerState.connected,
+    ownerEmail: business.notificationSettings?.ownerEmail || null,
+    ownerPhone: ownerContact,
+    messagingServiceReady: Boolean(business.twilioMessagingServiceSid),
+    numberAssigned: Boolean(managedTextingNumber && (business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid)),
+    testSmsTruth,
+    missedCallValidation,
+    webhookSnapshot,
+    provisioningStatus: business.provisioningStatus,
+    canSafelyMarkLive: onboardingConfidence.canSafelyMarkLive,
+    blockers: onboardingConfidence.blockers.map((blocker) => blocker.message),
+    events: operatorEvents,
   });
   const lastIssue = buildAdminBusinessIssue({
     events: operatorEvents,
@@ -232,7 +277,10 @@ export default async function AdminBusinessDetailPage({
     ownerState,
     webhookSnapshot,
     testSmsTruth,
-    successfulLeadCount,
+    onboardingConfidence,
+    missedCallValidation,
+    goLiveDecision,
+    proofs,
   });
   const nextStepGuide = buildAdminNextStepGuide({
     setupFlow,
@@ -252,6 +300,8 @@ export default async function AdminBusinessDetailPage({
   const archived = getQueryValue(searchParams, 'archived') === '1';
   const restored = getQueryValue(searchParams, 'restored') === '1';
   const statusSaved = getQueryValue(searchParams, 'statusSaved');
+  const validationSaved = getQueryValue(searchParams, 'validationSaved') === '1';
+  const liveAcknowledged = getQueryValue(searchParams, 'liveAcknowledged');
   const error = getQueryValue(searchParams, 'error');
 
   function renderAutomaticActions(step: TwilioSetupStep) {
@@ -546,31 +596,82 @@ export default async function AdminBusinessDetailPage({
 
     if (step.key === 'missed_call_validated') {
       return (
-        <div className="flex flex-wrap gap-3">
-          <Link className={buttonVariants({ size: 'sm' })} href={buildAdminCustomerOpenHref(business.id, '/app/call-flow')}>
-            Open customer call flow
-          </Link>
-          <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={buildAdminCustomerOpenHref(business.id, '/app')}>
-            Open customer workspace
-          </Link>
-          <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href="#recent-activity">
-            Open recent activity
-          </Link>
+        <div className="space-y-4">
+          <div className="flex flex-wrap gap-3">
+            <Link className={buttonVariants({ size: 'sm' })} href={buildAdminCustomerOpenHref(business.id, '/app/call-flow')}>
+              Open customer call flow
+            </Link>
+            <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={buildAdminCustomerOpenHref(business.id, '/app')}>
+              Open customer workspace
+            </Link>
+            <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href="#recent-activity">
+              Open recent activity
+            </Link>
+          </div>
+          <form action={confirmMissedCallValidationAction} className="space-y-3 rounded-xl border bg-background/80 p-4">
+            <input name="businessId" type="hidden" value={business.id} />
+            <input name="returnStep" type="hidden" value={step.key} />
+            <div className="space-y-2">
+              <Label htmlFor="manualMissedCallValidationNote">Manual validation note</Label>
+              <Textarea
+                id="manualMissedCallValidationNote"
+                name="note"
+                placeholder="Example: Placed a missed call from my cell, saw the lead created, recovery SMS sent, and owner alert arrived on +1..."
+                rows={4}
+              />
+            </div>
+            <Button size="sm" type="submit" variant="outline">
+              Mark missed-call flow validated
+            </Button>
+          </form>
         </div>
       );
     }
 
     if (step.key === 'safe_to_mark_live') {
       return (
-        <div className="flex flex-wrap gap-3">
-          <form action={setBusinessProvisioningStatusAction}>
+        <div className="space-y-4">
+          <form action={markBusinessLiveAction} className="space-y-4 rounded-xl border bg-background/80 p-4">
             <input name="businessId" type="hidden" value={business.id} />
             <input name="returnStep" type="hidden" value={step.key} />
-            <input name="status" type="hidden" value="LIVE" />
-            <Button disabled={!setupFlow.safeToMarkLive || business.provisioningStatus === 'LIVE'} size="sm" type="submit">
-              {business.provisioningStatus === 'LIVE' ? 'Already live' : 'Mark business live'}
+            {!onboardingConfidence.canSafelyMarkLive ? (
+              <>
+                <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm">
+                  <p className="font-medium text-destructive">Launch proof is still incomplete</p>
+                  <ul className="mt-2 space-y-2 text-destructive">
+                    {onboardingConfidence.blockers.map((blocker) => (
+                      <li key={blocker.message}>• {blocker.message}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="goLiveNote">Operator note</Label>
+                  <Textarea
+                    id="goLiveNote"
+                    name="note"
+                    placeholder="Record why this business is going live despite the current warning state."
+                    rows={4}
+                  />
+                </div>
+                <label className="flex items-start gap-2 rounded-xl border bg-background/80 p-3 text-sm">
+                  <input name="acknowledgeWarnings" type="checkbox" value="true" />
+                  <span>I understand this business is going live without complete proof and I am recording that decision explicitly.</span>
+                </label>
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                The current launch proof is green. Review it once more, then mark the business live when you want automation active.
+              </p>
+            )}
+            <Button disabled={business.provisioningStatus === 'LIVE' && onboardingConfidence.canSafelyMarkLive} size="sm" type="submit">
+              {business.provisioningStatus === 'LIVE' && onboardingConfidence.canSafelyMarkLive
+                ? 'Already live'
+                : onboardingConfidence.canSafelyMarkLive
+                  ? 'Mark business live'
+                  : 'Mark live with warnings'}
             </Button>
           </form>
+
           <form action={setBusinessProvisioningStatusAction}>
             <input name="businessId" type="hidden" value={business.id} />
             <input name="returnStep" type="hidden" value={step.key} />
@@ -789,9 +890,75 @@ export default async function AdminBusinessDetailPage({
       {synced ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Webhook sync complete for {synced}.</div> : null}
       {testSms ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Test SMS requested. Wait for final delivery or failure before trusting the setup.</div> : null}
       {statusSaved ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Provisioning status updated to {statusSaved}.</div> : null}
+      {validationSaved ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Manual missed-call validation proof saved.</div> : null}
+      {liveAcknowledged ? (
+        <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">
+          {liveAcknowledged === 'warnings' ? 'Business marked live with explicit warning acknowledgment.' : 'Business marked live after launch checks.'}
+        </div>
+      ) : null}
       {archived ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business archived safely. Automation is paused.</div> : null}
       {restored ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business restored and ready for review.</div> : null}
       {error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{error}</div> : null}
+
+      <Card className="border-primary/20 bg-primary/5">
+        <CardHeader className="gap-3">
+          <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+            <div className="space-y-2">
+              <CardDescription>Onboarding confidence</CardDescription>
+              <CardTitle className="text-lg">{onboardingConfidence.summary}</CardTitle>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Badge variant={onboardingConfidence.stateVariant}>{onboardingConfidence.stateLabel}</Badge>
+              <Badge variant={onboardingConfidence.readinessVariant}>{onboardingConfidence.readinessLabel}</Badge>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-5 text-sm">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="font-medium">Next action:</p>
+            <span className="text-muted-foreground">{onboardingConfidence.nextAction}</span>
+          </div>
+
+          <div className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+            <div className="space-y-3 rounded-xl border bg-background/80 p-4">
+              <p className="font-medium">Blockers and warnings</p>
+              {onboardingConfidence.blockers.length > 0 ? (
+                <ul className="space-y-2 text-muted-foreground">
+                  {onboardingConfidence.blockers.map((blocker) => (
+                    <li key={blocker.message}>• {blocker.message}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-muted-foreground">No current blockers are recorded for the go-live decision.</p>
+              )}
+              <div className="flex flex-wrap gap-2">
+                <Link className={buttonVariants({ size: 'sm' })} href={nextStepHref}>
+                  Open next step
+                </Link>
+                <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={buildStepPath(business.id, 'safe_to_mark_live', timelineFilter)}>
+                  Open go-live step
+                </Link>
+              </div>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-2">
+              {proofs.map((proof) => (
+                <div key={proof.key} className="rounded-xl border bg-background/80 p-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="font-medium">{proof.label}</p>
+                    <Badge variant={getOperatorToneBadgeVariant(proof.tone)}>{proof.statusLabel}</Badge>
+                  </div>
+                  <p className="mt-2 text-muted-foreground">{proof.detail}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {proof.verifiedAt ? `Latest proof ${formatDateTime(proof.verifiedAt)}` : proof.sourceLabel || 'No proof timestamp yet'}
+                  </p>
+                  {proof.evidenceSummary ? <p className="mt-2 text-xs text-muted-foreground">{proof.evidenceSummary}</p> : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
 
       <div className="grid gap-4 xl:grid-cols-3">
         <Card className="border-primary/20 bg-primary/5">
@@ -886,6 +1053,8 @@ export default async function AdminBusinessDetailPage({
                 step={step}
                 title={panel.title}
                 instructions={panel.instructions}
+                latestEvidence={panel.latestEvidence}
+                warnings={panel.warnings}
                 verification={panel.verification}
               />
             );

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -8,23 +8,26 @@ import {
   buildPendingOwnerClerkId,
   connectExistingBusinessOwner,
   findClerkUserByEmail,
+  getAdminOwnerState,
+  getTwilioWebhookSnapshot,
   inviteBusinessOwner,
   runAdminProvisioning,
   syncBusinessTwilioWebhooks,
   updateBusinessProvisioningStatus,
 } from '@/lib/admin-provisioning';
 import { deleteDeletableTestBusiness } from '@/lib/admin-business-lifecycle';
+import { buildAdminOnboardingConfidence, canDeleteTestBusiness, getDeleteTestBusinessBlockedReason } from '@/lib/admin-dashboard';
+import { buildAdminMissedCallValidationTruth } from '@/lib/admin-operator-proof';
 import { requireAdmin } from '@/lib/admin';
-import { canDeleteTestBusiness, getDeleteTestBusinessBlockedReason } from '@/lib/admin-dashboard';
 import {
   bulkDeleteTestDemoBusinesses,
   BULK_TEST_DATA_RESET_CONFIRMATION,
   DEMO_OWNER_CLERK_ID,
 } from '@/lib/admin-test-data-reset';
 import { logAuditEvent } from '@/lib/audit-log';
-import { buildTwilioSetupUpdateEventMetadata } from '@/lib/admin-operator-visibility';
+import { buildAdminTestSmsTruth, buildTwilioSetupUpdateEventMetadata } from '@/lib/admin-operator-visibility';
 import { db } from '@/lib/db';
-import { formatPhoneDetail, maskSid, recordBusinessOperatorEvent } from '@/lib/operator-events';
+import { formatPhoneDetail, listBusinessOperatorEvents, maskSid, recordBusinessOperatorEvent } from '@/lib/operator-events';
 import { maskPhoneForAudit, normalizePhoneNumber, normalizePhoneNumberToE164 } from '@/lib/phone';
 import { sendAndPersistOutboundMessage } from '@/lib/twilio-messaging';
 import {
@@ -34,6 +37,8 @@ import {
   adminConnectExistingOwnerSchema,
   adminDeleteBusinessSchema,
   adminInviteOwnerSchema,
+  adminMarkBusinessLiveSchema,
+  adminMissedCallValidationConfirmationSchema,
   adminSendTestSmsSchema,
   adminSetupBasicsSchema,
   adminTwilioSetupSchema,
@@ -43,6 +48,7 @@ import {
   adminWebhookSyncSchema,
 } from '@/lib/validators';
 import { createMessagingServiceForBusiness, createSubaccountForBusiness } from '@/lib/managed-twilio';
+import { buildTwilioSetupFlow } from '@/lib/twilio-setup';
 
 const DEFAULT_DEMO_NAME = 'CallbackCloser Demo';
 const DEFAULT_DEMO_TEXTING_NUMBER = '+15005550006';
@@ -208,6 +214,85 @@ async function loadBusinessForLifecycleAction(businessId: string) {
       notificationSettings: true,
     },
   });
+}
+
+async function loadBusinessLaunchContext(businessId: string) {
+  const [business, successfulLeadCount, operatorEvents] = await Promise.all([
+    db.business.findUnique({
+      where: { id: businessId },
+      include: {
+        notificationSettings: true,
+      },
+    }),
+    db.lead.count({
+      where: {
+        businessId,
+        OR: [{ ownerNotifiedAt: { not: null } }, { notifiedAt: { not: null } }],
+      },
+    }),
+    listBusinessOperatorEvents(businessId, 'all', 160),
+  ]);
+
+  if (!business) {
+    throw new Error('Business not found.');
+  }
+
+  const testSmsTruth = buildAdminTestSmsTruth(operatorEvents);
+  const [ownerState, webhookSnapshot] = await Promise.all([
+    getAdminOwnerState(business, business.notificationSettings),
+    getTwilioWebhookSnapshot(business),
+  ]);
+  const missedCallValidation = buildAdminMissedCallValidationTruth({
+    events: operatorEvents,
+    successfulLeadCount,
+  });
+  const setupFlow = buildTwilioSetupFlow({
+    business,
+    notificationSettings: business.notificationSettings,
+    ownerConnected: ownerState.connected,
+    successfulLeadCount,
+    testSmsState:
+      testSmsTruth.state === 'not_run'
+        ? 'not_started'
+        : testSmsTruth.state === 'pending'
+          ? 'pending_delivery'
+          : testSmsTruth.state,
+    webhookSnapshot,
+    missedCallValidation: {
+      complete: missedCallValidation.countsAsLaunchProof,
+      stateLabel: missedCallValidation.label,
+      detail: missedCallValidation.detail,
+      tone:
+        missedCallValidation.tone === 'success'
+          ? 'success'
+          : missedCallValidation.tone === 'attention'
+            ? 'attention'
+            : missedCallValidation.tone === 'pending'
+              ? 'pending'
+              : 'neutral',
+    },
+  });
+  const confidence = buildAdminOnboardingConfidence({
+    business,
+    notificationSettings: business.notificationSettings,
+    ownerConnected: ownerState.connected,
+    successfulLeadCount,
+    operatorEvents,
+    webhookSnapshot,
+    missedCallValidation,
+  });
+
+  return {
+    business,
+    confidence,
+    missedCallValidation,
+    setupFlow,
+    ownerState,
+    operatorEvents,
+    testSmsTruth,
+    webhookSnapshot,
+    successfulLeadCount,
+  };
 }
 
 export async function createDemoBusinessAction(formData: FormData) {
@@ -1361,6 +1446,63 @@ export async function resyncBusinessWebhooksAction(formData: FormData) {
   redirect(redirectPath);
 }
 
+export async function confirmMissedCallValidationAction(formData: FormData) {
+  const admin = await requireAdmin();
+  const returnStep = getReturnStep(formData);
+  const businessId = getString(formData, 'businessId');
+  const parsed = adminMissedCallValidationConfirmationSchema.safeParse(Object.fromEntries(formData));
+
+  if (!parsed.success) {
+    redirect(
+      buildAdminBusinessRedirectPath(
+        businessId,
+        withReturnStepParam({ error: parsed.error.issues[0]?.message || 'Add a short validation note.' }, returnStep)
+      )
+    );
+  }
+
+  const business = await db.business.findUnique({
+    where: { id: parsed.data.businessId },
+    select: {
+      id: true,
+      name: true,
+    },
+  });
+
+  if (!business) {
+    redirect(`/admin?error=${encodeURIComponent('Business not found.')}`);
+  }
+
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: 'admin.missed_call_validation_confirmed',
+    category: 'ADMIN_ACTIONS',
+    status: 'SUCCESS',
+    summary: 'Missed-call flow manually confirmed',
+    details: {
+      remediationStepKey: 'missed_call_validated',
+      note: parsed.data.note,
+    },
+  });
+
+  logAuditEvent({
+    event: 'admin_missed_call_validation_confirmed',
+    actorType: 'user',
+    actorId: admin.userId,
+    businessId: business.id,
+    targetType: 'business',
+    targetId: business.id,
+    metadata: {
+      actorEmail: admin.email,
+      source: 'admin_setup_panels',
+      note: parsed.data.note,
+    },
+  });
+
+  await revalidateAdminPaths(business.id);
+  redirect(buildAdminBusinessRedirectPath(business.id, withReturnStepParam({ validationSaved: 1 }, returnStep)));
+}
+
 export async function setBusinessProvisioningStatusAction(formData: FormData) {
   await requireAdmin();
   const returnStep = getReturnStep(formData);
@@ -1376,6 +1518,105 @@ export async function setBusinessProvisioningStatusAction(formData: FormData) {
     buildAdminBusinessRedirectPath(
       parsed.data.businessId,
       withReturnStepParam({ statusSaved: parsed.data.status.toLowerCase() }, returnStep)
+    )
+  );
+}
+
+export async function markBusinessLiveAction(formData: FormData) {
+  const admin = await requireAdmin();
+  const returnStep = getReturnStep(formData);
+  const businessId = getString(formData, 'businessId');
+  const parsed = adminMarkBusinessLiveSchema.safeParse(Object.fromEntries(formData));
+
+  if (!parsed.success) {
+    redirect(
+      buildAdminBusinessRedirectPath(
+        businessId,
+        withReturnStepParam({ error: parsed.error.issues[0]?.message || 'Unable to mark the business live.' }, returnStep)
+      )
+    );
+  }
+
+  const { business, confidence } = await loadBusinessLaunchContext(parsed.data.businessId);
+
+  if (business.archivedAt) {
+    redirect(buildAdminBusinessRedirectPath(business.id, withReturnStepParam({ error: 'Restore the archived business before marking it live.' }, returnStep)));
+  }
+
+  const blockers = confidence.blockers.map((blocker) => blocker.message);
+  const note = parsed.data.note?.trim() || null;
+
+  if (!confidence.canSafelyMarkLive && !parsed.data.acknowledgeWarnings) {
+    redirect(
+      buildAdminBusinessRedirectPath(
+        business.id,
+        withReturnStepParam(
+          {
+            error: blockers.length > 0 ? `Launch proof is still incomplete: ${blockers.join(' ')}` : 'Launch proof is still incomplete.',
+          },
+          returnStep
+        )
+      )
+    );
+  }
+
+  if (!confidence.canSafelyMarkLive && !note) {
+    redirect(
+      buildAdminBusinessRedirectPath(
+        business.id,
+        withReturnStepParam(
+          {
+            error: 'Add a short operator note before marking this business live with warnings.',
+          },
+          returnStep
+        )
+      )
+    );
+  }
+
+  await updateBusinessProvisioningStatus(business.id, BusinessProvisioningStatus.LIVE, null);
+  await recordBusinessOperatorEvent({
+    businessId: business.id,
+    type: confidence.canSafelyMarkLive ? 'admin.go_live_marked_safe' : 'admin.go_live_marked_with_warnings',
+    category: 'ADMIN_ACTIONS',
+    status: confidence.canSafelyMarkLive ? 'SUCCESS' : 'WARNING',
+    summary: confidence.canSafelyMarkLive ? 'Business marked live after launch checks' : 'Business marked live with known warnings',
+    details: {
+      remediationStepKey: 'safe_to_mark_live',
+      note,
+      blockers,
+      acknowledgeWarnings: parsed.data.acknowledgeWarnings,
+      canSafelyMarkLive: confidence.canSafelyMarkLive,
+    },
+  });
+
+  logAuditEvent({
+    event: 'admin_business_marked_live',
+    actorType: 'user',
+    actorId: admin.userId,
+    businessId: business.id,
+    targetType: 'business',
+    targetId: business.id,
+    metadata: {
+      actorEmail: admin.email,
+      source: 'admin_setup_panels',
+      blockers,
+      canSafelyMarkLive: confidence.canSafelyMarkLive,
+      note,
+    },
+  });
+
+  await revalidateAdminPaths(business.id);
+  redirect(
+    buildAdminBusinessRedirectPath(
+      business.id,
+      withReturnStepParam(
+        {
+          statusSaved: 'live',
+          liveAcknowledged: confidence.canSafelyMarkLive ? 'safe' : 'warnings',
+        },
+        returnStep
+      )
     )
   );
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -15,6 +15,7 @@ import { buildAdminCustomerOpenHref } from '@/lib/admin-customer-paths';
 import { BULK_TEST_DATA_RESET_CONFIRMATION, listTestDemoBusinessesForReset } from '@/lib/admin-test-data-reset';
 import {
   adminBoardFilterOptions,
+  buildAdminOnboardingConfidence,
   buildAdminBusinessPickerLabel,
   buildAdminNextStep,
   canDeleteTestBusiness,
@@ -23,6 +24,7 @@ import {
   matchesAdminBoardFilter,
   type AdminBoardFilter,
 } from '@/lib/admin-dashboard';
+import { buildAdminMissedCallValidationTruth } from '@/lib/admin-operator-proof';
 import {
   buildAdminBusinessIssue,
   buildAdminTestSmsTruth,
@@ -125,7 +127,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   const view = (getQueryValue(searchParams, 'view') as AdminBoardFilter | null) || 'all';
   const adminBusiness = await db.business.findUnique({ where: { ownerClerkId: admin.userId } });
 
-  const [businesses, businessPickerOptions, leadCounts, leadActivity, callActivity, messageActivity, latestOperatorIssues, latestTestSmsEvents, operatorSignals, resettableBusinesses] = await Promise.all([
+  const [businesses, businessPickerOptions, leadCounts, successfulLeadCounts, leadActivity, callActivity, messageActivity, latestOperatorIssues, latestTestSmsEvents, operatorSignals, confidenceEvents, resettableBusinesses] = await Promise.all([
     query
       ? searchBusinessesForAdmin(query)
       : db.business.findMany({
@@ -154,6 +156,13 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       by: ['businessId'],
       _count: { _all: true },
       _max: { lastInteractionAt: true, createdAt: true },
+    }),
+    db.lead.groupBy({
+      by: ['businessId'],
+      where: {
+        OR: [{ ownerNotifiedAt: { not: null } }, { notifiedAt: { not: null } }],
+      },
+      _count: { _all: true },
     }),
     db.lead.groupBy({
       by: ['businessId'],
@@ -209,10 +218,64 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       },
       take: 600,
     }),
+    db.businessOperatorEvent.findMany({
+      where: {
+        OR: [
+          {
+            type: {
+              startsWith: 'admin.test_sms_',
+            },
+          },
+          {
+            type: {
+              in: [
+                'voice.lead_created_from_call',
+                'voice.lead_updated_from_call',
+                'messaging.missed_call_sms_started',
+                'messaging.outbound_sms_requested',
+                'messaging.outbound_sms_accepted',
+                'messaging.outbound_sms_delivered',
+                'messaging.inbound_sms_received',
+                'messaging.outbound_sms_delivery_failed',
+                'messaging.missed_call_sms_suppressed',
+                'owner_alert.sms_sent',
+                'owner_alert.email_sent',
+                'owner_alert.in_app_sent',
+                'owner_alert.sms_delivered',
+                'owner_alert.sms_failed',
+                'owner_alert.email_failed',
+                'owner_alert.in_app_failed',
+                'admin.missed_call_validation_confirmed',
+                'admin.go_live_marked_safe',
+                'admin.go_live_marked_with_warnings',
+              ],
+            },
+          },
+          {
+            status: {
+              in: [OperatorEventStatus.FAILED, OperatorEventStatus.WARNING],
+            },
+          },
+        ],
+      },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        businessId: true,
+        type: true,
+        status: true,
+        summary: true,
+        detailsJson: true,
+        createdAt: true,
+        relatedEntityType: true,
+        relatedEntityId: true,
+      },
+      take: 1400,
+    }),
     listTestDemoBusinessesForReset(),
   ]);
 
   const leadCountMap = new Map(leadCounts.map((item) => [item.businessId, item._count._all]));
+  const successfulLeadCountMap = new Map(successfulLeadCounts.map((item) => [item.businessId, item._count._all]));
   const leadActivityMap = new Map(
     leadActivity.map((item) => [item.businessId, maxDate(item._max.lastInteractionAt, item._max.createdAt)])
   );
@@ -232,6 +295,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   >();
   const testSmsEventMap = new Map<string, Array<(typeof latestTestSmsEvents)[number]>>();
   const operatorSignalMap = new Map<string, { failed: number; warning: number }>();
+  const confidenceEventMap = new Map<string, Array<(typeof confidenceEvents)[number]>>();
 
   for (const issue of latestOperatorIssues) {
     if (!latestIssueMap.has(issue.businessId)) {
@@ -258,10 +322,19 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
     operatorSignalMap.set(signal.businessId, entry);
   }
 
+  for (const event of confidenceEvents) {
+    const existing = confidenceEventMap.get(event.businessId) || [];
+    if (existing.length < 24) {
+      existing.push(event);
+      confidenceEventMap.set(event.businessId, existing);
+    }
+  }
+
   const businessRows = businesses.map((business) => {
     const managedSummary = getManagedTwilioStatusSummary(business);
     const ownerPending = isPendingOwnerClerkId(business.ownerClerkId);
     const ownerConnected = !ownerPending;
+    const businessConfidenceEvents = confidenceEventMap.get(business.id) || [];
     const ownerStatusLabel = !business.notificationSettings?.ownerEmail
       ? 'Owner email missing'
       : ownerPending
@@ -311,6 +384,18 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       },
     });
     const testSmsTruth = buildAdminTestSmsTruth(testSmsEventMap.get(business.id) || []);
+    const missedCallValidation = buildAdminMissedCallValidationTruth({
+      events: businessConfidenceEvents,
+      successfulLeadCount: successfulLeadCountMap.get(business.id) ?? 0,
+    });
+    const onboardingConfidence = buildAdminOnboardingConfidence({
+      business,
+      notificationSettings: business.notificationSettings,
+      ownerConnected,
+      successfulLeadCount: successfulLeadCountMap.get(business.id) ?? 0,
+      operatorEvents: businessConfidenceEvents,
+      missedCallValidation,
+    });
     const attentionSignal =
       lastIssue.state === 'issue'
         ? compactCopy(`${lastIssue.summary}. ${lastIssue.detail}`)
@@ -338,6 +423,8 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       attentionSignal,
       operatorSignals,
       testSmsTruth,
+      missedCallValidation,
+      onboardingConfidence,
       canSendTestSms: Boolean(assignedNumber && (business.notificationSettings?.ownerPhone || business.notifyPhone)),
       blockerStepHref,
     };
@@ -375,10 +462,10 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   });
 
   const summaryStats = [
-    { label: 'Needs attention', value: filterCounts.get('needs_attention') ?? 0 },
-    { label: 'Not fully provisioned', value: filterCounts.get('not_fully_provisioned') ?? 0 },
-    { label: 'Live', value: filterCounts.get('live') ?? 0 },
-    { label: 'Archived', value: filterCounts.get('archived') ?? 0 },
+    { label: 'Needs attention', value: businessRows.filter((row) => row.onboardingConfidence.state === 'needs_attention').length },
+    { label: 'Waiting on A2P', value: businessRows.filter((row) => row.onboardingConfidence.state === 'waiting_on_a2p').length },
+    { label: 'Ready for live', value: businessRows.filter((row) => row.onboardingConfidence.state === 'ready_to_go_live').length },
+    { label: 'Live with warnings', value: businessRows.filter((row) => row.onboardingConfidence.state === 'live_with_warnings').length },
   ];
   const resettableBusinessPreview = resettableBusinesses.slice(0, 4).map((business) => business.name);
 
@@ -647,6 +734,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                   <div className="flex flex-wrap items-center gap-2">
                     <p className="text-base font-semibold">{selectedBusinessRow.business.name}</p>
                     <Badge variant={selectedBusinessRow.overallStatus.variant}>{selectedBusinessRow.overallStatus.label}</Badge>
+                    <Badge variant={selectedBusinessRow.onboardingConfidence.stateVariant}>{selectedBusinessRow.onboardingConfidence.stateLabel}</Badge>
                     {selectedBusinessRow.business.isTestBusiness ? <Badge variant="outline">Test</Badge> : null}
                     {isBusinessArchived(selectedBusinessRow.business) ? <Badge variant="outline">Archived</Badge> : null}
                   </div>
@@ -664,8 +752,10 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                       </p>
                     </div>
                     <div>
-                      <p className="font-medium">Last issue</p>
-                      <p className="mt-1 text-muted-foreground">{selectedBusinessRow.attentionSignal}</p>
+                      <p className="font-medium">Go-live blocker</p>
+                      <p className="mt-1 text-muted-foreground">
+                        {selectedBusinessRow.onboardingConfidence.blockers[0]?.message || selectedBusinessRow.onboardingConfidence.summary}
+                      </p>
                     </div>
                     <div>
                       <p className="font-medium">Test SMS</p>
@@ -673,6 +763,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                         <Badge variant={getOperatorToneBadgeVariant(selectedBusinessRow.testSmsTruth.tone)}>
                           {selectedBusinessRow.testSmsTruth.label}
                         </Badge>
+                        <Badge variant={selectedBusinessRow.onboardingConfidence.readinessVariant}>{selectedBusinessRow.onboardingConfidence.readinessLabel}</Badge>
                       </div>
                     </div>
                   </div>
@@ -773,7 +864,6 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                   business,
                   ownerStatusLabel,
                   ownerStatusVariant,
-                  managedSummary,
                   nextStep,
                   leadCount,
                   assignedNumber,
@@ -784,6 +874,8 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                   attentionSignal,
                   operatorSignals,
                   testSmsTruth,
+                  missedCallValidation,
+                  onboardingConfidence,
                   canSendTestSms,
                   blockerStepHref,
                 }) => (
@@ -794,12 +886,15 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                           {business.name}
                         </Link>
                         <Badge variant={overallStatus.variant}>{overallStatus.label}</Badge>
+                        <Badge variant={onboardingConfidence.stateVariant}>{onboardingConfidence.stateLabel}</Badge>
                         {business.isTestBusiness ? <Badge variant="outline">Test</Badge> : null}
                         {isBusinessArchived(business) ? <Badge variant="outline">Archived</Badge> : null}
                       </div>
                       <div className="space-y-1 text-sm">
-                        <p className="font-medium">Last issue</p>
-                        <p className={cn('text-muted-foreground', lastIssue.state === 'issue' ? 'text-destructive' : '')}>{attentionSignal}</p>
+                        <p className="font-medium">Needs attention</p>
+                        <p className={cn('text-muted-foreground', onboardingConfidence.state === 'needs_attention' || lastIssue.state === 'issue' ? 'text-destructive' : '')}>
+                          {onboardingConfidence.blockers[0]?.message || attentionSignal}
+                        </p>
                       </div>
                       <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
                         <span>{business.id}</span>
@@ -824,9 +919,9 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
 
                     <div className="grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-1">
                       <div>
-                        <p className="font-medium">Provisioning</p>
-                        <p className="mt-1">{managedSummary.label}</p>
-                        <p className="mt-1 text-xs text-muted-foreground">{managedSummary.nextStep}</p>
+                        <p className="font-medium">Readiness</p>
+                        <p className="mt-1">{onboardingConfidence.readinessLabel}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">{onboardingConfidence.summary}</p>
                       </div>
                       <div>
                         <p className="font-medium">A2P</p>
@@ -842,10 +937,13 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
 
                     <div className="space-y-2 text-sm">
                       <p className="font-medium">Next action</p>
-                      <p>{nextStep.actionLabel}</p>
+                      <p>{onboardingConfidence.nextAction}</p>
                       <p className="text-muted-foreground">{nextStep.title}</p>
                       <div className="flex flex-wrap gap-2">
                         <Badge variant={getOperatorToneBadgeVariant(testSmsTruth.tone)}>Test SMS {testSmsTruth.label}</Badge>
+                        <Badge variant={onboardingConfidence.readinessVariant}>{onboardingConfidence.readinessLabel}</Badge>
+                        {!missedCallValidation.countsAsLaunchProof ? <Badge variant="outline">Missed-call proof missing</Badge> : null}
+                        {onboardingConfidence.state === 'live_with_warnings' ? <Badge variant="destructive">Live with warnings</Badge> : null}
                         {lastIssue.state === 'issue' ? <Badge variant={getOperatorToneBadgeVariant(lastIssue.tone)}>Needs attention</Badge> : null}
                       </div>
                       {business.twilioWebhookSyncedAt ? (
@@ -853,6 +951,9 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                       ) : (
                         <p className="text-xs text-muted-foreground">Webhook sync still needed</p>
                       )}
+                      {missedCallValidation.verifiedAt ? (
+                        <p className="text-xs text-muted-foreground">Missed-call proof {formatRelativeTime(missedCallValidation.verifiedAt)}</p>
+                      ) : null}
                       {lastIssue.createdAt ? <p className="text-xs text-destructive">Latest issue recorded {formatRelativeTime(lastIssue.createdAt)}</p> : null}
                     </div>
 

--- a/components/admin-business-setup-step-card.tsx
+++ b/components/admin-business-setup-step-card.tsx
@@ -22,6 +22,8 @@ export function AdminBusinessSetupStepCard({
   nextAction,
   instructions,
   verification,
+  latestEvidence,
+  warnings,
   automaticActions,
   manualEntry,
   open,
@@ -34,6 +36,8 @@ export function AdminBusinessSetupStepCard({
   nextAction: string;
   instructions: string[];
   verification: string[];
+  latestEvidence: string[];
+  warnings: string[];
   automaticActions?: ReactNode;
   manualEntry?: ReactNode;
   open?: boolean;
@@ -74,6 +78,28 @@ export function AdminBusinessSetupStepCard({
             <p className="font-medium">What to do next</p>
             <p className="text-muted-foreground">{nextAction}</p>
           </section>
+
+          {latestEvidence.length > 0 ? (
+            <section className="space-y-2 text-sm">
+              <p className="font-medium">Latest evidence</p>
+              <ul className="space-y-2 text-muted-foreground">
+                {latestEvidence.map((item) => (
+                  <li key={item}>• {item}</li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+
+          {warnings.length > 0 ? (
+            <section className="space-y-2 rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm">
+              <p className="font-medium text-destructive">Warnings before completion</p>
+              <ul className="space-y-2 text-destructive">
+                {warnings.map((item) => (
+                  <li key={item}>• {item}</li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
 
           {automaticActions ? (
             <section className="space-y-3 text-sm">

--- a/lib/admin-dashboard.ts
+++ b/lib/admin-dashboard.ts
@@ -11,7 +11,9 @@ import {
   type OwnerNotification,
 } from '@prisma/client';
 
+import type { TwilioWebhookSnapshot } from '@/lib/admin-provisioning-presenters';
 import { DEMO_OWNER_CLERK_ID, isTestDemoBusiness } from '@/lib/admin-test-data-reset';
+import type { AdminMissedCallValidationTruth } from '@/lib/admin-operator-proof';
 import { getManagedTextingNumber, getManagedTwilioStatusSummary } from '@/lib/managed-twilio-status';
 import { formatMessageStatus, isMessageDeliveryIssueStatus } from '@/lib/lead-presenters';
 
@@ -412,8 +414,10 @@ export function buildAdminOnboardingConfidence(params: {
   ownerConnected: boolean;
   successfulLeadCount: number;
   operatorEvents: Array<{ type: string; status: OperatorEventStatus; createdAt: Date }>;
+  webhookSnapshot?: TwilioWebhookSnapshot | null;
+  missedCallValidation?: Pick<AdminMissedCallValidationTruth, 'countsAsLaunchProof' | 'detail'> | null;
 }) {
-  const { business, notificationSettings, ownerConnected, successfulLeadCount, operatorEvents } = params;
+  const { business, notificationSettings, ownerConnected, successfulLeadCount, operatorEvents, webhookSnapshot, missedCallValidation } = params;
   const managedSummary = getManagedTwilioStatusSummary(business);
   const nextStep = buildAdminNextStep({ business, notificationSettings, ownerConnected });
   const ownerEmail = notificationSettings?.ownerEmail?.trim() || null;
@@ -423,7 +427,10 @@ export function buildAdminOnboardingConfidence(params: {
   const twilioSetupReady = managedSummary.accountReady;
   const numberReady = Boolean(getManagedTextingNumber(business) && (business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid));
   const messagingServiceReady = Boolean(business.twilioMessagingServiceSid);
-  const webhooksReady = Boolean(business.twilioWebhookSyncedAt);
+  const webhooksReady =
+    webhookSnapshot && !webhookSnapshot.error
+      ? webhookSnapshot.voiceSynced && webhookSnapshot.smsSynced && webhookSnapshot.statusSynced
+      : Boolean(business.twilioWebhookSyncedAt);
   const compliancePending =
     managedSummary.onboardingReady && !managedSummary.complianceReady && !managedSummary.attentionRequired;
   const latestTestSmsState = getAdminTestSmsConfidenceState(operatorEvents);
@@ -433,7 +440,7 @@ export function buildAdminOnboardingConfidence(params: {
   const hasRecentFailures = operatorEvents.some(
     (event) => event.status === OperatorEventStatus.FAILED || event.status === OperatorEventStatus.WARNING
   );
-  const missedCallValidated = successfulLeadCount > 0;
+  const missedCallValidated = missedCallValidation?.countsAsLaunchProof ?? successfulLeadCount > 0;
   const readyForTest = ownerConnected && ownerAlertsReady && twilioSetupReady && numberReady && messagingServiceReady && webhooksReady && managedSummary.complianceReady;
   const readyForLive = readyForTest && hasTestSmsSuccess && missedCallValidated;
   const canSafelyMarkLive = readyForLive;
@@ -485,7 +492,12 @@ export function buildAdminOnboardingConfidence(params: {
     blockers.push({ level: 'error', message: 'The latest admin test SMS did not complete cleanly. Fix that before you go live.' });
   }
   if (readyForTest && !missedCallValidated) {
-    blockers.push({ level: 'warning', message: 'Run one real missed-call test and confirm the lead reaches the owner before marking this business live.' });
+    blockers.push({
+      level: 'warning',
+      message:
+        missedCallValidation?.detail ||
+        'Run one real missed-call test and confirm the lead reaches the owner before marking this business live.',
+    });
   }
 
   const milestones: OnboardingConfidenceMilestone[] = [
@@ -569,7 +581,11 @@ export function buildAdminOnboardingConfidence(params: {
       label: 'Missed-call flow validated',
       complete: missedCallValidated,
       variant: milestoneVariant({ complete: missedCallValidated, blocking: readyForTest }),
-      detail: missedCallValidated ? 'At least one missed-call lead reached the owner flow for this business.' : 'Run one real missed-call test from start to finish before going live.',
+      detail:
+        missedCallValidation?.detail ||
+        (missedCallValidated
+          ? 'At least one missed-call lead reached the owner flow for this business.'
+          : 'Run one real missed-call test from start to finish before going live.'),
     },
     {
       key: 'live_gate',

--- a/lib/admin-operator-proof.ts
+++ b/lib/admin-operator-proof.ts
@@ -1,0 +1,551 @@
+import { BusinessProvisioningStatus, OperatorEventStatus, type BusinessOperatorEvent } from '@prisma/client';
+
+import type { TwilioWebhookSnapshot } from '@/lib/admin-provisioning-presenters';
+import type { AdminTestSmsTruth } from '@/lib/admin-operator-visibility';
+import type { TwilioSetupStepKey } from '@/lib/twilio-setup';
+
+type ProofEvent = Pick<
+  BusinessOperatorEvent,
+  'type' | 'status' | 'summary' | 'detailsJson' | 'createdAt' | 'relatedEntityType' | 'relatedEntityId'
+>;
+
+export type AdminProofTone = 'neutral' | 'pending' | 'success' | 'attention';
+export type AdminProofStatus = 'not_started' | 'waiting' | 'validated' | 'manual' | 'failed';
+
+export type AdminMissedCallValidationTruth = {
+  state: 'not_run' | 'waiting' | 'validated_by_sequence' | 'manually_confirmed' | 'failed';
+  label: string;
+  tone: AdminProofTone;
+  summary: string;
+  detail: string;
+  verifiedAt: Date | null;
+  sourceLabel: string | null;
+  evidenceSummary: string | null;
+  relatedLeadId: string | null;
+  latestRelatedEventAt: Date | null;
+  countsAsLaunchProof: boolean;
+};
+
+export type AdminGoLiveDecisionTruth = {
+  state: 'not_acknowledged' | 'ready_for_live' | 'marked_live' | 'marked_live_with_warnings';
+  label: string;
+  tone: AdminProofTone;
+  summary: string;
+  detail: string;
+  decidedAt: Date | null;
+  sourceLabel: string | null;
+  note: string | null;
+  blockers: string[];
+};
+
+export type AdminOperationalProof = {
+  key: 'owner_flow' | 'webhooks' | 'messaging_path' | 'test_sms' | 'missed_call_flow' | 'go_live_decision';
+  label: string;
+  stepKey: TwilioSetupStepKey;
+  status: AdminProofStatus;
+  statusLabel: string;
+  tone: AdminProofTone;
+  detail: string;
+  sourceLabel: string | null;
+  verifiedAt: Date | null;
+  evidenceSummary: string | null;
+  countsAsLaunchProof: boolean;
+};
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getDetailString(details: unknown, key: string) {
+  if (!isJsonObject(details)) return null;
+  const value = details[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function getLatestEvent(events: ProofEvent[], predicate: (event: ProofEvent) => boolean) {
+  return events
+    .filter(predicate)
+    .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime())[0] || null;
+}
+
+function getLeadId(event: ProofEvent) {
+  if (event.relatedEntityType === 'lead' && event.relatedEntityId) {
+    return event.relatedEntityId;
+  }
+
+  return getDetailString(event.detailsJson, 'leadId');
+}
+
+function buildProofState(params: {
+  status: AdminProofStatus;
+  detail: string;
+  sourceLabel: string | null;
+  verifiedAt: Date | null;
+  evidenceSummary: string | null;
+  countsAsLaunchProof: boolean;
+  stepKey: TwilioSetupStepKey;
+  label: string;
+}) {
+  const meta = {
+    not_started: { statusLabel: 'Not started', tone: 'neutral' as const },
+    waiting: { statusLabel: 'Waiting', tone: 'pending' as const },
+    validated: { statusLabel: 'Validated', tone: 'success' as const },
+    manual: { statusLabel: 'Manually confirmed', tone: 'success' as const },
+    failed: { statusLabel: 'Needs attention', tone: 'attention' as const },
+  }[params.status];
+
+  return {
+    key: params.label,
+    label: params.label,
+    stepKey: params.stepKey,
+    status: params.status,
+    statusLabel: meta.statusLabel,
+    tone: meta.tone,
+    detail: params.detail,
+    sourceLabel: params.sourceLabel,
+    verifiedAt: params.verifiedAt,
+    evidenceSummary: params.evidenceSummary,
+    countsAsLaunchProof: params.countsAsLaunchProof,
+  };
+}
+
+export function buildAdminMissedCallValidationTruth(params: {
+  events: ProofEvent[];
+  successfulLeadCount: number;
+}) {
+  const { events, successfulLeadCount } = params;
+  const sortedEvents = [...events].sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime());
+
+  const manualConfirmation = getLatestEvent(sortedEvents, (event) => event.type === 'admin.missed_call_validation_confirmed');
+  const latestFailure = getLatestEvent(
+    sortedEvents,
+    (event) =>
+      event.type === 'messaging.missed_call_sms_suppressed' ||
+      event.type === 'messaging.outbound_sms_delivery_failed' ||
+      event.type === 'owner_alert.sms_failed' ||
+      event.type === 'owner_alert.email_failed' ||
+      event.type === 'owner_alert.in_app_failed'
+  );
+
+  const latestLeadSignal = getLatestEvent(
+    sortedEvents,
+    (event) =>
+      event.type === 'voice.lead_created_from_call' ||
+      event.type === 'voice.lead_updated_from_call' ||
+      event.type === 'messaging.missed_call_sms_started' ||
+      event.type === 'messaging.outbound_sms_requested' ||
+      event.type === 'messaging.outbound_sms_accepted' ||
+      event.type === 'messaging.outbound_sms_delivered' ||
+      event.type === 'messaging.inbound_sms_received' ||
+      event.type === 'owner_alert.sms_sent' ||
+      event.type === 'owner_alert.email_sent' ||
+      event.type === 'owner_alert.in_app_sent' ||
+      event.type === 'owner_alert.sms_delivered'
+  );
+
+  if (manualConfirmation && (!latestFailure || manualConfirmation.createdAt >= latestFailure.createdAt)) {
+    const note = getDetailString(manualConfirmation.detailsJson, 'note');
+    return {
+      state: 'manually_confirmed',
+      label: 'Manually confirmed',
+      tone: 'success',
+      summary: manualConfirmation.summary,
+      detail: note || 'An operator recorded manual proof that the missed-call flow reached the expected outcome.',
+      verifiedAt: manualConfirmation.createdAt,
+      sourceLabel: 'Operator confirmation',
+      evidenceSummary: note,
+      relatedLeadId: getLeadId(manualConfirmation),
+      latestRelatedEventAt: manualConfirmation.createdAt,
+      countsAsLaunchProof: true,
+    } satisfies AdminMissedCallValidationTruth;
+  }
+
+  const byLead = new Map<
+    string,
+    {
+      leadEvent?: ProofEvent;
+      smsEvent?: ProofEvent;
+      replyEvent?: ProofEvent;
+      ownerAlertEvent?: ProofEvent;
+    }
+  >();
+
+  for (const event of sortedEvents) {
+    const leadId = getLeadId(event);
+    if (!leadId) continue;
+
+    const current = byLead.get(leadId) || {};
+
+    if (!current.leadEvent && (event.type === 'voice.lead_created_from_call' || event.type === 'voice.lead_updated_from_call')) {
+      current.leadEvent = event;
+    }
+
+    if (
+      !current.smsEvent &&
+      (event.type === 'messaging.missed_call_sms_started' ||
+        event.type === 'messaging.outbound_sms_requested' ||
+        event.type === 'messaging.outbound_sms_accepted' ||
+        event.type === 'messaging.outbound_sms_delivered')
+    ) {
+      current.smsEvent = event;
+    }
+
+    if (!current.replyEvent && event.type === 'messaging.inbound_sms_received') {
+      current.replyEvent = event;
+    }
+
+    if (
+      !current.ownerAlertEvent &&
+      (event.type === 'owner_alert.sms_sent' ||
+        event.type === 'owner_alert.email_sent' ||
+        event.type === 'owner_alert.in_app_sent' ||
+        event.type === 'owner_alert.sms_delivered')
+    ) {
+      current.ownerAlertEvent = event;
+    }
+
+    byLead.set(leadId, current);
+  }
+
+  const recentSequence = [...byLead.entries()]
+    .map(([leadId, entry]) => ({
+      leadId,
+      entry,
+      verifiedAt: [entry.leadEvent, entry.smsEvent, entry.replyEvent, entry.ownerAlertEvent]
+        .filter((event): event is ProofEvent => Boolean(event))
+        .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime())[0]?.createdAt || null,
+    }))
+    .filter((candidate) => Boolean(candidate.entry.leadEvent && candidate.entry.smsEvent && candidate.entry.ownerAlertEvent))
+    .sort((left, right) => (right.verifiedAt?.getTime() || 0) - (left.verifiedAt?.getTime() || 0))[0];
+
+  if (recentSequence && (!latestFailure || (recentSequence.verifiedAt && recentSequence.verifiedAt >= latestFailure.createdAt))) {
+    const hadReply = Boolean(recentSequence.entry.replyEvent);
+    return {
+      state: 'validated_by_sequence',
+      label: 'Validated by event sequence',
+      tone: 'success',
+      summary: 'Missed-call flow validated by recent business activity',
+      detail: hadReply
+        ? 'CallbackCloser recorded the missed call, recovery SMS path, inbound reply, and owner alert for one lead.'
+        : 'CallbackCloser recorded the missed call, recovery SMS path, and owner alert for one lead.',
+      verifiedAt: recentSequence.verifiedAt,
+      sourceLabel: 'Recent event sequence',
+      evidenceSummary: `Lead ${recentSequence.leadId.slice(-6)} shows a missed-call recovery sequence through owner alert delivery.`,
+      relatedLeadId: recentSequence.leadId,
+      latestRelatedEventAt: recentSequence.verifiedAt,
+      countsAsLaunchProof: true,
+    } satisfies AdminMissedCallValidationTruth;
+  }
+
+  if (latestFailure) {
+    const reason = getDetailString(latestFailure.detailsJson, 'errorMessage') || getDetailString(latestFailure.detailsJson, 'error');
+    return {
+      state: 'failed',
+      label: 'Needs attention',
+      tone: 'attention',
+      summary: latestFailure.summary,
+      detail: reason || 'The latest missed-call recovery attempt did not complete cleanly enough to count as proof.',
+      verifiedAt: null,
+      sourceLabel: 'Recent failed event',
+      evidenceSummary: latestFailure.summary,
+      relatedLeadId: getLeadId(latestFailure),
+      latestRelatedEventAt: latestFailure.createdAt,
+      countsAsLaunchProof: false,
+    } satisfies AdminMissedCallValidationTruth;
+  }
+
+  if (latestLeadSignal) {
+    return {
+      state: 'waiting',
+      label: 'Waiting for proof',
+      tone: 'pending',
+      summary: latestLeadSignal.summary,
+      detail: 'CallbackCloser has seen part of the missed-call flow, but it does not yet have enough evidence to prove the full business path.',
+      verifiedAt: null,
+      sourceLabel: 'Partial event sequence',
+      evidenceSummary: latestLeadSignal.summary,
+      relatedLeadId: getLeadId(latestLeadSignal),
+      latestRelatedEventAt: latestLeadSignal.createdAt,
+      countsAsLaunchProof: false,
+    } satisfies AdminMissedCallValidationTruth;
+  }
+
+  if (successfulLeadCount > 0) {
+    return {
+      state: 'waiting',
+      label: 'Historical signal only',
+      tone: 'pending',
+      summary: 'Historical lead activity exists, but explicit launch proof is still missing',
+      detail: 'This business has historical owner-notified leads, but the current operator console does not yet have a recorded validation sequence or manual confirmation.',
+      verifiedAt: null,
+      sourceLabel: 'Historical lead count',
+      evidenceSummary: `${successfulLeadCount} historical owner-notified lead${successfulLeadCount === 1 ? '' : 's'}`,
+      relatedLeadId: null,
+      latestRelatedEventAt: null,
+      countsAsLaunchProof: false,
+    } satisfies AdminMissedCallValidationTruth;
+  }
+
+  return {
+    state: 'not_run',
+    label: 'Not run',
+    tone: 'neutral',
+    summary: 'Missed-call flow not validated yet',
+    detail: 'Run one real missed call from start to finish, or record a manual confirmation note if you validated it outside this console.',
+    verifiedAt: null,
+    sourceLabel: null,
+    evidenceSummary: null,
+    relatedLeadId: null,
+    latestRelatedEventAt: null,
+    countsAsLaunchProof: false,
+  } satisfies AdminMissedCallValidationTruth;
+}
+
+export function buildAdminGoLiveDecisionTruth(params: {
+  provisioningStatus: BusinessProvisioningStatus;
+  canSafelyMarkLive: boolean;
+  blockers: string[];
+  events: ProofEvent[];
+}) {
+  const latestDecisionEvent = getLatestEvent(
+    params.events,
+    (event) => event.type === 'admin.go_live_marked_safe' || event.type === 'admin.go_live_marked_with_warnings'
+  );
+  const note = latestDecisionEvent ? getDetailString(latestDecisionEvent.detailsJson, 'note') : null;
+
+  if (params.provisioningStatus === BusinessProvisioningStatus.LIVE) {
+    if (latestDecisionEvent?.type === 'admin.go_live_marked_with_warnings' || !params.canSafelyMarkLive) {
+      return {
+        state: 'marked_live_with_warnings',
+        label: 'Live with warnings',
+        tone: 'attention',
+        summary: latestDecisionEvent?.summary || 'Business is live with known launch gaps',
+        detail:
+          note ||
+          (params.blockers.length > 0
+            ? `The business is live even though these launch gaps still exist: ${params.blockers.join(', ')}.`
+            : 'The business is live, but the current launch proof is incomplete.'),
+        decidedAt: latestDecisionEvent?.createdAt || null,
+        sourceLabel: latestDecisionEvent ? 'Operator acknowledgment' : 'Current business state',
+        note,
+        blockers: params.blockers,
+      } satisfies AdminGoLiveDecisionTruth;
+    }
+
+    return {
+      state: 'marked_live',
+      label: 'Live',
+      tone: 'success',
+      summary: latestDecisionEvent?.summary || 'Business marked live after launch checks',
+      detail: note || 'The business is live and the recorded launch proof still clears the go-live gate.',
+      decidedAt: latestDecisionEvent?.createdAt || null,
+      sourceLabel: latestDecisionEvent ? 'Operator decision' : 'Current business state',
+      note,
+      blockers: [],
+    } satisfies AdminGoLiveDecisionTruth;
+  }
+
+  if (params.canSafelyMarkLive) {
+    return {
+      state: 'ready_for_live',
+      label: 'Ready for live',
+      tone: 'success',
+      summary: 'All required launch checks are in place',
+      detail: 'This business clears the current go-live gate. Mark it live when you are ready to activate automation.',
+      decidedAt: null,
+      sourceLabel: 'Current launch proof',
+      note: null,
+      blockers: [],
+    } satisfies AdminGoLiveDecisionTruth;
+  }
+
+  return {
+    state: 'not_acknowledged',
+    label: 'Not ready',
+    tone: 'pending',
+    summary: 'Go-live decision still needs operator review',
+    detail:
+      params.blockers.length > 0
+        ? `Before this business goes live, fix or acknowledge these gaps: ${params.blockers.join(', ')}.`
+        : 'The business still needs a final operator review before it should go live.',
+    decidedAt: latestDecisionEvent?.createdAt || null,
+    sourceLabel: latestDecisionEvent ? 'Previous operator note' : null,
+    note,
+    blockers: params.blockers,
+  } satisfies AdminGoLiveDecisionTruth;
+}
+
+export function buildAdminOperationalProofs(params: {
+  ownerConnected: boolean;
+  ownerEmail: string | null;
+  ownerPhone: string | null;
+  messagingServiceReady: boolean;
+  numberAssigned: boolean;
+  testSmsTruth: AdminTestSmsTruth;
+  missedCallValidation: AdminMissedCallValidationTruth;
+  webhookSnapshot: TwilioWebhookSnapshot | null;
+  provisioningStatus: BusinessProvisioningStatus;
+  canSafelyMarkLive: boolean;
+  blockers: string[];
+  events: ProofEvent[];
+}) {
+  const webhookSyncEvent = getLatestEvent(params.events, (event) => event.type === 'webhooks.sync_succeeded');
+  const goLiveDecision = buildAdminGoLiveDecisionTruth({
+    provisioningStatus: params.provisioningStatus,
+    canSafelyMarkLive: params.canSafelyMarkLive,
+    blockers: params.blockers,
+    events: params.events,
+  });
+
+  const webhookProof = buildProofState({
+    label: 'Webhook expectations',
+    stepKey: 'voice_webhook_synced',
+    status:
+      params.webhookSnapshot && !params.webhookSnapshot.error
+        ? params.webhookSnapshot.voiceSynced && params.webhookSnapshot.smsSynced && params.webhookSnapshot.statusSynced
+          ? 'validated'
+          : 'failed'
+        : 'waiting',
+    detail:
+      !params.webhookSnapshot
+        ? 'CallbackCloser cannot compare live Twilio webhook values until it can read the assigned number.'
+        : params.webhookSnapshot.error
+          ? params.webhookSnapshot.error
+          : params.webhookSnapshot.voiceSynced && params.webhookSnapshot.smsSynced && params.webhookSnapshot.statusSynced
+            ? 'Voice, SMS, and status callbacks match the current CallbackCloser URLs.'
+            : 'At least one webhook does not match the current CallbackCloser URL yet.',
+    sourceLabel: params.webhookSnapshot ? 'Live Twilio webhook read' : null,
+    verifiedAt: webhookSyncEvent?.createdAt || null,
+    evidenceSummary:
+      params.webhookSnapshot && !params.webhookSnapshot.error
+        ? `Voice ${params.webhookSnapshot.voiceSynced ? 'ok' : 'mismatch'}, SMS ${params.webhookSnapshot.smsSynced ? 'ok' : 'mismatch'}, status ${params.webhookSnapshot.statusSynced ? 'ok' : 'mismatch'}.`
+        : null,
+    countsAsLaunchProof:
+      Boolean(
+        params.webhookSnapshot &&
+          !params.webhookSnapshot.error &&
+          params.webhookSnapshot.voiceSynced &&
+          params.webhookSnapshot.smsSynced &&
+          params.webhookSnapshot.statusSynced
+      ),
+  });
+
+  const ownerProof = buildProofState({
+    label: 'Owner flow',
+    stepKey: 'owner_connected',
+    status: params.ownerConnected && Boolean(params.ownerEmail || params.ownerPhone) ? 'validated' : 'waiting',
+    detail:
+      params.ownerConnected && Boolean(params.ownerEmail || params.ownerPhone)
+        ? 'The owner account is connected and CallbackCloser has at least one route for alerts or follow-up.'
+        : 'Connect the owner and save an owner phone or email before you rely on this business in production.',
+    sourceLabel: params.ownerConnected ? 'Saved business owner state' : null,
+    verifiedAt: null,
+    evidenceSummary: params.ownerEmail || params.ownerPhone,
+    countsAsLaunchProof: params.ownerConnected && Boolean(params.ownerEmail || params.ownerPhone),
+  });
+
+  const testSmsProof = buildProofState({
+    label: 'Test SMS',
+    stepKey: 'test_sms_delivered',
+    status:
+      params.testSmsTruth.state === 'delivered'
+        ? 'validated'
+        : params.testSmsTruth.state === 'failed'
+          ? 'failed'
+          : params.testSmsTruth.state === 'pending'
+            ? 'waiting'
+            : 'not_started',
+    detail: params.testSmsTruth.detail,
+    sourceLabel:
+      params.testSmsTruth.state === 'delivered'
+        ? 'Twilio delivery callback'
+        : params.testSmsTruth.state === 'failed'
+          ? 'Twilio delivery callback'
+          : params.testSmsTruth.state === 'pending'
+            ? 'Twilio accepted the request'
+            : null,
+    verifiedAt: params.testSmsTruth.lastAttemptAt,
+    evidenceSummary: params.testSmsTruth.summary,
+    countsAsLaunchProof: params.testSmsTruth.state === 'delivered',
+  });
+
+  const messagingProof = buildProofState({
+    label: 'Messaging path',
+    stepKey: 'messaging_service_ready',
+    status:
+      params.messagingServiceReady && params.numberAssigned && params.testSmsTruth.state === 'delivered'
+        ? 'validated'
+        : params.testSmsTruth.state === 'failed'
+          ? 'failed'
+          : params.messagingServiceReady && params.numberAssigned
+            ? 'waiting'
+            : 'not_started',
+    detail:
+      params.messagingServiceReady && params.numberAssigned && params.testSmsTruth.state === 'delivered'
+        ? 'The Messaging Service, business number, and delivered test SMS all support the live messaging path.'
+        : params.testSmsTruth.state === 'failed'
+          ? 'The messaging path is configured, but the latest test SMS failed. Fix delivery before launch.'
+          : params.messagingServiceReady && params.numberAssigned
+            ? 'The Twilio resources are saved, but the live messaging path still needs a delivered test SMS.'
+            : 'Create or save the Messaging Service and business number before messaging can be trusted.',
+    sourceLabel: params.testSmsTruth.state === 'delivered' ? 'Resource state + delivered test SMS' : 'Saved Twilio setup',
+    verifiedAt: params.testSmsTruth.lastAttemptAt,
+    evidenceSummary:
+      params.messagingServiceReady && params.numberAssigned
+        ? params.testSmsTruth.state === 'delivered'
+          ? 'Messaging resources saved and delivery proven.'
+          : 'Messaging resources saved, delivery still unproven.'
+        : null,
+    countsAsLaunchProof: params.messagingServiceReady && params.numberAssigned && params.testSmsTruth.state === 'delivered',
+  });
+
+  const missedCallProof = buildProofState({
+    label: 'Missed-call flow',
+    stepKey: 'missed_call_validated',
+    status:
+      params.missedCallValidation.state === 'validated_by_sequence'
+        ? 'validated'
+        : params.missedCallValidation.state === 'manually_confirmed'
+          ? 'manual'
+          : params.missedCallValidation.state === 'failed'
+            ? 'failed'
+            : params.missedCallValidation.state === 'waiting'
+              ? 'waiting'
+              : 'not_started',
+    detail: params.missedCallValidation.detail,
+    sourceLabel: params.missedCallValidation.sourceLabel,
+    verifiedAt: params.missedCallValidation.verifiedAt,
+    evidenceSummary: params.missedCallValidation.evidenceSummary,
+    countsAsLaunchProof: params.missedCallValidation.countsAsLaunchProof,
+  });
+
+  const goLiveProof = buildProofState({
+    label: 'Go-live decision',
+    stepKey: 'safe_to_mark_live',
+    status:
+      goLiveDecision.state === 'marked_live'
+        ? 'validated'
+        : goLiveDecision.state === 'marked_live_with_warnings'
+          ? 'failed'
+          : goLiveDecision.state === 'ready_for_live'
+            ? 'validated'
+            : 'waiting',
+    detail: goLiveDecision.detail,
+    sourceLabel: goLiveDecision.sourceLabel,
+    verifiedAt: goLiveDecision.decidedAt,
+    evidenceSummary: goLiveDecision.note,
+    countsAsLaunchProof: params.canSafelyMarkLive,
+  });
+
+  return {
+    goLiveDecision,
+    proofs: [
+      { ...ownerProof, key: 'owner_flow' as const },
+      { ...webhookProof, key: 'webhooks' as const },
+      { ...messagingProof, key: 'messaging_path' as const },
+      { ...testSmsProof, key: 'test_sms' as const },
+      { ...missedCallProof, key: 'missed_call_flow' as const },
+      { ...goLiveProof, key: 'go_live_decision' as const },
+    ] satisfies AdminOperationalProof[],
+  };
+}

--- a/lib/admin-setup-remediation.ts
+++ b/lib/admin-setup-remediation.ts
@@ -1,5 +1,7 @@
 import { TwilioAccountMode, type Business } from '@prisma/client';
 
+import type { AdminOnboardingConfidence } from '@/lib/admin-dashboard';
+import type { AdminGoLiveDecisionTruth, AdminMissedCallValidationTruth, AdminOperationalProof } from '@/lib/admin-operator-proof';
 import type { AdminTestSmsTruth } from '@/lib/admin-operator-visibility';
 import type { AdminOwnerState, TwilioWebhookSnapshot } from '@/lib/admin-provisioning-presenters';
 import { formatDateTime } from '@/lib/lead-presenters';
@@ -39,6 +41,8 @@ export type AdminSetupPanel = {
   nextAction: string;
   instructions: string[];
   verification: string[];
+  latestEvidence: string[];
+  warnings: string[];
   manualFields: AdminSetupManualField[];
   automaticActionLabel: string | null;
   secondaryAutomaticActionLabel: string | null;
@@ -89,15 +93,30 @@ export function buildAdminSetupPanels(params: {
   ownerState: AdminOwnerState;
   webhookSnapshot: TwilioWebhookSnapshot | null;
   testSmsTruth: AdminTestSmsTruth;
-  successfulLeadCount: number;
+  onboardingConfidence: AdminOnboardingConfidence;
+  missedCallValidation: AdminMissedCallValidationTruth;
+  goLiveDecision: AdminGoLiveDecisionTruth;
+  proofs: AdminOperationalProof[];
 }) {
-  const { business, setupFlow, ownerState, webhookSnapshot, testSmsTruth, successfulLeadCount } = params;
+  const {
+    business,
+    setupFlow,
+    ownerState,
+    webhookSnapshot,
+    testSmsTruth,
+    onboardingConfidence,
+    missedCallValidation,
+    goLiveDecision,
+    proofs,
+  } = params;
   const usingSubaccount = business.twilioAccountMode === TwilioAccountMode.BUSINESS_SUBACCOUNT;
   const numberLabel = business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber || 'No business number is saved yet.';
   const numberSid = business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid || 'No number SID is saved yet.';
   const voiceWebhook = formatWebhookExpectation(webhookSnapshot, 'voice');
   const smsWebhook = formatWebhookExpectation(webhookSnapshot, 'sms');
   const statusWebhook = formatWebhookExpectation(webhookSnapshot, 'status');
+  const messagingProof = proofs.find((proof) => proof.key === 'messaging_path');
+  const webhookProof = proofs.find((proof) => proof.key === 'webhooks');
 
   const panels: AdminSetupPanel[] = [
     {
@@ -122,6 +141,10 @@ export function buildAdminSetupPanels(params: {
         'The step should show Owner connected.',
         'The business should display the correct owner email and no pending invite blocker.',
       ],
+      latestEvidence: ownerState.connected
+        ? [ownerState.email ? `Connected owner: ${ownerState.email}` : 'A CallbackCloser owner account is linked.']
+        : [],
+      warnings: ownerState.connected ? [] : ['Without an attached owner, the business still lacks a trustworthy handoff path.'],
       manualFields: [
         {
           key: 'ownerEmail',
@@ -154,6 +177,8 @@ export function buildAdminSetupPanels(params: {
         `The step should show ${setupFlow.accountModeLabel}.`,
         usingSubaccount ? 'The next step should ask for a subaccount.' : 'The subaccount step should no longer block the flow.',
       ],
+      latestEvidence: [`Current mode: ${setupFlow.accountModeLabel}.`],
+      warnings: [],
       manualFields: [
         {
           key: 'twilioAccountMode',
@@ -180,6 +205,8 @@ export function buildAdminSetupPanels(params: {
         `The step should show ${setupFlow.numberSetupModeLabel}.`,
         'The number assignment panel should match the path you selected.',
       ],
+      latestEvidence: [`Current number path: ${setupFlow.numberSetupModeLabel}.`],
+      warnings: [],
       manualFields: [
         {
           key: 'twilioNumberSetupMode',
@@ -216,6 +243,8 @@ export function buildAdminSetupPanels(params: {
       verification: usingSubaccount
         ? ['The step should show Subaccount ready.', 'A Twilio subaccount SID that begins with AC should be saved on the business.']
         : ['The step should stay non-blocking while main-account mode is selected.'],
+      latestEvidence: business.twilioSubaccountSid ? [`Saved subaccount SID: ${business.twilioSubaccountSid}`] : [],
+      warnings: usingSubaccount && !business.twilioSubaccountSid ? ['Subaccount mode still needs an AC SID before Twilio resources can be trusted.'] : [],
       manualFields: usingSubaccount
         ? [
             {
@@ -245,6 +274,14 @@ export function buildAdminSetupPanels(params: {
         'After saving, send a test SMS from the next step.',
       ],
       verification: ['The step should show Ready.', 'The saved Messaging Service SID should begin with MG.', 'A test SMS should accept or deliver after this is saved.'],
+      latestEvidence: [
+        business.twilioMessagingServiceSid ? `Saved Messaging Service SID: ${business.twilioMessagingServiceSid}` : 'No Messaging Service SID is saved yet.',
+        ...(messagingProof?.evidenceSummary ? [messagingProof.evidenceSummary] : []),
+      ],
+      warnings:
+        testSmsTruth.state === 'failed'
+          ? ['The latest test SMS failed, so the messaging path is still not proven even if the MG SID is saved.']
+          : [],
       manualFields: [
         {
           key: 'twilioMessagingServiceSid',
@@ -272,6 +309,8 @@ export function buildAdminSetupPanels(params: {
         'Then move to the webhook steps so CallbackCloser can verify routing.',
       ],
       verification: ['The step should show Ready.', 'A Twilio phone number and number SID should both be saved.', 'The webhook steps should be able to compare the assigned number against Twilio.'],
+      latestEvidence: [`Current number: ${numberLabel}`, `Current number SID: ${numberSid}`],
+      warnings: [],
       manualFields: [
         {
           key: 'twilioPhoneNumber',
@@ -302,6 +341,13 @@ export function buildAdminSetupPanels(params: {
         'After saving in Twilio, re-open this step or run sync again to verify.',
       ],
       verification: ['The step should show Synced.', 'The current Twilio voice webhook should match the expected CallbackCloser URL exactly.'],
+      latestEvidence: [`Current Twilio value: ${voiceWebhook.current}`, `Expected CallbackCloser value: ${voiceWebhook.expected}`],
+      warnings:
+        webhookSnapshot?.error
+          ? [webhookSnapshot.error]
+          : webhookProof?.status === 'failed'
+            ? ['The live Twilio webhook read still shows at least one mismatch.']
+            : [],
       manualFields: [
         {
           key: 'twilioPhoneNumberSid',
@@ -326,6 +372,13 @@ export function buildAdminSetupPanels(params: {
         'Re-open this step or run sync again after the Twilio value is updated.',
       ],
       verification: ['The step should show Synced.', 'The current Twilio SMS webhook should match the expected CallbackCloser URL exactly.'],
+      latestEvidence: [`Current Twilio value: ${smsWebhook.current}`, `Expected CallbackCloser value: ${smsWebhook.expected}`],
+      warnings:
+        webhookSnapshot?.error
+          ? [webhookSnapshot.error]
+          : webhookProof?.status === 'failed'
+            ? ['The live Twilio webhook read still shows at least one mismatch.']
+            : [],
       manualFields: [
         {
           key: 'twilioPhoneNumberSid',
@@ -350,6 +403,13 @@ export function buildAdminSetupPanels(params: {
         'After saving in Twilio, reload this step or run sync again.',
       ],
       verification: ['The step should show Synced.', 'The Twilio status callback should match the expected CallbackCloser URL exactly.'],
+      latestEvidence: [`Current Twilio value: ${statusWebhook.current}`, `Expected CallbackCloser value: ${statusWebhook.expected}`],
+      warnings:
+        webhookSnapshot?.error
+          ? [webhookSnapshot.error]
+          : webhookProof?.status === 'failed'
+            ? ['The live Twilio webhook read still shows at least one mismatch.']
+            : [],
       manualFields: [
         {
           key: 'twilioPhoneNumberSid',
@@ -378,6 +438,12 @@ export function buildAdminSetupPanels(params: {
         'If the business is blocked, record the blocker in plain English so the next operator does not have to guess.',
       ],
       verification: ['The saved status should match the real Twilio state.', 'If approved, the step should show Approved.', 'If blocked, the blocker note should explain why.'],
+      latestEvidence: [
+        business.a2pCustomerProfileSid ? `Customer profile SID: ${business.a2pCustomerProfileSid}` : 'No customer profile SID saved.',
+        business.a2pBrandSid ? `Brand SID: ${business.a2pBrandSid}` : 'No brand SID saved.',
+        business.a2pCampaignSid ? `Campaign SID: ${business.a2pCampaignSid}` : 'No campaign SID saved.',
+      ],
+      warnings: business.a2pFailureReason ? [business.a2pFailureReason] : [],
       manualFields: [
         {
           key: 'managedTwilioStatus',
@@ -431,6 +497,19 @@ export function buildAdminSetupPanels(params: {
         'If the test fails, use the related setup steps and recent activity to correct the blocking issue.',
       ],
       verification: ['This step should show Delivered.', 'Recent activity should contain the final test SMS delivery event.', 'You should avoid marking the business live until delivery is confirmed.'],
+      latestEvidence: [
+        testSmsTruth.lastAttemptAt ? `Last attempt: ${formatDateTime(testSmsTruth.lastAttemptAt)}` : 'No test SMS attempt recorded yet.',
+        `Latest result: ${testSmsTruth.summary}.`,
+        ...(testSmsTruth.reason ? [`Known reason: ${testSmsTruth.reason}.`] : []),
+      ],
+      warnings:
+        testSmsTruth.state === 'failed'
+          ? ['Do not treat messaging as proven until the business line delivers a test SMS cleanly.']
+          : testSmsTruth.state === 'pending'
+            ? ['Twilio accepted the request, but delivery is still unproven.']
+            : testSmsTruth.state === 'not_run'
+              ? ['This business still lacks direct test-delivery proof.']
+              : [],
       manualFields: [
         {
           key: 'destinationPhone',
@@ -446,18 +525,27 @@ export function buildAdminSetupPanels(params: {
       key: 'missed_call_validated',
       title: 'Missed-call flow validation',
       currentState:
-        successfulLeadCount > 0
-          ? `${successfulLeadCount} missed-call validation event${successfulLeadCount === 1 ? '' : 's'} reached owner-visible lead state.`
-          : 'No missed-call validation has been recorded yet.',
+        missedCallValidation.verifiedAt
+          ? `${missedCallValidation.label} • latest proof ${formatDateTime(missedCallValidation.verifiedAt)}`
+          : missedCallValidation.summary,
       explanation: 'This is the end-to-end proof that inbound call, missed-call detection, lead creation, outbound SMS, and owner visibility all still work in order.',
-      nextAction: 'Run a real missed call and use the customer workspace plus timeline to confirm the flow end to end.',
+      nextAction: missedCallValidation.countsAsLaunchProof
+        ? 'Use this proof to support the final go-live decision, or record a fresher note if you re-tested the flow manually.'
+        : 'Run a real missed call and use the customer workspace plus timeline to confirm the flow end to end.',
       instructions: [
         'Confirm the forwarding number and owner alert phone are correct.',
         'Place a real missed call to the business number.',
         'Check the customer call-flow or leads view to confirm the lead was created.',
         'Use recent activity to confirm the event order: inbound call, missed call, lead, SMS, and owner alert.',
+        'If you validated the flow outside the app, record a short manual confirmation note so the proof stays visible here.',
       ],
-      verification: ['The timeline should show the full missed-call sequence in order.', 'The customer workspace should show the lead and owner visibility outcome.', 'This step should show Validated after the flow succeeds.'],
+      verification: ['The timeline should show the full missed-call sequence in order.', 'The customer workspace should show the lead and owner visibility outcome.', 'This step should only count as complete once recent evidence or a manual note exists.'],
+      latestEvidence: [
+        missedCallValidation.verifiedAt ? `Latest proof timestamp: ${formatDateTime(missedCallValidation.verifiedAt)}` : 'No missed-call proof timestamp recorded yet.',
+        missedCallValidation.summary,
+        ...(missedCallValidation.evidenceSummary ? [missedCallValidation.evidenceSummary] : []),
+      ],
+      warnings: missedCallValidation.countsAsLaunchProof ? [] : ['Without explicit missed-call proof, the founder still has to guess whether the recovery flow actually works.'],
       manualFields: [
         {
           key: 'forwardingNumber',
@@ -480,13 +568,27 @@ export function buildAdminSetupPanels(params: {
       title: 'Safe to mark live',
       currentState: findStep(setupFlow, 'safe_to_mark_live').detail,
       explanation: 'This is the final operator gate. It should only clear once the business has real setup proof, not just saved labels.',
-      nextAction: findStep(setupFlow, 'safe_to_mark_live').complete ? 'Mark the business live when you are ready.' : 'Clear the remaining setup blockers before marking the business live.',
+      nextAction: findStep(setupFlow, 'safe_to_mark_live').complete
+        ? 'Review the proof list and mark the business live when you are ready.'
+        : 'Clear the remaining setup blockers before marking the business live, or record an explicit warning note if you must launch anyway.',
       instructions: [
-        'Review the remaining blocked steps above.',
-        'Do not mark the business live until each blocking step is complete.',
+        'Review the remaining blocked steps and proof list above.',
+        'Do not mark the business live until each blocking step is complete unless you are intentionally accepting the warning state.',
+        'If you must launch with known gaps, record a short note explaining what is still missing and why you are proceeding.',
         'If the business should stop running, pause automation here instead of leaving the state ambiguous.',
       ],
-      verification: ['The launch gate should say Ready before you mark live.', 'The business should only be marked live after test SMS and missed-call validation are complete.'],
+      verification: ['The launch gate should say Ready before you mark live, unless the operator explicitly acknowledges a warning state.', 'The business should only be treated as fully live after test SMS and missed-call validation are complete.'],
+      latestEvidence: [
+        goLiveDecision.decidedAt ? `Latest go-live decision: ${formatDateTime(goLiveDecision.decidedAt)}` : 'No explicit go-live decision has been recorded yet.',
+        goLiveDecision.summary,
+        ...(goLiveDecision.note ? [goLiveDecision.note] : []),
+      ],
+      warnings:
+        onboardingConfidence.blockers.length > 0
+          ? onboardingConfidence.blockers.map((blocker) => blocker.message)
+          : goLiveDecision.state === 'marked_live_with_warnings'
+            ? [goLiveDecision.detail]
+            : [],
       manualFields: [],
       automaticActionLabel: 'Mark business live',
       secondaryAutomaticActionLabel: 'Pause automation',

--- a/lib/twilio-setup.ts
+++ b/lib/twilio-setup.ts
@@ -234,8 +234,14 @@ export function buildTwilioSetupFlow(params: {
   successfulLeadCount: number;
   testSmsState: 'not_started' | 'pending_delivery' | 'delivered' | 'failed';
   webhookSnapshot: TwilioWebhookSnapshot | null;
+  missedCallValidation?: {
+    complete: boolean;
+    stateLabel: string;
+    detail: string;
+    tone: TwilioSetupTone;
+  } | null;
 }) {
-  const { business, notificationSettings, ownerConnected, successfulLeadCount, testSmsState, webhookSnapshot } = params;
+  const { business, notificationSettings, ownerConnected, successfulLeadCount, testSmsState, webhookSnapshot, missedCallValidation } = params;
   const accountMode = business.twilioAccountMode || TwilioAccountMode.BUSINESS_SUBACCOUNT;
   const numberSetupMode = business.twilioNumberSetupMode || TwilioNumberSetupMode.NEW_NUMBER;
   const managedSummary = getManagedTwilioStatusSummary(business);
@@ -253,7 +259,7 @@ export function buildTwilioSetupFlow(params: {
   const testSmsDelivered = testSmsState === 'delivered';
   const hasOwnerRouting = Boolean(ownerPhone || ownerEmail);
   const hasForwardingNumber = Boolean(business.forwardingNumber?.trim());
-  const missedCallValidated = successfulLeadCount > 0;
+  const missedCallValidated = missedCallValidation?.complete ?? successfulLeadCount > 0;
   const existingNumberMessage =
     'Existing-number support stays truthful here: CallbackCloser can only attach a number that already lives in the selected Twilio account context. Numbers that live elsewhere still need admin assistance.';
 
@@ -272,11 +278,14 @@ export function buildTwilioSetupFlow(params: {
   if (!hasOwnerRouting) liveBlockers.push('save an owner alert destination');
 
   const safeToMarkLive = liveBlockers.length === 0;
+  const liveWithWarnings = business.provisioningStatus === BusinessProvisioningStatus.LIVE && !safeToMarkLive;
   const liveGateDetail = safeToMarkLive
     ? business.provisioningStatus === BusinessProvisioningStatus.LIVE
       ? 'This business is already live and the current setup still clears the launch gate.'
       : 'This business clears the Twilio launch gate. It is safe to mark live.'
-    : `Before this business goes live, ${liveBlockers.join(', ')}.`;
+    : liveWithWarnings
+      ? `This business is already live, but the current launch gate is not clear: ${liveBlockers.join(', ')}.`
+      : `Before this business goes live, ${liveBlockers.join(', ')}.`;
 
   const steps: TwilioSetupStep[] = [
     {
@@ -406,24 +415,28 @@ export function buildTwilioSetupFlow(params: {
       key: 'missed_call_validated',
       label: '12. Missed-call flow validated',
       complete: missedCallValidated,
-      tone: buildTone(missedCallValidated),
-      stateLabel: missedCallValidated ? 'Validated' : 'Still needed',
-      detail: missedCallValidated
-        ? `${successfulLeadCount} missed-call test${successfulLeadCount === 1 ? '' : 's'} reached owner-notification visibility.`
-        : !hasForwardingNumber
-          ? 'Save the forwarding number first so the live call path is accurate before testing.'
-          : !hasOwnerRouting
-            ? 'Save an owner alert destination before the missed-call validation test.'
-            : 'Run one real missed call and confirm the owner alert and lead handoff both land correctly.',
+      tone: missedCallValidation?.tone ?? buildTone(missedCallValidated),
+      stateLabel: missedCallValidation?.stateLabel ?? (missedCallValidated ? 'Validated' : 'Still needed'),
+      detail:
+        missedCallValidation?.detail ??
+        (missedCallValidated
+          ? `${successfulLeadCount} missed-call test${successfulLeadCount === 1 ? '' : 's'} reached owner-notification visibility.`
+          : !hasForwardingNumber
+            ? 'Save the forwarding number first so the live call path is accurate before testing.'
+            : !hasOwnerRouting
+              ? 'Save an owner alert destination before the missed-call validation test.'
+              : 'Run one real missed call and confirm the owner alert and lead handoff both land correctly.'),
     },
     {
       key: 'safe_to_mark_live',
       label: '13. Safe to mark live',
-      complete: safeToMarkLive || business.provisioningStatus === BusinessProvisioningStatus.LIVE,
-      tone: safeToMarkLive || business.provisioningStatus === BusinessProvisioningStatus.LIVE ? 'success' : 'pending',
+      complete: safeToMarkLive,
+      tone: liveWithWarnings ? 'attention' : safeToMarkLive ? 'success' : 'pending',
       stateLabel:
         business.provisioningStatus === BusinessProvisioningStatus.LIVE
-          ? 'Live'
+          ? safeToMarkLive
+            ? 'Live'
+            : 'Live with warnings'
           : safeToMarkLive
             ? 'Ready'
             : 'Blocked',

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -150,6 +150,17 @@ export const adminSendTestSmsSchema = z.object({
   destinationPhone: z.string().trim().min(7).max(30),
 });
 
+export const adminMissedCallValidationConfirmationSchema = z.object({
+  businessId: z.string().min(1),
+  note: z.string().trim().min(12).max(500),
+});
+
+export const adminMarkBusinessLiveSchema = z.object({
+  businessId: z.string().min(1),
+  note: z.string().trim().max(500).optional().or(z.literal('')),
+  acknowledgeWarnings: z.coerce.boolean().optional().default(false),
+});
+
 export const adminSetupBasicsSchema = z.object({
   businessId: z.string().min(1),
   ownerName: z.string().trim().max(120).optional().or(z.literal('')),

--- a/tests/admin-dashboard.test.ts
+++ b/tests/admin-dashboard.test.ts
@@ -272,11 +272,57 @@ test('onboarding confidence distinguishes ready-for-test from ready-for-live', (
         createdAt: new Date('2026-04-17T12:00:00.000Z'),
       },
     ],
+    missedCallValidation: {
+      countsAsLaunchProof: true,
+      detail: 'Recent event sequence proves the missed-call flow reached the owner alert path.',
+    },
   });
 
   assert.equal(readyForLive.state, 'ready_to_go_live');
   assert.equal(readyForLive.canSafelyMarkLive, true);
   assert.equal(readyForLive.readinessLabel, 'Ready for live');
+});
+
+test('onboarding confidence does not overstate webhook or missed-call proof when explicit truth is missing', () => {
+  const confidence = buildAdminOnboardingConfidence({
+    business: createBusiness({
+      managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+      a2pApprovedAt: new Date('2026-04-17T00:00:00.000Z'),
+      twilioWebhookSyncedAt: new Date('2026-04-17T00:00:00.000Z'),
+    }),
+    notificationSettings: createNotificationSettings(),
+    ownerConnected: true,
+    successfulLeadCount: 4,
+    operatorEvents: [
+      {
+        type: 'admin.test_sms_delivered',
+        status: OperatorEventStatus.SUCCESS,
+        createdAt: new Date('2026-04-17T12:00:00.000Z'),
+      },
+    ],
+    webhookSnapshot: {
+      currentVoiceUrl: 'https://wrong.example.com/voice',
+      currentSmsUrl: 'https://app.callbackcloser.com/api/twilio/sms',
+      currentStatusUrl: 'https://app.callbackcloser.com/api/twilio/message-status',
+      expectedVoiceUrl: 'https://app.callbackcloser.com/api/twilio/voice',
+      expectedSmsUrl: 'https://app.callbackcloser.com/api/twilio/sms',
+      expectedStatusUrl: 'https://app.callbackcloser.com/api/twilio/message-status',
+      voiceSynced: false,
+      smsSynced: true,
+      statusSynced: true,
+      error: null,
+    },
+    missedCallValidation: {
+      countsAsLaunchProof: false,
+      detail: 'Historical lead activity exists, but explicit missed-call proof is still missing.',
+    },
+  });
+
+  assert.equal(confidence.readyForTest, false);
+  assert.equal(confidence.canSafelyMarkLive, false);
+  assert.equal(confidence.state, 'in_setup');
+  assert.match(confidence.milestones.find((item) => item.key === 'webhooks')?.detail || '', /re-sync/i);
+  assert.match(confidence.milestones.find((item) => item.key === 'missed_call_validation')?.detail || '', /explicit/i);
 });
 
 test('admin test SMS confidence waits for delivery confirmation', () => {

--- a/tests/admin-operator-proof.test.ts
+++ b/tests/admin-operator-proof.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { BusinessProvisioningStatus, OperatorEventStatus } from '@prisma/client';
+
+import { buildAdminMissedCallValidationTruth, buildAdminOperationalProofs } from '../lib/admin-operator-proof.ts';
+
+test('missed-call validation truth distinguishes explicit sequence proof from manual confirmation', () => {
+  const sequenceTruth = buildAdminMissedCallValidationTruth({
+    events: [
+      {
+        type: 'voice.lead_created_from_call',
+        status: OperatorEventStatus.SUCCESS,
+        summary: 'Lead created from missed call',
+        detailsJson: null,
+        createdAt: new Date('2026-04-21T10:00:00.000Z'),
+        relatedEntityType: 'lead',
+        relatedEntityId: 'lead_123456',
+      },
+      {
+        type: 'messaging.missed_call_sms_started',
+        status: OperatorEventStatus.SUCCESS,
+        summary: 'Recovery SMS started',
+        detailsJson: null,
+        createdAt: new Date('2026-04-21T10:01:00.000Z'),
+        relatedEntityType: 'lead',
+        relatedEntityId: 'lead_123456',
+      },
+      {
+        type: 'owner_alert.sms_sent',
+        status: OperatorEventStatus.SUCCESS,
+        summary: 'Owner alert sent',
+        detailsJson: null,
+        createdAt: new Date('2026-04-21T10:03:00.000Z'),
+        relatedEntityType: 'lead',
+        relatedEntityId: 'lead_123456',
+      },
+    ],
+    successfulLeadCount: 0,
+  });
+
+  assert.equal(sequenceTruth.state, 'validated_by_sequence');
+  assert.equal(sequenceTruth.countsAsLaunchProof, true);
+  assert.match(sequenceTruth.detail, /owner alert/i);
+
+  const manualTruth = buildAdminMissedCallValidationTruth({
+    events: [
+      {
+        type: 'admin.missed_call_validation_confirmed',
+        status: OperatorEventStatus.SUCCESS,
+        summary: 'Missed-call flow manually confirmed',
+        detailsJson: { note: 'Validated from a real missed call and owner alert on my phone.' },
+        createdAt: new Date('2026-04-21T11:00:00.000Z'),
+        relatedEntityType: null,
+        relatedEntityId: null,
+      },
+    ],
+    successfulLeadCount: 0,
+  });
+
+  assert.equal(manualTruth.state, 'manually_confirmed');
+  assert.equal(manualTruth.countsAsLaunchProof, true);
+  assert.match(manualTruth.detail, /real missed call/i);
+});
+
+test('operational proofs keep go-live truth honest when proof is incomplete', () => {
+  const missedCallValidation = buildAdminMissedCallValidationTruth({
+    events: [],
+    successfulLeadCount: 0,
+  });
+
+  const proofBundle = buildAdminOperationalProofs({
+    ownerConnected: true,
+    ownerEmail: 'owner@acme.com',
+    ownerPhone: '+15551230000',
+    messagingServiceReady: true,
+    numberAssigned: true,
+    testSmsTruth: {
+      state: 'delivered',
+      label: 'Delivered',
+      tone: 'success',
+      summary: 'Test SMS delivered',
+      detail: 'Delivery confirmed.',
+      reason: null,
+      lastAttemptAt: new Date('2026-04-21T12:00:00.000Z'),
+      eventType: 'admin.test_sms_delivered',
+    },
+    missedCallValidation,
+    webhookSnapshot: {
+      currentVoiceUrl: 'https://app.callbackcloser.com/api/twilio/voice',
+      currentSmsUrl: 'https://app.callbackcloser.com/api/twilio/sms',
+      currentStatusUrl: 'https://app.callbackcloser.com/api/twilio/message-status',
+      expectedVoiceUrl: 'https://app.callbackcloser.com/api/twilio/voice',
+      expectedSmsUrl: 'https://app.callbackcloser.com/api/twilio/sms',
+      expectedStatusUrl: 'https://app.callbackcloser.com/api/twilio/message-status',
+      voiceSynced: true,
+      smsSynced: true,
+      statusSynced: true,
+      error: null,
+    },
+    provisioningStatus: BusinessProvisioningStatus.LIVE,
+    canSafelyMarkLive: false,
+    blockers: ['Run one real missed-call test and confirm the lead reaches the owner before marking this business live.'],
+    events: [],
+  });
+
+  const goLiveProof = proofBundle.proofs.find((proof) => proof.key === 'go_live_decision');
+  const missedCallProof = proofBundle.proofs.find((proof) => proof.key === 'missed_call_flow');
+
+  assert.equal(goLiveProof?.status, 'failed');
+  assert.match(goLiveProof?.detail || '', /launch gaps still exist/i);
+  assert.equal(missedCallProof?.status, 'not_started');
+  assert.equal(proofBundle.goLiveDecision.state, 'marked_live_with_warnings');
+});

--- a/tests/admin-operator-routes.test.ts
+++ b/tests/admin-operator-routes.test.ts
@@ -23,7 +23,7 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminHome, /Delete all test\/demo businesses/);
   assert.match(adminHome, /BULK_TEST_DATA_RESET_CONFIRMATION/);
   assert.match(adminHome, /Business triage board/);
-  assert.match(adminHome, /Last issue/);
+  assert.match(adminHome, /Go-live blocker/);
   assert.match(adminHome, /Test SMS/);
   assert.match(adminHome, /Open customer workspace/);
   assert.match(adminHome, /Delete demo\/test business permanently/);
@@ -34,6 +34,8 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminActions, /export async function saveAdminSetupBasicsAction/);
   assert.match(adminActions, /export async function createBusinessTwilioSubaccountAction/);
   assert.match(adminActions, /export async function createBusinessMessagingServiceAction/);
+  assert.match(adminActions, /export async function confirmMissedCallValidationAction/);
+  assert.match(adminActions, /export async function markBusinessLiveAction/);
   assert.match(adminActions, /must start with \$\{prefix\}/);
   assert.match(adminActions, /const admin = await requireAdmin\(\)/);
   assert.match(adminHome, /View support workspace snapshot/);
@@ -44,13 +46,18 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminDetail, /Setup steps/);
   assert.match(adminDetail, /Last issue/);
   assert.match(adminDetail, /Test SMS truth/);
+  assert.match(adminDetail, /Onboarding confidence/);
   assert.match(adminDetail, /Next step/);
   assert.match(adminDetail, /Mark business live/);
+  assert.match(adminDetail, /Mark missed-call flow validated/);
+  assert.match(adminDetail, /Mark live with warnings/);
   assert.match(adminDetail, /Advanced/);
   assert.match(adminDetail, /Invite owner by email/);
   assert.match(adminDetail, /Connect existing owner/);
   assert.match(adminDetail, /Send test SMS/);
   assert.match(stepCard, /Manual fallback \/ manual entry/);
+  assert.match(stepCard, /Latest evidence/);
+  assert.match(stepCard, /Warnings before completion/);
   assert.match(stepCard, /Step-by-step/);
   assert.match(stepCard, /How to verify/);
   assert.match(adminDetail, /Create subaccount automatically/);

--- a/tests/admin-setup-remediation.test.ts
+++ b/tests/admin-setup-remediation.test.ts
@@ -4,11 +4,16 @@ import test from 'node:test';
 import {
   BusinessProvisioningStatus,
   ManagedTwilioStatus,
+  OperatorEventStatus,
+  SubscriptionStatus,
   TwilioAccountMode,
   TwilioNumberSetupMode,
 } from '@prisma/client';
 
+import { buildAdminOnboardingConfidence } from '../lib/admin-dashboard.ts';
+import { buildAdminMissedCallValidationTruth, buildAdminOperationalProofs } from '../lib/admin-operator-proof.ts';
 import { buildAdminNextStepGuide, buildAdminSetupPanels } from '../lib/admin-setup-remediation.ts';
+import { buildAdminTestSmsTruth } from '../lib/admin-operator-visibility.ts';
 import { buildTwilioSetupFlow } from '../lib/twilio-setup.ts';
 
 function buildSetupFlow(overrides: Partial<Parameters<typeof buildTwilioSetupFlow>[0]['business']> = {}) {
@@ -59,6 +64,101 @@ function buildSetupFlow(overrides: Partial<Parameters<typeof buildTwilioSetupFlo
 
 test('setup remediation panels expose actionable manual fallback for subaccount and webhook steps', () => {
   const setupFlow = buildSetupFlow();
+  const testSmsTruth = {
+    state: 'failed',
+    label: 'Failed',
+    tone: 'attention',
+    summary: 'Test SMS failed',
+    detail: 'Carrier rejected the destination.',
+    reason: 'Carrier rejected the destination.',
+    lastAttemptAt: new Date('2026-04-21T12:00:00.000Z'),
+    eventType: 'admin.test_sms_failed',
+  } as const;
+  const missedCallValidation = buildAdminMissedCallValidationTruth({
+    events: [
+      {
+        type: 'messaging.missed_call_sms_suppressed',
+        status: OperatorEventStatus.FAILED,
+        summary: 'Recovery SMS suppressed',
+        detailsJson: { error: 'No valid destination' },
+        createdAt: new Date('2026-04-21T12:02:00.000Z'),
+        relatedEntityType: 'lead',
+        relatedEntityId: 'lead_123',
+      },
+    ],
+    successfulLeadCount: 0,
+  });
+  const onboardingConfidence = buildAdminOnboardingConfidence({
+    business: {
+      id: 'biz_123',
+      name: 'Acme Plumbing',
+      ownerClerkId: 'user_123',
+      ownerName: 'Casey Owner',
+      ownerInviteSentAt: null,
+      isTestBusiness: false,
+      archivedAt: null,
+      forwardingNumber: '+15557654321',
+      notifyPhone: '+15551230000',
+      provisioningStatus: BusinessProvisioningStatus.ONBOARDING,
+      provisioningError: null,
+      provisioningLastRunAt: new Date('2026-04-21T12:00:00.000Z'),
+      twilioAccountMode: TwilioAccountMode.BUSINESS_SUBACCOUNT,
+      twilioNumberSetupMode: TwilioNumberSetupMode.NEW_NUMBER,
+      twilioSubaccountSid: null,
+      twilioMessagingServiceSid: null,
+      twilioPrimaryNumberSid: null,
+      twilioPhoneNumberSid: null,
+      twilioPrimaryPhoneNumber: null,
+      twilioPhoneNumber: null,
+      twilioWebhookSyncedAt: null,
+      managedTwilioStatus: ManagedTwilioStatus.DRAFT,
+      a2pCustomerProfileSid: null,
+      a2pBrandSid: null,
+      a2pCampaignSid: null,
+      a2pFailureReason: null,
+      a2pApprovedAt: null,
+      subscriptionStatus: SubscriptionStatus.ACTIVE,
+      stripePriceId: null,
+      updatedAt: new Date('2026-04-21T12:00:00.000Z'),
+    },
+    notificationSettings: {
+      ownerPhone: '+15551230000',
+      ownerEmail: 'owner@acme.com',
+      notifySms: true,
+      notifyEmail: true,
+      notifyInApp: true,
+      urgentOnly: false,
+    },
+    ownerConnected: false,
+    successfulLeadCount: 0,
+    operatorEvents: [],
+    missedCallValidation,
+  });
+  const proofBundle = buildAdminOperationalProofs({
+    ownerConnected: false,
+    ownerEmail: 'owner@acme.com',
+    ownerPhone: '+15551230000',
+    messagingServiceReady: false,
+    numberAssigned: false,
+    testSmsTruth,
+    missedCallValidation,
+    webhookSnapshot: {
+      currentVoiceUrl: 'https://wrong.example.com/voice',
+      currentSmsUrl: 'https://wrong.example.com/sms',
+      currentStatusUrl: 'https://wrong.example.com/status',
+      expectedVoiceUrl: 'https://app.callbackcloser.com/api/twilio/voice',
+      expectedSmsUrl: 'https://app.callbackcloser.com/api/twilio/sms',
+      expectedStatusUrl: 'https://app.callbackcloser.com/api/twilio/message-status',
+      voiceSynced: false,
+      smsSynced: false,
+      statusSynced: false,
+      error: null,
+    },
+    provisioningStatus: BusinessProvisioningStatus.ONBOARDING,
+    canSafelyMarkLive: false,
+    blockers: onboardingConfidence.blockers.map((blocker) => blocker.message),
+    events: [],
+  });
   const panels = buildAdminSetupPanels({
     business: {
       name: 'Acme Plumbing',
@@ -105,17 +205,11 @@ test('setup remediation panels expose actionable manual fallback for subaccount 
       statusSynced: false,
       error: null,
     },
-    testSmsTruth: {
-      state: 'failed',
-      label: 'Failed',
-      tone: 'attention',
-      summary: 'Test SMS failed',
-      detail: 'Carrier rejected the destination.',
-      reason: 'Carrier rejected the destination.',
-      lastAttemptAt: new Date('2026-04-21T12:00:00.000Z'),
-      eventType: 'admin.test_sms_failed',
-    },
-    successfulLeadCount: 0,
+    testSmsTruth,
+    onboardingConfidence,
+    missedCallValidation,
+    goLiveDecision: proofBundle.goLiveDecision,
+    proofs: proofBundle.proofs,
   });
 
   const subaccountPanel = panels.find((panel) => panel.key === 'account_ready')!;
@@ -125,10 +219,12 @@ test('setup remediation panels expose actionable manual fallback for subaccount 
   const statusWebhookPanel = panels.find((panel) => panel.key === 'status_callback_synced')!;
   assert.match(statusWebhookPanel.instructions.join(' '), /api\/twilio\/message-status/);
   assert.equal(statusWebhookPanel.automaticActionLabel, 'Re-sync status callback');
+  assert.match(statusWebhookPanel.latestEvidence.join(' '), /Expected CallbackCloser value/i);
 
   const testSmsPanel = panels.find((panel) => panel.key === 'test_sms_delivered')!;
   assert.match(testSmsPanel.currentState, /Failed/i);
   assert.equal(testSmsPanel.automaticActionLabel, 'Retry test SMS');
+  assert.equal(testSmsPanel.warnings.length > 0, true);
 });
 
 test('setup remediation panels stay truthful for main-account mode and next-step guide prefers the issue step', () => {
@@ -138,6 +234,107 @@ test('setup remediation panels stay truthful for main-account mode and next-step
     twilioMessagingServiceSid: 'MG1234567890abcdef1234567890abcd',
     twilioPrimaryPhoneNumber: '+15551230000',
     twilioPrimaryNumberSid: 'PN1234567890abcdef1234567890abcd',
+    a2pApprovedAt: new Date('2026-04-21T12:00:00.000Z'),
+  });
+  const testSmsTruth = buildAdminTestSmsTruth([
+    {
+      type: 'admin.test_sms_delivered',
+      status: OperatorEventStatus.SUCCESS,
+      summary: 'Test SMS delivered',
+      detailsJson: { messageStatus: 'delivered' },
+      createdAt: new Date('2026-04-21T12:05:00.000Z'),
+    },
+  ]);
+  const missedCallValidation = buildAdminMissedCallValidationTruth({
+    events: [
+      {
+        type: 'admin.missed_call_validation_confirmed',
+        status: OperatorEventStatus.SUCCESS,
+        summary: 'Missed-call flow manually confirmed',
+        detailsJson: { note: 'Validated end-to-end after test call.' },
+        createdAt: new Date('2026-04-21T12:10:00.000Z'),
+        relatedEntityType: null,
+        relatedEntityId: null,
+      },
+    ],
+    successfulLeadCount: 2,
+  });
+  const onboardingConfidence = buildAdminOnboardingConfidence({
+    business: {
+      id: 'biz_123',
+      name: 'Acme Plumbing',
+      ownerClerkId: 'user_123',
+      ownerName: 'Casey Owner',
+      ownerInviteSentAt: null,
+      isTestBusiness: false,
+      archivedAt: null,
+      forwardingNumber: '+15557654321',
+      notifyPhone: '+15551230000',
+      provisioningStatus: BusinessProvisioningStatus.ONBOARDING,
+      provisioningError: null,
+      provisioningLastRunAt: new Date('2026-04-21T12:00:00.000Z'),
+      twilioAccountMode: TwilioAccountMode.MAIN_ACCOUNT,
+      twilioNumberSetupMode: TwilioNumberSetupMode.EXISTING_NUMBER,
+      twilioSubaccountSid: null,
+      twilioMessagingServiceSid: 'MG1234567890abcdef1234567890abcd',
+      twilioPrimaryNumberSid: 'PN1234567890abcdef1234567890abcd',
+      twilioPhoneNumberSid: 'PN1234567890abcdef1234567890abcd',
+      twilioPrimaryPhoneNumber: '+15551230000',
+      twilioPhoneNumber: '+15551230000',
+      twilioWebhookSyncedAt: new Date('2026-04-21T12:00:00.000Z'),
+      managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+      a2pCustomerProfileSid: null,
+      a2pBrandSid: null,
+      a2pCampaignSid: null,
+      a2pFailureReason: null,
+      a2pApprovedAt: new Date('2026-04-21T12:00:00.000Z'),
+      subscriptionStatus: SubscriptionStatus.ACTIVE,
+      stripePriceId: null,
+      updatedAt: new Date('2026-04-21T12:00:00.000Z'),
+    },
+    notificationSettings: {
+      ownerPhone: '+15551230000',
+      ownerEmail: 'owner@acme.com',
+      notifySms: true,
+      notifyEmail: true,
+      notifyInApp: true,
+      urgentOnly: false,
+    },
+    ownerConnected: true,
+    successfulLeadCount: 2,
+    operatorEvents: [
+      {
+        type: 'admin.test_sms_delivered',
+        status: OperatorEventStatus.SUCCESS,
+        createdAt: new Date('2026-04-21T12:05:00.000Z'),
+      },
+    ],
+    missedCallValidation,
+  });
+  const proofBundle = buildAdminOperationalProofs({
+    ownerConnected: true,
+    ownerEmail: 'owner@acme.com',
+    ownerPhone: '+15551230000',
+    messagingServiceReady: true,
+    numberAssigned: true,
+    testSmsTruth,
+    missedCallValidation,
+    webhookSnapshot: {
+      currentVoiceUrl: 'https://app.callbackcloser.com/api/twilio/voice',
+      currentSmsUrl: 'https://app.callbackcloser.com/api/twilio/sms',
+      currentStatusUrl: 'https://app.callbackcloser.com/api/twilio/message-status',
+      expectedVoiceUrl: 'https://app.callbackcloser.com/api/twilio/voice',
+      expectedSmsUrl: 'https://app.callbackcloser.com/api/twilio/sms',
+      expectedStatusUrl: 'https://app.callbackcloser.com/api/twilio/message-status',
+      voiceSynced: true,
+      smsSynced: true,
+      statusSynced: true,
+      error: null,
+    },
+    provisioningStatus: BusinessProvisioningStatus.ONBOARDING,
+    canSafelyMarkLive: true,
+    blockers: [],
+    events: [],
   });
 
   const panels = buildAdminSetupPanels({
@@ -186,17 +383,11 @@ test('setup remediation panels stay truthful for main-account mode and next-step
       statusSynced: true,
       error: null,
     },
-    testSmsTruth: {
-      state: 'delivered',
-      label: 'Delivered',
-      tone: 'success',
-      summary: 'Test SMS delivered',
-      detail: 'Delivery confirmed.',
-      reason: null,
-      lastAttemptAt: new Date('2026-04-21T12:05:00.000Z'),
-      eventType: 'admin.test_sms_delivered',
-    },
-    successfulLeadCount: 2,
+    testSmsTruth,
+    onboardingConfidence,
+    missedCallValidation,
+    goLiveDecision: proofBundle.goLiveDecision,
+    proofs: proofBundle.proofs,
   });
 
   const accountReadyPanel = panels.find((panel) => panel.key === 'account_ready')!;


### PR DESCRIPTION
## Summary
- add explicit onboarding confidence and go-live proof on the admin business page
- deepen setup steps with evidence, warnings, manual missed-call confirmation, and safer go-live acknowledgment
- make the admin home a clearer daily operator queue with readiness and blocker signals

## Validation
- npm install
- npm run env:check
- npm run preflight:providers
- npm run typecheck
- npm run lint
- npm run test
- npm run build