### PR TITLE
Add founder-only business reset flow

### DIFF
--- a/app/admin/[businessId]/page.tsx
+++ b/app/admin/[businessId]/page.tsx
@@ -28,7 +28,7 @@ import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { buildAdminCustomerOpenHref } from '@/lib/admin-customer-paths';
-import { buildAdminOnboardingConfidence, isBusinessArchived } from '@/lib/admin-dashboard';
+import { buildAdminOnboardingConfidence, canDeleteTestBusiness, getDeleteTestBusinessBlockedReason, isBusinessArchived } from '@/lib/admin-dashboard';
 import { buildAdminMissedCallValidationTruth, buildAdminOperationalProofs } from '@/lib/admin-operator-proof';
 import { buildAdminNextStepGuide, buildAdminSetupPanels } from '@/lib/admin-setup-remediation';
 import {
@@ -1210,7 +1210,7 @@ export default async function AdminBusinessDetailPage({
               </Button>
             </form>
           )}
-          {business.isTestBusiness ? (
+          {canDeleteTestBusiness(business) ? (
             <form action={deleteTestBusinessAction}>
               <input name="businessId" type="hidden" value={business.id} />
               <input name="confirmationName" type="hidden" value={business.name} />
@@ -1218,6 +1218,8 @@ export default async function AdminBusinessDetailPage({
                 Delete test business
               </Button>
             </form>
+          ) : business.isTestBusiness ? (
+            <p className="text-sm text-muted-foreground">{getDeleteTestBusinessBlockedReason(business)}</p>
           ) : null}
         </CardContent>
       </Card>

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -15,10 +15,14 @@ import {
   syncBusinessTwilioWebhooks,
   updateBusinessProvisioningStatus,
 } from '@/lib/admin-provisioning';
-import { deleteDeletableTestBusiness } from '@/lib/admin-business-lifecycle';
+import {
+  deleteAllBusinessesForFounderReset,
+  deleteDeletableTestBusiness,
+  FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION,
+} from '@/lib/admin-business-lifecycle';
 import { buildAdminOnboardingConfidence, canDeleteTestBusiness, getDeleteTestBusinessBlockedReason } from '@/lib/admin-dashboard';
 import { buildAdminMissedCallValidationTruth } from '@/lib/admin-operator-proof';
-import { requireAdmin } from '@/lib/admin';
+import { requireAdmin, requireFounderAdmin } from '@/lib/admin';
 import {
   bulkDeleteTestDemoBusinesses,
   BULK_TEST_DATA_RESET_CONFIRMATION,
@@ -43,6 +47,7 @@ import {
   adminSetupBasicsSchema,
   adminTwilioSetupSchema,
   adminBusinessUpdateSchema,
+  adminFounderDeleteAllBusinessesSchema,
   adminProvisionBusinessSchema,
   adminProvisioningStatusSchema,
   adminWebhookSyncSchema,
@@ -1963,6 +1968,49 @@ export async function deleteTestBusinessAction(formData: FormData) {
 
   revalidatePath('/admin');
   redirect(clearBusinessSelectionFromReturnPath(parsed.data.returnTo, { deleted: 1 }, '/admin?deleted=1'));
+}
+
+export async function founderDeleteAllBusinessesAction(formData: FormData) {
+  const founder = await requireFounderAdmin();
+
+  const parsed = adminFounderDeleteAllBusinessesSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    redirect(`/admin?error=${encodeURIComponent(parsed.error.issues[0]?.message || 'Invalid founder reset request.')}`);
+  }
+
+  let redirectPath = '/admin';
+
+  try {
+    const result = await deleteAllBusinessesForFounderReset({
+      confirmation: parsed.data.confirmationText,
+    });
+
+    logAuditEvent({
+      event: 'admin_all_businesses_bulk_deleted',
+      actorType: 'user',
+      actorId: founder.userId,
+      targetType: 'business_collection',
+      targetId: 'all_current_businesses',
+      metadata: {
+        actorEmail: founder.email,
+        deletedCount: result.deletedCount,
+        deletedBusinessNames: result.deletedBusinessNames,
+        confirmationText: FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION,
+      },
+    });
+
+    revalidatePath('/admin');
+
+    redirectPath =
+      result.deletedCount > 0
+        ? `/admin?founderResetResult=deleted&founderResetDeleted=${encodeURIComponent(String(result.deletedCount))}`
+        : '/admin?founderResetResult=noop&founderResetDeleted=0';
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to delete the current businesses.';
+    redirectPath = `/admin?error=${encodeURIComponent(message)}`;
+  }
+
+  redirect(redirectPath);
 }
 
 export async function bulkDeleteTestBusinessesAction(formData: FormData) {

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2,17 +2,17 @@ import Link from 'next/link';
 
 import {
   archiveBusinessAction,
-  bulkDeleteTestBusinessesAction,
   createAdminBusinessAction,
   createDemoBusinessAction,
   deleteTestBusinessAction,
+  founderDeleteAllBusinessesAction,
   provisionBusinessAction,
   resyncBusinessWebhooksAction,
   restoreBusinessAction,
   sendBusinessTestSmsAction,
 } from '@/app/admin/actions';
 import { buildAdminCustomerOpenHref } from '@/lib/admin-customer-paths';
-import { BULK_TEST_DATA_RESET_CONFIRMATION, listTestDemoBusinessesForReset } from '@/lib/admin-test-data-reset';
+import { FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION } from '@/lib/admin-business-lifecycle';
 import {
   adminBoardFilterOptions,
   buildAdminOnboardingConfidence,
@@ -121,13 +121,13 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   const deleted = getQueryValue(searchParams, 'deleted') === '1';
   const error = getQueryValue(searchParams, 'error');
   const query = getQueryValue(searchParams, 'q')?.trim() || '';
-  const resetResult = getQueryValue(searchParams, 'resetResult');
-  const resetDeleted = Number(getQueryValue(searchParams, 'resetDeleted') || '0');
+  const founderResetResult = getQueryValue(searchParams, 'founderResetResult');
+  const founderResetDeleted = Number(getQueryValue(searchParams, 'founderResetDeleted') || '0');
   const restored = getQueryValue(searchParams, 'restored') === '1';
   const view = (getQueryValue(searchParams, 'view') as AdminBoardFilter | null) || 'all';
   const adminBusiness = await db.business.findUnique({ where: { ownerClerkId: admin.userId } });
 
-  const [businesses, businessPickerOptions, leadCounts, successfulLeadCounts, leadActivity, callActivity, messageActivity, latestOperatorIssues, latestTestSmsEvents, operatorSignals, confidenceEvents, resettableBusinesses] = await Promise.all([
+  const [businesses, businessPickerOptions, leadCounts, successfulLeadCounts, leadActivity, callActivity, messageActivity, latestOperatorIssues, latestTestSmsEvents, operatorSignals, confidenceEvents] = await Promise.all([
     query
       ? searchBusinessesForAdmin(query)
       : db.business.findMany({
@@ -271,7 +271,6 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       },
       take: 1400,
     }),
-    listTestDemoBusinessesForReset(),
   ]);
 
   const leadCountMap = new Map(leadCounts.map((item) => [item.businessId, item._count._all]));
@@ -467,7 +466,8 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
     { label: 'Ready for live', value: businessRows.filter((row) => row.onboardingConfidence.state === 'ready_to_go_live').length },
     { label: 'Live with warnings', value: businessRows.filter((row) => row.onboardingConfidence.state === 'live_with_warnings').length },
   ];
-  const resettableBusinessPreview = resettableBusinesses.slice(0, 4).map((business) => business.name);
+  const founderResetBusinessCount = businessPickerOptions.length;
+  const founderResetBusinessPreview = businessPickerOptions.slice(0, 4).map((business) => business.name);
 
   return (
     <div className="container space-y-6 py-8">
@@ -500,13 +500,13 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       {archived ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business archived. Permanent delete stays locked until the workspace is clearly demo/test.</div> : null}
       {restored ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business restored to active triage.</div> : null}
       {deleted ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Demo/test business deleted permanently.</div> : null}
-      {resetResult === 'deleted' && Number.isFinite(resetDeleted) ? (
+      {founderResetResult === 'deleted' && Number.isFinite(founderResetDeleted) ? (
         <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">
-          Deleted {resetDeleted} test/demo {resetDeleted === 1 ? 'business' : 'businesses'}.
+          Deleted {founderResetDeleted} current {founderResetDeleted === 1 ? 'business' : 'businesses'}. You can create one clean business workspace now.
         </div>
       ) : null}
-      {resetResult === 'noop' ? (
-        <div className="rounded-md border bg-background/80 p-3 text-sm text-muted-foreground">No test/demo businesses were eligible for deletion.</div>
+      {founderResetResult === 'noop' ? (
+        <div className="rounded-md border bg-background/80 p-3 text-sm text-muted-foreground">No businesses were available for founder reset.</div>
       ) : null}
       {createdDemo && createdBusinessId ? (
         <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">
@@ -622,45 +622,55 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
         </Card>
       </div>
 
-      <Card className="border-destructive/30 bg-destructive/5">
-        <CardHeader>
-          <CardTitle>Reset test data</CardTitle>
-          <CardDescription>
-            Founder/admin-only destructive cleanup. This removes every current test/demo business and its business-owned data so you can restart from a clean slate.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
-          <div className="rounded-xl border bg-background/80 p-4 text-sm">
-            <p className="font-medium text-foreground">
-              {resettableBusinesses.length} test/demo {resettableBusinesses.length === 1 ? 'business' : 'businesses'} eligible for deletion
-            </p>
-            <p className="mt-2 text-muted-foreground">
-              Only businesses marked as test/demo or the dedicated simulator demo workspace are included. Real customer businesses stay untouched.
-            </p>
-            {resettableBusinessPreview.length > 0 ? (
-              <p className="mt-3 text-muted-foreground">
-                Preview: {resettableBusinessPreview.join(', ')}
-                {resettableBusinesses.length > resettableBusinessPreview.length ? ` and ${resettableBusinesses.length - resettableBusinessPreview.length} more.` : '.'}
+      {admin.isFounder ? (
+        <Card className="border-destructive/30 bg-destructive/5">
+          <CardHeader>
+            <CardTitle>Founder reset</CardTitle>
+            <CardDescription>
+              One-time founder-only cleanup. Use this only because there are no real customer businesses yet. Normal real-customer lifecycle should still be archive or disable, not hard delete.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+            <div className="rounded-xl border bg-background/80 p-4 text-sm">
+              <p className="font-medium text-foreground">
+                {founderResetBusinessCount} current {founderResetBusinessCount === 1 ? 'business' : 'businesses'} will be deleted
               </p>
-            ) : (
-              <p className="mt-3 text-muted-foreground">No test/demo businesses are currently eligible for cleanup.</p>
-            )}
-          </div>
-
-          <form action={bulkDeleteTestBusinessesAction} className="rounded-xl border border-destructive/30 bg-background/80 p-4">
-            <div className="space-y-2">
-              <Label htmlFor="confirmationText">Type {BULK_TEST_DATA_RESET_CONFIRMATION}</Label>
-              <Input id="confirmationText" name="confirmationText" autoComplete="off" placeholder={BULK_TEST_DATA_RESET_CONFIRMATION} />
+              <p className="mt-2 text-muted-foreground">
+                This permanently deletes every current business record, including archived ones, so you can restart from one clean workspace.
+              </p>
+              {founderResetBusinessPreview.length > 0 ? (
+                <p className="mt-3 text-muted-foreground">
+                  Preview: {founderResetBusinessPreview.join(', ')}
+                  {founderResetBusinessCount > founderResetBusinessPreview.length
+                    ? ` and ${founderResetBusinessCount - founderResetBusinessPreview.length} more.`
+                    : '.'}
+                </p>
+              ) : (
+                <p className="mt-3 text-muted-foreground">No businesses are currently present.</p>
+              )}
             </div>
-            <p className="mt-3 text-xs text-muted-foreground">
-              This is irreversible. Deleting a business also removes its business-scoped leads, calls, messages, notifications, operator events, settings, and related demo data through the existing schema cascades.
-            </p>
-            <Button className="mt-4" type="submit" variant="destructive" disabled={resettableBusinesses.length === 0}>
-              Delete all test/demo businesses
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
+
+            <form action={founderDeleteAllBusinessesAction} className="rounded-xl border border-destructive/30 bg-background/80 p-4">
+              <div className="space-y-2">
+                <Label htmlFor="founderResetConfirmationText">Type {FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION}</Label>
+                <Input
+                  id="founderResetConfirmationText"
+                  name="confirmationText"
+                  autoComplete="off"
+                  placeholder={FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION}
+                />
+              </div>
+              <p className="mt-3 text-xs text-muted-foreground">
+                This is irreversible. Deleting a business also removes its leads, calls, messages, owner notifications, business settings, operator events,
+                simulator runs, SMS consent records, and other business-owned data through the existing schema cascades.
+              </p>
+              <Button className="mt-4" type="submit" variant="destructive" disabled={founderResetBusinessCount === 0}>
+                Delete all current businesses
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      ) : null}
 
       <Card className="bg-card/90">
         <CardHeader>
@@ -853,9 +863,11 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
 
           {visibleRows.length === 0 ? (
             <div className="rounded-xl border border-dashed p-6 text-sm text-muted-foreground">
-              {selectedBusinessId
-                ? 'That business is no longer available on the board. Clear the selection and pick another workspace.'
-                : 'No businesses matched this view. Try a different filter or search for the exact business ID, owner email, or Twilio number.'}
+              {businessPickerOptions.length === 0
+                ? 'All businesses have been removed. Create your first clean business workspace with Fast onboard.'
+                : selectedBusinessId
+                  ? 'That business is no longer available on the board. Clear the selection and pick another workspace.'
+                  : 'No businesses matched this view. Try a different filter or search for the exact business ID, owner email, or Twilio number.'}
             </div>
           ) : (
             <div className="overflow-hidden rounded-xl border">

--- a/lib/admin-business-lifecycle.ts
+++ b/lib/admin-business-lifecycle.ts
@@ -1,5 +1,79 @@
+import type { Business } from '@prisma/client';
+
 import { canDeleteTestBusiness, getDeleteTestBusinessBlockedReason } from '@/lib/admin-dashboard';
 import { db } from '@/lib/db';
+
+export const FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION = 'DELETE ALL BUSINESSES';
+
+export type FounderBusinessResetCandidate = Pick<Business, 'id' | 'name' | 'isTestBusiness' | 'archivedAt'>;
+
+function normalizeConfirmation(value: string | null | undefined) {
+  return value?.trim().toUpperCase() || '';
+}
+
+export async function listBusinessesForFounderReset(candidateIds?: string[]) {
+  return db.business.findMany({
+    where: candidateIds?.length
+      ? {
+          id: {
+            in: candidateIds,
+          },
+        }
+      : undefined,
+    orderBy: [{ archivedAt: 'asc' }, { updatedAt: 'desc' }],
+    select: {
+      id: true,
+      name: true,
+      isTestBusiness: true,
+      archivedAt: true,
+    },
+  });
+}
+
+export async function deleteAllBusinessesForFounderReset(params: { confirmation: string; candidateIds?: string[] }) {
+  if (normalizeConfirmation(params.confirmation) !== FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION) {
+    throw new Error(`Type ${FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION} to confirm deleting all current businesses.`);
+  }
+
+  return db.$transaction(async (tx) => {
+    const candidates = await tx.business.findMany({
+      where: params.candidateIds?.length
+        ? {
+            id: {
+              in: params.candidateIds,
+            },
+          }
+        : undefined,
+      orderBy: [{ archivedAt: 'asc' }, { updatedAt: 'desc' }],
+      select: {
+        id: true,
+        name: true,
+        isTestBusiness: true,
+        archivedAt: true,
+      },
+    });
+
+    if (candidates.length === 0) {
+      return {
+        deletedCount: 0,
+        deletedBusinessNames: [] as string[],
+      };
+    }
+
+    const result = await tx.business.deleteMany({
+      where: {
+        id: {
+          in: candidates.map((business) => business.id),
+        },
+      },
+    });
+
+    return {
+      deletedCount: result.count,
+      deletedBusinessNames: candidates.map((business) => business.name),
+    };
+  });
+}
 
 export async function deleteDeletableTestBusiness(businessId: string) {
   const business = await db.business.findUnique({

--- a/lib/admin.ts
+++ b/lib/admin.ts
@@ -17,6 +17,12 @@ function isAllowedAdminUser(params: { userId: string; email: string | null }) {
   return (founderUserId && params.userId === founderUserId) || (params.email ? adminEmailAllowlist.has(params.email) : false);
 }
 
+export function isFounderUserId(userId: string | null | undefined, env: Readonly<Record<string, string | undefined>> = process.env) {
+  const founderUserId = env.FOUNDER_CLERK_USER_ID?.trim();
+  if (!founderUserId || !userId) return false;
+  return userId === founderUserId;
+}
+
 export async function getAdminSession() {
   const { userId } = await auth();
   if (!userId) {
@@ -33,6 +39,7 @@ export async function getAdminSession() {
     userId,
     email: primaryEmail,
     isAdmin: isAllowedAdminUser({ userId, email: primaryEmail }),
+    isFounder: isFounderUserId(userId),
   };
 }
 
@@ -49,5 +56,16 @@ export async function requireAdmin() {
   return {
     userId: session.userId,
     email: session.email,
+    isFounder: session.isFounder,
   };
+}
+
+export async function requireFounderAdmin() {
+  const admin = await requireAdmin();
+
+  if (!admin.isFounder) {
+    redirect('/admin?error=Founder-only+cleanup+action.');
+  }
+
+  return admin;
 }

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -212,6 +212,10 @@ export const adminBulkDeleteTestBusinessesSchema = z.object({
   confirmationText: z.string().trim().min(1),
 });
 
+export const adminFounderDeleteAllBusinessesSchema = z.object({
+  confirmationText: z.string().trim().min(1),
+});
+
 export const businessTwilioAdminOverrideSchema = z.object({
   twilioAccountMode: twilioAccountModeSchema.default('BUSINESS_SUBACCOUNT'),
   twilioNumberSetupMode: twilioNumberSetupModeSchema.default('NEW_NUMBER'),

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isFounderUserId } from '../lib/admin.ts';
+
+test('isFounderUserId only authorizes the configured founder account', () => {
+  const env = {
+    FOUNDER_CLERK_USER_ID: 'user_founder',
+  };
+
+  assert.equal(isFounderUserId('user_founder', env), true);
+  assert.equal(isFounderUserId('user_customer', env), false);
+  assert.equal(isFounderUserId(null, env), false);
+});

--- a/tests/admin-bulk-delete-action.test.ts
+++ b/tests/admin-bulk-delete-action.test.ts
@@ -6,16 +6,19 @@ function read(path: string) {
   return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 }
 
-test('bulk delete action keeps redirect outside the try/catch and returns plain admin UI states', () => {
+test('founder bulk delete action keeps redirect outside the try/catch and returns plain admin UI states', () => {
   const actions = read('app/admin/actions.ts');
   const adminPage = read('app/admin/page.tsx');
 
-  const actionSection = actions.slice(actions.indexOf('export async function bulkDeleteTestBusinessesAction'));
+  const actionStart = actions.indexOf('export async function founderDeleteAllBusinessesAction');
+  const nextActionStart = actions.indexOf('export async function bulkDeleteTestBusinessesAction');
+  const actionSection = actions.slice(actionStart, nextActionStart);
   const catchStart = actionSection.indexOf('} catch (error) {');
   const finalRedirectStart = actionSection.lastIndexOf('\n\n  redirect(redirectPath);');
   const catchSection = actionSection.slice(catchStart, finalRedirectStart);
 
-  assert.match(actions, /export async function bulkDeleteTestBusinessesAction/);
+  assert.match(actions, /export async function founderDeleteAllBusinessesAction/);
+  assert.match(actions, /const founder = await requireFounderAdmin\(\)/);
   assert.match(actions, /let redirectPath = '\/admin'/);
   assert.match(actions, /redirectPath = `\/admin\?error=\$\{encodeURIComponent\(message\)\}`/);
   assert.match(actions, /redirect\(redirectPath\);/);
@@ -23,8 +26,10 @@ test('bulk delete action keeps redirect outside the try/catch and returns plain 
   assert.notEqual(finalRedirectStart, -1);
   assert.doesNotMatch(catchSection, /redirect\(/);
 
-  assert.match(adminPage, /resetResult === 'deleted'/);
-  assert.match(adminPage, /Deleted \{resetDeleted\} test\/demo/);
-  assert.match(adminPage, /resetResult === 'noop'/);
-  assert.match(adminPage, /No test\/demo businesses were eligible for deletion/);
+  assert.match(adminPage, /admin\.isFounder \?/);
+  assert.match(adminPage, /founderResetResult === 'deleted'/);
+  assert.match(adminPage, /Deleted \{founderResetDeleted\} current/);
+  assert.match(adminPage, /founderResetResult === 'noop'/);
+  assert.match(adminPage, /No businesses were available for founder reset/);
+  assert.match(adminPage, /All businesses have been removed\. Create your first clean business workspace with Fast onboard\./);
 });

--- a/tests/admin-founder-business-reset.test.ts
+++ b/tests/admin-founder-business-reset.test.ts
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+
+import {
+  deleteAllBusinessesForFounderReset,
+  FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION,
+} from '../lib/admin-business-lifecycle.ts';
+import { db } from '../lib/db.ts';
+
+function uniqueDigits(seed: string) {
+  const digits = seed.replace(/\D/g, '').padEnd(10, '4');
+  return digits.slice(-10);
+}
+
+function makePhone(seed: string, suffix: string) {
+  return `+1${uniqueDigits(`${seed}${suffix}`)}`;
+}
+
+function makeSid(prefix: string, seed: string) {
+  const normalized = seed.replace(/-/g, '').padEnd(32, '0');
+  return `${prefix}${normalized.slice(0, 32)}`;
+}
+
+async function seedBusinessGraph(seed: string) {
+  const business = await db.business.create({
+    data: {
+      ownerClerkId: `founder-reset-${seed}`,
+      name: `Founder Reset ${seed.slice(0, 6)}`,
+      isTestBusiness: false,
+      forwardingNumber: makePhone(seed, '100'),
+      notifyPhone: makePhone(seed, '200'),
+      missedCallSeconds: 20,
+      timezone: 'America/New_York',
+      serviceLabel1: 'Repair',
+      serviceLabel2: 'Install',
+      serviceLabel3: 'Maintenance',
+      notificationSettings: {
+        create: {
+          ownerEmail: `owner-${seed.slice(0, 8)}@example.com`,
+          ownerPhone: makePhone(seed, '200'),
+        },
+      },
+    },
+  });
+
+  const call = await db.call.create({
+    data: {
+      businessId: business.id,
+      twilioCallSid: makeSid('CA', `${seed}call`),
+      fromPhone: makePhone(seed, '300'),
+      fromPhoneNormalized: makePhone(seed, '300'),
+      toPhone: makePhone(seed, '100'),
+      toPhoneNormalized: makePhone(seed, '100'),
+      status: 'MISSED',
+      missed: true,
+    },
+  });
+
+  const lead = await db.lead.create({
+    data: {
+      businessId: business.id,
+      callId: call.id,
+      callerPhone: call.fromPhone,
+      callerPhoneNormalized: call.fromPhoneNormalized,
+      summary: 'Founder reset lead',
+    },
+  });
+
+  await db.message.create({
+    data: {
+      businessId: business.id,
+      leadId: lead.id,
+      direction: 'OUTBOUND',
+      participant: 'LEAD',
+      fromPhone: makePhone(seed, '100'),
+      toPhone: lead.callerPhoneNormalized,
+      body: 'Founder reset outbound message',
+    },
+  });
+
+  await db.ownerNotification.create({
+    data: {
+      businessId: business.id,
+      leadId: lead.id,
+      channel: 'SMS',
+      destination: makePhone(seed, '200'),
+      body: 'Founder reset owner notification',
+    },
+  });
+
+  await db.businessOperatorEvent.create({
+    data: {
+      businessId: business.id,
+      type: 'admin.founder_reset_seeded',
+      category: 'ADMIN_ACTIONS',
+      status: 'INFO',
+      summary: 'Founder reset seed',
+    },
+  });
+
+  await db.simulatorRun.create({
+    data: {
+      businessId: business.id,
+      leadId: lead.id,
+      publicId: `sim_${seed.replace(/-/g, '')}`,
+      callerPhone: lead.callerPhoneNormalized,
+    },
+  });
+
+  await db.smsConsent.create({
+    data: {
+      businessId: business.id,
+      phoneNormalized: lead.callerPhoneNormalized,
+      phoneRawLastSeen: lead.callerPhone,
+      optedOut: false,
+    },
+  });
+
+  return { business, call, lead };
+}
+
+test('deleteAllBusinessesForFounderReset deletes every selected business and all business-owned records', async () => {
+  const first = await seedBusinessGraph(randomUUID());
+  const second = await seedBusinessGraph(randomUUID());
+  const preserved = await seedBusinessGraph(randomUUID());
+
+  try {
+    const result = await deleteAllBusinessesForFounderReset({
+      confirmation: FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION,
+      candidateIds: [first.business.id, second.business.id],
+    });
+
+    assert.equal(result.deletedCount, 2);
+    assert.deepEqual(
+      [...result.deletedBusinessNames].sort(),
+      [first.business.name, second.business.name].sort()
+    );
+
+    for (const seeded of [first, second]) {
+      assert.equal(await db.business.findUnique({ where: { id: seeded.business.id } }), null);
+      assert.equal(await db.call.findUnique({ where: { id: seeded.call.id } }), null);
+      assert.equal(await db.lead.findUnique({ where: { id: seeded.lead.id } }), null);
+      assert.equal(await db.message.count({ where: { businessId: seeded.business.id } }), 0);
+      assert.equal(await db.ownerNotification.count({ where: { businessId: seeded.business.id } }), 0);
+      assert.equal(await db.businessNotificationSettings.count({ where: { businessId: seeded.business.id } }), 0);
+      assert.equal(await db.businessOperatorEvent.count({ where: { businessId: seeded.business.id } }), 0);
+      assert.equal(await db.simulatorRun.count({ where: { businessId: seeded.business.id } }), 0);
+      assert.equal(await db.smsConsent.count({ where: { businessId: seeded.business.id } }), 0);
+    }
+
+    assert.notEqual(await db.business.findUnique({ where: { id: preserved.business.id } }), null);
+  } finally {
+    await db.business.deleteMany({
+      where: {
+        id: {
+          in: [first.business.id, second.business.id, preserved.business.id],
+        },
+      },
+    });
+  }
+});
+
+test('deleteAllBusinessesForFounderReset requires explicit confirmation and preserves data when confirmation is wrong', async () => {
+  const seeded = await seedBusinessGraph(randomUUID());
+
+  try {
+    await assert.rejects(
+      deleteAllBusinessesForFounderReset({
+        confirmation: 'delete please',
+        candidateIds: [seeded.business.id],
+      }),
+      /DELETE ALL BUSINESSES/
+    );
+
+    assert.notEqual(await db.business.findUnique({ where: { id: seeded.business.id } }), null);
+  } finally {
+    await db.business.deleteMany({ where: { id: seeded.business.id } });
+  }
+});

--- a/tests/admin-operator-routes.test.ts
+++ b/tests/admin-operator-routes.test.ts
@@ -19,9 +19,9 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminHome, /Operator control panel/);
   assert.match(adminHome, /Fast onboard/);
   assert.match(adminHome, /Create business workspace/);
-  assert.match(adminHome, /Reset test data/);
-  assert.match(adminHome, /Delete all test\/demo businesses/);
-  assert.match(adminHome, /BULK_TEST_DATA_RESET_CONFIRMATION/);
+  assert.match(adminHome, /Founder reset/);
+  assert.match(adminHome, /Delete all current businesses/);
+  assert.match(adminHome, /FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION/);
   assert.match(adminHome, /Business triage board/);
   assert.match(adminHome, /Go-live blocker/);
   assert.match(adminHome, /Test SMS/);
@@ -29,7 +29,7 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminHome, /Delete demo\/test business permanently/);
   assert.match(adminHome, /Type business name to permanently delete/);
   assert.match(adminHome, /Open customer leads/);
-  assert.match(adminActions, /export async function bulkDeleteTestBusinessesAction/);
+  assert.match(adminActions, /export async function founderDeleteAllBusinessesAction/);
   assert.match(adminActions, /export async function saveAdminTwilioSetupAction/);
   assert.match(adminActions, /export async function saveAdminSetupBasicsAction/);
   assert.match(adminActions, /export async function createBusinessTwilioSubaccountAction/);
@@ -67,6 +67,8 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminDetail, /Open customer settings/);
   assert.match(adminDetail, /Open customer call flow/);
   assert.match(adminDetail, /View support workspace snapshot/);
+  assert.match(adminDetail, /canDeleteTestBusiness\(business\)/);
+  assert.match(adminDetail, /getDeleteTestBusinessBlockedReason\(business\)/);
   assert.match(adminHome, /Open blocker step/);
   assert.match(activityTimeline, /Recent activity/);
   assert.match(activityTimeline, /Show more activity/);


### PR DESCRIPTION
## Summary
- add a founder-only admin reset action that can hard-delete every current business after typing DELETE ALL BUSINESSES
- preserve normal archive-first lifecycle behavior for real customer businesses and keep permanent delete gated to founder or archived demo/test flows
- add regression coverage for cascade cleanup, founder-only gating, redirect handling, and the post-reset empty state

## Root cause
- the existing bulk cleanup flow only targeted businesses marked as test/demo or the dedicated simulator owner
- the current local businesses are not marked as test/demo, so the reset card never considered them eligible for deletion
- the business detail page also exposed a test-business delete button before the archive precondition was satisfied, which made that path look broken

## Validation
- npm run typecheck
- npm run lint
- npm run test
- npm run build