### PR TITLE
admin: tighten business page truth and activity flow

### DIFF
--- a/app/admin/[businessId]/page.tsx
+++ b/app/admin/[businessId]/page.tsx
@@ -86,21 +86,60 @@ function getTimelineFilter(searchParams: Record<string, string | string[] | unde
   return 'all';
 }
 
-function buildTimelineFilterPath(businessId: string, filter: BusinessTimelineFilter, step: TwilioSetupStepKey | null) {
+function getActivityExpanded(searchParams: Record<string, string | string[] | undefined> | undefined) {
+  return getQueryValue(searchParams, 'activity') === 'all';
+}
+
+function buildTimelineFilterPath(
+  businessId: string,
+  filter: BusinessTimelineFilter,
+  step: TwilioSetupStepKey | null,
+  activityExpanded: boolean
+) {
   const search = new URLSearchParams();
   if (filter !== 'all') search.set('timeline', filter);
   if (step) search.set('step', step);
+  if (activityExpanded) search.set('activity', 'all');
   const query = search.toString();
   return query ? `/admin/${businessId}?${query}` : `/admin/${businessId}`;
 }
 
-function buildStepPath(businessId: string, step: TwilioSetupStepKey, timelineFilter: BusinessTimelineFilter) {
+function buildStepPath(
+  businessId: string,
+  step: TwilioSetupStepKey,
+  timelineFilter: BusinessTimelineFilter,
+  activityExpanded: boolean
+) {
   const search = new URLSearchParams();
   if (timelineFilter !== 'all') {
     search.set('timeline', timelineFilter);
   }
   search.set('step', step);
+  if (activityExpanded) {
+    search.set('activity', 'all');
+  }
   return `/admin/${businessId}?${search.toString()}#step-${step}`;
+}
+
+function buildActivityPath(
+  businessId: string,
+  timelineFilter: BusinessTimelineFilter,
+  step: TwilioSetupStepKey | null,
+  expanded: boolean
+) {
+  const search = new URLSearchParams();
+  if (timelineFilter !== 'all') {
+    search.set('timeline', timelineFilter);
+  }
+  if (step) {
+    search.set('step', step);
+  }
+  if (expanded) {
+    search.set('activity', 'all');
+  }
+
+  const query = search.toString();
+  return query ? `/admin/${businessId}?${query}#recent-activity` : `/admin/${businessId}#recent-activity`;
 }
 
 function HiddenAdminTwilioFields({
@@ -172,6 +211,7 @@ export default async function AdminBusinessDetailPage({
   const business = businessRecord;
 
   const timelineFilter = getTimelineFilter(searchParams);
+  const activityExpanded = getActivityExpanded(searchParams);
   const testSmsTruth = buildAdminTestSmsTruth(operatorEvents);
   const [ownerState, webhookSnapshot, availableNumbers] = await Promise.all([
     getAdminOwnerState(business, business.notificationSettings),
@@ -253,10 +293,15 @@ export default async function AdminBusinessDetailPage({
   const timelineFilterLinks = businessTimelineFilterOptions.map((option) => ({
     key: option.key,
     label: option.label,
-    href: buildTimelineFilterPath(business.id, option.key, selectedStepKey),
+    href: buildTimelineFilterPath(business.id, option.key, selectedStepKey, activityExpanded),
     count: timelineCounts.get(option.key) ?? 0,
   }));
   const visibleTimelineEvents = operatorEvents.filter((event) => matchesTimelineFilter(event, timelineFilter));
+  const expandActivityHref = visibleTimelineEvents.length > 5 ? buildActivityPath(business.id, timelineFilter, selectedStepKey, true) : null;
+  const collapseActivityHref = activityExpanded ? buildActivityPath(business.id, timelineFilter, selectedStepKey, false) : null;
+  const lastIssueHref = lastIssue.remediationStepKey
+    ? buildStepPath(business.id, lastIssue.remediationStepKey, timelineFilter, activityExpanded)
+    : null;
   const defaults: AdminTwilioDefaults = {
     businessId: business.id,
     twilioAccountMode: business.twilioAccountMode,
@@ -288,7 +333,7 @@ export default async function AdminBusinessDetailPage({
     panels: setupPanels,
   });
   const nextStep = getStepByKey(setupFlow.steps, nextStepGuide.key);
-  const nextStepHref = buildStepPath(business.id, nextStepGuide.key, timelineFilter);
+  const nextStepHref = buildStepPath(business.id, nextStepGuide.key, timelineFilter, activityExpanded);
   const selectedStep = getStepByKey(setupFlow.steps, selectedStepKey);
 
   const created = getQueryValue(searchParams, 'created') === '1';
@@ -935,7 +980,7 @@ export default async function AdminBusinessDetailPage({
                 <Link className={buttonVariants({ size: 'sm' })} href={nextStepHref}>
                   Open next step
                 </Link>
-                <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={buildStepPath(business.id, 'safe_to_mark_live', timelineFilter)}>
+                <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={buildStepPath(business.id, 'safe_to_mark_live', timelineFilter, activityExpanded)}>
                   Open go-live step
                 </Link>
               </div>
@@ -978,6 +1023,11 @@ export default async function AdminBusinessDetailPage({
             <p className="text-xs text-muted-foreground">
               {lastIssue.createdAt ? `Recorded ${formatDateTime(lastIssue.createdAt)}` : 'Derived from the current business state.'}
             </p>
+            {lastIssueHref ? (
+              <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={lastIssueHref}>
+                Open fix step
+              </Link>
+            ) : null}
           </CardContent>
         </Card>
 
@@ -995,7 +1045,7 @@ export default async function AdminBusinessDetailPage({
             <p className="text-xs text-muted-foreground">
               {testSmsTruth.lastAttemptAt ? `Last attempt ${formatDateTime(testSmsTruth.lastAttemptAt)}` : 'No test SMS attempt recorded yet.'}
             </p>
-            <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={buildStepPath(business.id, 'test_sms_delivered', timelineFilter)}>
+            <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={buildStepPath(business.id, 'test_sms_delivered', timelineFilter, activityExpanded)}>
               Open testing step
             </Link>
           </CardContent>
@@ -1029,7 +1079,14 @@ export default async function AdminBusinessDetailPage({
       </div>
 
       <div id="recent-activity">
-        <AdminBusinessActivityTimeline events={visibleTimelineEvents} activeFilter={timelineFilter} filterLinks={timelineFilterLinks} />
+        <AdminBusinessActivityTimeline
+          activeFilter={timelineFilter}
+          collapseHref={collapseActivityHref}
+          events={visibleTimelineEvents}
+          expandHref={expandActivityHref}
+          expanded={activityExpanded}
+          filterLinks={timelineFilterLinks}
+        />
       </div>
 
       <Card className="bg-card/90" id="admin-setup-steps">
@@ -1046,7 +1103,7 @@ export default async function AdminBusinessDetailPage({
                 automaticActions={renderAutomaticActions(step)}
                 currentState={panel.currentState}
                 explanation={panel.explanation}
-                href={buildStepPath(business.id, step.key, timelineFilter)}
+                href={buildStepPath(business.id, step.key, timelineFilter, activityExpanded)}
                 manualEntry={renderManualEntry(step)}
                 nextAction={panel.nextAction}
                 open={selectedStepKey === step.key}

--- a/components/admin-business-activity-timeline.tsx
+++ b/components/admin-business-activity-timeline.tsx
@@ -63,11 +63,22 @@ export function AdminBusinessActivityTimeline({
   events,
   activeFilter,
   filterLinks,
+  expanded,
+  expandHref,
+  collapseHref,
+  defaultVisibleCount = 5,
 }: {
   events: TimelineEvent[];
   activeFilter: BusinessTimelineFilter;
   filterLinks: Array<{ key: BusinessTimelineFilter; label: string; href: string; count: number }>;
+  expanded: boolean;
+  expandHref: string | null;
+  collapseHref: string | null;
+  defaultVisibleCount?: number;
 }) {
+  const visibleEvents = expanded ? events : events.slice(0, defaultVisibleCount);
+  const hasHiddenEvents = events.length > defaultVisibleCount;
+
   return (
     <Card className="bg-card/90">
       <CardHeader className="space-y-4">
@@ -95,7 +106,7 @@ export function AdminBusinessActivityTimeline({
           <div className="rounded-xl border border-dashed p-6 text-sm text-muted-foreground">No business events match this filter yet.</div>
         ) : (
           <div className="space-y-3">
-            {events.map((event) => (
+            {visibleEvents.map((event) => (
               <details key={event.id} className="rounded-xl border bg-background/80 p-4">
                 <summary className="cursor-pointer list-none">
                   <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
@@ -121,6 +132,27 @@ export function AdminBusinessActivityTimeline({
                 </div>
               </details>
             ))}
+            {hasHiddenEvents ? (
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border bg-background/80 p-4 text-sm">
+                <p className="text-muted-foreground">
+                  {expanded
+                    ? `Showing all ${events.length} activity items.`
+                    : `Showing ${visibleEvents.length} of ${events.length} activity items by default.`}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {!expanded && expandHref ? (
+                    <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={expandHref}>
+                      Show more activity
+                    </Link>
+                  ) : null}
+                  {expanded && collapseHref ? (
+                    <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={collapseHref}>
+                      Collapse activity
+                    </Link>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
           </div>
         )}
       </CardContent>

--- a/lib/admin-dashboard.ts
+++ b/lib/admin-dashboard.ts
@@ -445,30 +445,6 @@ export function buildAdminOnboardingConfidence(params: {
   const readyForLive = readyForTest && hasTestSmsSuccess && missedCallValidated;
   const canSafelyMarkLive = readyForLive;
 
-  let state: OnboardingConfidenceState = 'in_setup';
-  if (isBusinessArchived(business)) {
-    state = 'archived';
-  } else if (business.provisioningStatus === BusinessProvisioningStatus.LIVE && (!canSafelyMarkLive || hasRecentFailures || managedSummary.attentionRequired)) {
-    state = 'live_with_warnings';
-  } else if (business.provisioningStatus === BusinessProvisioningStatus.LIVE && canSafelyMarkLive) {
-    state = 'live';
-  } else if (
-    nextStep.tone === 'attention' ||
-    managedSummary.attentionRequired ||
-    business.provisioningStatus === BusinessProvisioningStatus.NEEDS_ATTENTION ||
-    hasTestSmsFailure
-  ) {
-    state = 'needs_attention';
-  } else if (compliancePending) {
-    state = 'waiting_on_a2p';
-  } else if (readyForLive) {
-    state = 'ready_to_go_live';
-  } else if (readyForTest) {
-    state = 'ready_for_test';
-  } else if (!twilioSetupReady && !numberReady && !messagingServiceReady && !webhooksReady && !ownerConnected) {
-    state = 'draft';
-  }
-
   const blockers: AdminOnboardingConfidence['blockers'] = [];
   if (nextStep.tone === 'attention') {
     blockers.push({ level: 'error', message: nextStep.detail });
@@ -498,6 +474,32 @@ export function buildAdminOnboardingConfidence(params: {
         missedCallValidation?.detail ||
         'Run one real missed-call test and confirm the lead reaches the owner before marking this business live.',
     });
+  }
+
+  const hasActiveGoLiveWarnings = blockers.length > 0;
+
+  let state: OnboardingConfidenceState = 'in_setup';
+  if (isBusinessArchived(business)) {
+    state = 'archived';
+  } else if (business.provisioningStatus === BusinessProvisioningStatus.LIVE && hasActiveGoLiveWarnings) {
+    state = 'live_with_warnings';
+  } else if (business.provisioningStatus === BusinessProvisioningStatus.LIVE && !hasActiveGoLiveWarnings) {
+    state = 'live';
+  } else if (
+    nextStep.tone === 'attention' ||
+    managedSummary.attentionRequired ||
+    business.provisioningStatus === BusinessProvisioningStatus.NEEDS_ATTENTION ||
+    hasTestSmsFailure
+  ) {
+    state = 'needs_attention';
+  } else if (compliancePending) {
+    state = 'waiting_on_a2p';
+  } else if (readyForLive) {
+    state = 'ready_to_go_live';
+  } else if (readyForTest) {
+    state = 'ready_for_test';
+  } else if (!twilioSetupReady && !numberReady && !messagingServiceReady && !webhooksReady && !ownerConnected) {
+    state = 'draft';
   }
 
   const milestones: OnboardingConfidenceMilestone[] = [

--- a/lib/admin-operator-proof.ts
+++ b/lib/admin-operator-proof.ts
@@ -314,12 +314,15 @@ export function buildAdminGoLiveDecisionTruth(params: {
   const note = latestDecisionEvent ? getDetailString(latestDecisionEvent.detailsJson, 'note') : null;
 
   if (params.provisioningStatus === BusinessProvisioningStatus.LIVE) {
-    if (latestDecisionEvent?.type === 'admin.go_live_marked_with_warnings' || !params.canSafelyMarkLive) {
+    if (!params.canSafelyMarkLive) {
       return {
         state: 'marked_live_with_warnings',
         label: 'Live with warnings',
         tone: 'attention',
-        summary: latestDecisionEvent?.summary || 'Business is live with known launch gaps',
+        summary:
+          latestDecisionEvent?.type === 'admin.go_live_marked_with_warnings'
+            ? latestDecisionEvent.summary
+            : 'Business is live with known launch gaps',
         detail:
           note ||
           (params.blockers.length > 0
@@ -336,8 +339,14 @@ export function buildAdminGoLiveDecisionTruth(params: {
       state: 'marked_live',
       label: 'Live',
       tone: 'success',
-      summary: latestDecisionEvent?.summary || 'Business marked live after launch checks',
-      detail: note || 'The business is live and the recorded launch proof still clears the go-live gate.',
+      summary:
+        latestDecisionEvent?.type === 'admin.go_live_marked_safe'
+          ? latestDecisionEvent.summary
+          : 'Business is live and no current go-live warnings remain',
+      detail:
+        latestDecisionEvent?.type === 'admin.go_live_marked_with_warnings' && note
+          ? `Earlier warning note: ${note}`
+          : note || 'The business is live and the current launch proof clears the go-live gate.',
       decidedAt: latestDecisionEvent?.createdAt || null,
       sourceLabel: latestDecisionEvent ? 'Operator decision' : 'Current business state',
       note,

--- a/lib/admin-operator-visibility.ts
+++ b/lib/admin-operator-visibility.ts
@@ -82,6 +82,7 @@ function isOpenIssueStatus(status: OperatorEventStatus) {
 function getRemediationStepKeyForIssueEvent(event: IssueEventRecord): TwilioSetupStepKey | null {
   if (event.type.startsWith('onboarding.owner_')) return 'owner_connected';
   if (event.type.startsWith('admin.test_sms_')) return 'test_sms_delivered';
+  if (event.type.startsWith('owner_alert.')) return 'owner_connected';
   if (event.type === 'provisioning.twilio_subaccount_failed') return 'account_ready';
   if (event.type === 'provisioning.messaging_service_failed') return 'messaging_service_ready';
   if (

--- a/tests/admin-dashboard.test.ts
+++ b/tests/admin-dashboard.test.ts
@@ -407,3 +407,35 @@ test('onboarding confidence stays honest when A2P is pending or live has warning
   assert.equal(liveWithWarnings.canSafelyMarkLive, false);
   assert.equal(liveWithWarnings.readinessLabel, 'Live with warnings');
 });
+
+test('historical warning events do not keep a clean live business in live-with-warnings', () => {
+  const cleanLive = buildAdminOnboardingConfidence({
+    business: createBusiness({
+      provisioningStatus: BusinessProvisioningStatus.LIVE,
+      managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+      a2pApprovedAt: new Date('2026-04-17T00:00:00.000Z'),
+    }),
+    notificationSettings: createNotificationSettings(),
+    ownerConnected: true,
+    successfulLeadCount: 2,
+    operatorEvents: [
+      {
+        type: 'owner_alert.email_skipped',
+        status: OperatorEventStatus.WARNING,
+        createdAt: new Date('2026-04-15T12:00:00.000Z'),
+      },
+      {
+        type: 'admin.test_sms_delivered',
+        status: OperatorEventStatus.SUCCESS,
+        createdAt: new Date('2026-04-17T12:00:00.000Z'),
+      },
+    ],
+    missedCallValidation: {
+      countsAsLaunchProof: true,
+      detail: 'Recent event sequence proves the missed-call flow reached the owner alert path.',
+    },
+  });
+
+  assert.equal(cleanLive.state, 'live');
+  assert.equal(cleanLive.blockers.length, 0);
+});

--- a/tests/admin-operator-routes.test.ts
+++ b/tests/admin-operator-routes.test.ts
@@ -45,6 +45,7 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminDetail, /automatic repair and manual fallback/i);
   assert.match(adminDetail, /Setup steps/);
   assert.match(adminDetail, /Last issue/);
+  assert.match(adminDetail, /Open fix step/);
   assert.match(adminDetail, /Test SMS truth/);
   assert.match(adminDetail, /Onboarding confidence/);
   assert.match(adminDetail, /Next step/);
@@ -68,6 +69,8 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminDetail, /View support workspace snapshot/);
   assert.match(adminHome, /Open blocker step/);
   assert.match(activityTimeline, /Recent activity/);
+  assert.match(activityTimeline, /Show more activity/);
+  assert.match(activityTimeline, /Collapse activity/);
   assert.match(activityTimeline, /Expand details/);
   assert.doesNotMatch(adminDetail, /Connect or invite owner/);
   assert.match(supportWorkspace, /support mode workspace/);

--- a/tests/admin-operator-visibility.test.ts
+++ b/tests/admin-operator-visibility.test.ts
@@ -109,6 +109,27 @@ test('admin business issue prefers the latest recorded issue and falls back to t
 
   assert.equal(fallbackIssue.summary, 'Messaging Service missing');
   assert.equal(fallbackIssue.remediationStepKey, 'messaging_service_ready');
+
+  const ownerAlertIssue = buildAdminBusinessIssue({
+    events: [
+      {
+        type: 'owner_alert.email_skipped',
+        category: OperatorEventCategory.OWNER_ALERTS,
+        status: OperatorEventStatus.WARNING,
+        summary: 'Owner email alert skipped',
+        detailsJson: { reason: 'missing_config' },
+        createdAt: new Date('2026-04-20T12:04:00.000Z'),
+      },
+    ],
+    currentStep: {
+      stepKey: 'safe_to_mark_live',
+      title: 'Safe to mark live',
+      detail: 'Review launch proof.',
+      tone: 'pending',
+    },
+  });
+
+  assert.equal(ownerAlertIssue.remediationStepKey, 'owner_connected');
 });
 
 test('twilio setup update metadata stays specific enough for future remediation panels', () => {


### PR DESCRIPTION
## Summary
- fix contradictory live vs live-with-warnings readiness state behavior so only active unresolved go-live warnings keep a business in warning state
- make last-issue cards actionable by linking them into the matching remediation step, including owner alert issues
- collapse recent activity to 5 items by default with show more/collapse controls that preserve the current filter and selected step

## Testing
- npm run typecheck
- npm run lint
- npm run test
- npm run build