### PR TITLE
Hotfix messaging compliance toll-free enum mismatch

### DIFF
--- a/app/app/call-flow/page.tsx
+++ b/app/app/call-flow/page.tsx
@@ -48,7 +48,7 @@ export default async function CallFlowPage() {
         ? {
             key: 'compliance',
             label:
-              managedTwilioSummary.complianceType === 'TOLL_FREE'
+              managedTwilioSummary.complianceType === 'TOLL_FREE_VERIFICATION'
                 ? 'Toll-free verification'
                 : managedTwilioSummary.complianceTypeUnknown
                   ? 'Number type'
@@ -99,10 +99,10 @@ export default async function CallFlowPage() {
     {
       key: 'compliance',
       label: managedTwilioSummary.complianceReady
-        ? managedTwilioSummary.complianceType === 'TOLL_FREE'
+        ? managedTwilioSummary.complianceType === 'TOLL_FREE_VERIFICATION'
           ? 'Toll-free verification complete'
           : 'A2P approved'
-        : managedTwilioSummary.complianceType === 'TOLL_FREE'
+        : managedTwilioSummary.complianceType === 'TOLL_FREE_VERIFICATION'
           ? 'Toll-free verification in progress'
           : managedTwilioSummary.complianceTypeUnknown
             ? 'Number type still needed'
@@ -147,7 +147,7 @@ export default async function CallFlowPage() {
         title: 'The caller gets a text right away',
         detail: managedTwilioSummary.complianceReady
           ? 'The conversation collects the service type, urgency, ZIP, callback timing, and optional name without extra admin work.'
-          : managedTwilioSummary.complianceType === 'TOLL_FREE'
+          : managedTwilioSummary.complianceType === 'TOLL_FREE_VERIFICATION'
             ? 'The automated SMS handoff stays pending until the managed Twilio setup and toll-free verification are complete.'
             : managedTwilioSummary.complianceTypeUnknown
               ? 'The automated SMS handoff stays pending until the number type is selected and messaging compliance is recorded.'

--- a/components/messaging-compliance-fields.tsx
+++ b/components/messaging-compliance-fields.tsx
@@ -53,7 +53,7 @@ export function MessagingComplianceFields({
   const submitLabel =
     complianceType === 'LOCAL_A2P'
       ? 'Save A2P status'
-      : complianceType === 'TOLL_FREE'
+      : complianceType === 'TOLL_FREE_VERIFICATION'
         ? 'Save toll-free verification status'
         : 'Save messaging compliance status';
 
@@ -109,7 +109,7 @@ export function MessagingComplianceFields({
         </div>
       </div>
 
-      <div className={cn('contents', complianceType === 'TOLL_FREE' ? '' : 'hidden')}>
+      <div className={cn('contents', complianceType === 'TOLL_FREE_VERIFICATION' ? '' : 'hidden')}>
         <div className="space-y-2">
           <Label htmlFor={`${idPrefix}TollFreeVerificationStatus`}>Toll-free verification status</Label>
           <Select

--- a/lib/admin-dashboard.ts
+++ b/lib/admin-dashboard.ts
@@ -328,7 +328,7 @@ export function buildAdminNextStep(params: {
     };
   }
 
-  if (managedSummary.complianceType === MessagingComplianceType.TOLL_FREE && !managedSummary.complianceStarted) {
+  if (managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION && !managedSummary.complianceStarted) {
     return {
       title: 'Toll-free verification still needs recording',
       detail: 'Messaging is wired up, but toll-free verification still needs to be recorded before compliant live texting can launch.',
@@ -364,7 +364,7 @@ export function buildAdminNextStep(params: {
     };
   }
 
-  if (managedSummary.complianceType === MessagingComplianceType.TOLL_FREE && managedSummary.compliancePendingReview) {
+  if (managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION && managedSummary.compliancePendingReview) {
     return {
       title: 'Toll-free verification still pending',
       detail: 'Toll-free verification is waiting on Twilio review. No action is needed unless Twilio requests changes.',
@@ -487,7 +487,7 @@ export function buildAdminOnboardingConfidence(params: {
     blockers.push({
       level: 'warning',
       message:
-        managedSummary.complianceType === MessagingComplianceType.TOLL_FREE
+        managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
           ? 'Toll-free verification is still pending. No operator action is needed unless Twilio asks for changes.'
           : 'A2P review is still pending. No operator action is needed unless Twilio asks for changes.',
     });
@@ -601,7 +601,7 @@ export function buildAdminOnboardingConfidence(params: {
       complete: managedSummary.complianceReady,
       variant: milestoneVariant({ complete: managedSummary.complianceReady, blocking: managedSummary.attentionRequired }),
       detail: managedSummary.complianceReady
-        ? managedSummary.complianceType === MessagingComplianceType.TOLL_FREE
+        ? managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
           ? 'Toll-free verification is recorded as verified.'
           : 'A2P approval is recorded.'
         : managedSummary.nextStep,
@@ -669,9 +669,9 @@ export function buildAdminOnboardingConfidence(params: {
       stateVariant: 'secondary',
       readinessLabel: 'Waiting on external approval',
       readinessVariant: 'secondary',
-      nextAction: managedSummary.complianceType === MessagingComplianceType.TOLL_FREE ? 'Wait for toll-free verification' : 'Wait for Twilio approval',
+      nextAction: managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION ? 'Wait for toll-free verification' : 'Wait for Twilio approval',
       summary:
-        managedSummary.complianceType === MessagingComplianceType.TOLL_FREE
+        managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
           ? 'Infrastructure is in place, but compliant messaging is still waiting on toll-free verification.'
           : 'Infrastructure is in place, but compliant messaging is still waiting on Twilio or carrier review.',
     },

--- a/lib/admin-setup-remediation.ts
+++ b/lib/admin-setup-remediation.ts
@@ -438,7 +438,7 @@ export function buildAdminSetupPanels(params: {
           return 'Number type has not been selected yet.';
         }
 
-        if (managedSummary.complianceType === MessagingComplianceType.TOLL_FREE) {
+        if (managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION) {
           return business.tollFreeVerificationNote
             ? `Current note: ${business.tollFreeVerificationNote}`
             : business.tollFreeVerificationSid
@@ -456,7 +456,7 @@ export function buildAdminSetupPanels(params: {
       nextAction:
         business.messagingComplianceType === MessagingComplianceType.UNKNOWN
           ? 'Choose the number type first, then record the actual messaging compliance state.'
-          : business.messagingComplianceType === MessagingComplianceType.TOLL_FREE
+          : business.messagingComplianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
           ? 'Record the actual toll-free verification state and any known verification SID or blocker note.'
           : 'Record the actual messaging compliance state and any known Twilio identifiers or blocker note.',
       instructions:
@@ -466,7 +466,7 @@ export function buildAdminSetupPanels(params: {
               'Once the number type is selected, save the compliance state that matches reality.',
               'Record any known verification SID, A2P identifiers, or blocker note so the next operator has context.',
             ]
-          : business.messagingComplianceType === MessagingComplianceType.TOLL_FREE
+          : business.messagingComplianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
           ? [
               'Confirm that this business is using a toll-free number.',
               'Save the toll-free verification state that matches reality.',
@@ -482,7 +482,7 @@ export function buildAdminSetupPanels(params: {
       verification:
         business.messagingComplianceType === MessagingComplianceType.UNKNOWN
           ? ['The number type should be selected before launch readiness is evaluated.']
-          : business.messagingComplianceType === MessagingComplianceType.TOLL_FREE
+          : business.messagingComplianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
           ? [
               'The saved status should match the real Twilio toll-free verification state.',
               'If verified, the step should show Verified.',
@@ -492,7 +492,7 @@ export function buildAdminSetupPanels(params: {
       latestEvidence:
         business.messagingComplianceType === MessagingComplianceType.UNKNOWN
           ? ['No number type is selected yet.']
-          : business.messagingComplianceType === MessagingComplianceType.TOLL_FREE
+          : business.messagingComplianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
           ? [
               business.tollFreeVerificationSid ? `Verification SID: ${business.tollFreeVerificationSid}` : 'No toll-free verification SID saved.',
               business.tollFreeVerificationNote ? `Blocker note: ${business.tollFreeVerificationNote}` : 'No toll-free blocker note saved.',
@@ -505,7 +505,7 @@ export function buildAdminSetupPanels(params: {
       warnings:
         business.messagingComplianceType === MessagingComplianceType.UNKNOWN
           ? []
-          : business.messagingComplianceType === MessagingComplianceType.TOLL_FREE
+          : business.messagingComplianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
           ? business.tollFreeVerificationNote
             ? [business.tollFreeVerificationNote]
             : []
@@ -522,12 +522,12 @@ export function buildAdminSetupPanels(params: {
                 helpText: 'Choose the path that matches the actual texting number before evaluating readiness.',
               },
             ]
-          : business.messagingComplianceType === MessagingComplianceType.TOLL_FREE
+          : business.messagingComplianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
           ? [
               {
                 key: 'messagingComplianceType',
                 label: 'Number type',
-                placeholder: 'TOLL_FREE',
+                placeholder: 'TOLL_FREE_VERIFICATION',
                 helpText: 'Choose the path that matches the actual texting number.',
               },
               {
@@ -588,7 +588,7 @@ export function buildAdminSetupPanels(params: {
               },
             ],
       automaticActionLabel:
-        business.messagingComplianceType === MessagingComplianceType.TOLL_FREE
+        business.messagingComplianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
           ? 'Save toll-free verification status'
           : business.messagingComplianceType === MessagingComplianceType.LOCAL_A2P
             ? 'Save A2P status'

--- a/lib/managed-twilio-status.ts
+++ b/lib/managed-twilio-status.ts
@@ -46,7 +46,7 @@ export type ManagedTwilioSummary = {
 export const messagingComplianceTypeLabels: Record<MessagingComplianceType, string> = {
   UNKNOWN: 'Unknown / not selected',
   LOCAL_A2P: 'Local 10DLC / A2P',
-  TOLL_FREE: 'Toll-free verification',
+  TOLL_FREE_VERIFICATION: 'Toll-free verification',
 };
 
 export function getMessagingComplianceTypeLabel(type: MessagingComplianceType) {
@@ -181,7 +181,7 @@ function resolveMessagingComplianceType(
   }
 
   if (business.tollFreeVerificationSid || business.tollFreeVerificationNote) {
-    return MessagingComplianceType.TOLL_FREE;
+    return MessagingComplianceType.TOLL_FREE_VERIFICATION;
   }
 
   return MessagingComplianceType.UNKNOWN;

--- a/lib/twilio-compliance.ts
+++ b/lib/twilio-compliance.ts
@@ -34,7 +34,7 @@ export function getMessagingComplianceSidValidationError(input: {
     );
   }
 
-  if (input.messagingComplianceType === MessagingComplianceType.TOLL_FREE) {
+  if (input.messagingComplianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION) {
     return getOptionalTwilioSidError(input.tollFreeVerificationSid, 'BU', 'Toll-free verification SID');
   }
 

--- a/lib/twilio-setup.ts
+++ b/lib/twilio-setup.ts
@@ -206,7 +206,7 @@ function formatMessagingComplianceDetail(business: SetupBusiness) {
     return {
       complete: false,
       detail:
-        complianceType === MessagingComplianceType.TOLL_FREE
+        complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
           ? 'Record whether toll-free verification is not started, pending review, verified, or blocked so launch status stays truthful.'
           : 'Record whether A2P is not started, pending review, approved, or blocked so launch status stays truthful.',
       stateLabel: 'Needs update',
@@ -220,10 +220,10 @@ function formatMessagingComplianceDetail(business: SetupBusiness) {
       detail:
         complianceType === MessagingComplianceType.LOCAL_A2P && business.a2pApprovedAt
           ? `Recorded as approved on ${business.a2pApprovedAt.toLocaleDateString()}.`
-          : complianceType === MessagingComplianceType.TOLL_FREE
+          : complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
             ? 'Recorded as verified for live messaging.'
             : 'Recorded as approved for live messaging.',
-      stateLabel: complianceType === MessagingComplianceType.TOLL_FREE ? 'Verified' : 'Approved',
+      stateLabel: complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION ? 'Verified' : 'Approved',
       tone: 'success' as const,
     };
   }
@@ -293,7 +293,7 @@ export function buildTwilioSetupFlow(params: {
     liveBlockers.push(
       managedSummary.complianceTypeUnknown
         ? 'choose the number type'
-        : managedSummary.complianceType === MessagingComplianceType.TOLL_FREE
+        : managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
           ? 'clear toll-free verification'
           : 'clear A2P approval'
     );

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -4,7 +4,10 @@ import { MAX_AVERAGE_JOB_VALUE } from '@/lib/business-settings';
 
 const twilioAccountModeSchema = z.enum(['MAIN_ACCOUNT', 'BUSINESS_SUBACCOUNT']);
 const twilioNumberSetupModeSchema = z.enum(['NEW_NUMBER', 'EXISTING_NUMBER']);
-const messagingComplianceTypeSchema = z.enum(['UNKNOWN', 'LOCAL_A2P', 'TOLL_FREE_VERIFICATION']);
+const messagingComplianceTypeSchema = z.preprocess(
+  (value) => (value === 'TOLL_FREE' ? 'TOLL_FREE_VERIFICATION' : value),
+  z.enum(['UNKNOWN', 'LOCAL_A2P', 'TOLL_FREE_VERIFICATION'])
+);
 const tollFreeVerificationStatusSchema = z.enum(['NOT_STARTED', 'PENDING', 'APPROVED', 'REJECTED', 'NEEDS_UPDATE', 'NOT_APPLICABLE']);
 const averageJobValueSchema = z.preprocess(
   (value) => {

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -4,7 +4,7 @@ import { MAX_AVERAGE_JOB_VALUE } from '@/lib/business-settings';
 
 const twilioAccountModeSchema = z.enum(['MAIN_ACCOUNT', 'BUSINESS_SUBACCOUNT']);
 const twilioNumberSetupModeSchema = z.enum(['NEW_NUMBER', 'EXISTING_NUMBER']);
-const messagingComplianceTypeSchema = z.enum(['UNKNOWN', 'LOCAL_A2P', 'TOLL_FREE']);
+const messagingComplianceTypeSchema = z.enum(['UNKNOWN', 'LOCAL_A2P', 'TOLL_FREE_VERIFICATION']);
 const tollFreeVerificationStatusSchema = z.enum(['NOT_STARTED', 'PENDING', 'APPROVED', 'REJECTED', 'NEEDS_UPDATE', 'NOT_APPLICABLE']);
 const averageJobValueSchema = z.preprocess(
   (value) => {

--- a/prisma/migrations/20260523103000_add_messaging_compliance_fields/migration.sql
+++ b/prisma/migrations/20260523103000_add_messaging_compliance_fields/migration.sql
@@ -1,7 +1,7 @@
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'MessagingComplianceType') THEN
-    CREATE TYPE "MessagingComplianceType" AS ENUM ('UNKNOWN', 'LOCAL_A2P', 'TOLL_FREE');
+    CREATE TYPE "MessagingComplianceType" AS ENUM ('UNKNOWN', 'LOCAL_A2P', 'TOLL_FREE_VERIFICATION');
   END IF;
 END $$;
 

--- a/prisma/migrations/20260523161000_align_messaging_compliance_toll_free_enum/migration.sql
+++ b/prisma/migrations/20260523161000_align_messaging_compliance_toll_free_enum/migration.sql
@@ -1,0 +1,20 @@
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'MessagingComplianceType')
+     AND EXISTS (
+       SELECT 1
+       FROM pg_enum e
+       JOIN pg_type t ON e.enumtypid = t.oid
+       WHERE t.typname = 'MessagingComplianceType'
+         AND e.enumlabel = 'TOLL_FREE'
+     )
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_enum e
+       JOIN pg_type t ON e.enumtypid = t.oid
+       WHERE t.typname = 'MessagingComplianceType'
+         AND e.enumlabel = 'TOLL_FREE_VERIFICATION'
+     ) THEN
+    ALTER TYPE "MessagingComplianceType" RENAME VALUE 'TOLL_FREE' TO 'TOLL_FREE_VERIFICATION';
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -374,7 +374,7 @@ enum TwilioNumberSetupMode {
 enum MessagingComplianceType {
   UNKNOWN
   LOCAL_A2P
-  TOLL_FREE
+  TOLL_FREE_VERIFICATION
 }
 
 enum TollFreeVerificationStatus {

--- a/tests/admin-dashboard.test.ts
+++ b/tests/admin-dashboard.test.ts
@@ -170,7 +170,7 @@ test('next-step guidance supports toll-free verification and unknown number type
     business: createBusiness({
       twilioAccountMode: TwilioAccountMode.MAIN_ACCOUNT,
       twilioSubaccountSid: null,
-      messagingComplianceType: MessagingComplianceType.TOLL_FREE,
+      messagingComplianceType: MessagingComplianceType.TOLL_FREE_VERIFICATION,
       managedTwilioStatus: ManagedTwilioStatus.DRAFT,
       a2pCustomerProfileSid: null,
       a2pBrandSid: null,
@@ -454,7 +454,7 @@ test('toll-free businesses can reach ready-for-live without A2P metadata', () =>
     business: createBusiness({
       twilioAccountMode: TwilioAccountMode.MAIN_ACCOUNT,
       twilioSubaccountSid: null,
-      messagingComplianceType: MessagingComplianceType.TOLL_FREE,
+      messagingComplianceType: MessagingComplianceType.TOLL_FREE_VERIFICATION,
       managedTwilioStatus: ManagedTwilioStatus.DRAFT,
       a2pCustomerProfileSid: null,
       a2pBrandSid: null,

--- a/tests/managed-twilio-status.test.ts
+++ b/tests/managed-twilio-status.test.ts
@@ -151,7 +151,7 @@ test('failed review produces an attention-required summary', () => {
 test('verified toll-free setup becomes messaging-ready without A2P identifiers', () => {
   const summary = getManagedTwilioStatusSummary(
     createManagedBusiness({
-      messagingComplianceType: MessagingComplianceType.TOLL_FREE,
+      messagingComplianceType: MessagingComplianceType.TOLL_FREE_VERIFICATION,
       managedTwilioStatus: ManagedTwilioStatus.DRAFT,
       twilioSubaccountSid: null,
       twilioAccountMode: TwilioAccountMode.MAIN_ACCOUNT,

--- a/tests/twilio-compliance.test.ts
+++ b/tests/twilio-compliance.test.ts
@@ -64,13 +64,13 @@ test('shared helpers keep generic Twilio SID validation strict', () => {
   assert.equal(normalizeOptionalSid('   '), null);
 });
 
-test('settings save schema accepts toll-free verification enum and rejects stale toll-free enum values', () => {
+test('settings save schema accepts toll-free verification enum and normalizes stale toll-free enum values', () => {
   const valid = businessTwilioAdminOverrideSchema.safeParse({
     messagingComplianceType: 'TOLL_FREE_VERIFICATION',
     tollFreeVerificationStatus: 'APPROVED',
     tollFreeVerificationSid: 'BUd2b9b67869f08c15f570d9f81d920dad',
   });
-  const invalid = businessTwilioAdminOverrideSchema.safeParse({
+  const legacy = businessTwilioAdminOverrideSchema.safeParse({
     messagingComplianceType: 'TOLL_FREE',
     tollFreeVerificationStatus: 'APPROVED',
     tollFreeVerificationSid: 'BUd2b9b67869f08c15f570d9f81d920dad',
@@ -78,5 +78,6 @@ test('settings save schema accepts toll-free verification enum and rejects stale
 
   assert.equal(valid.success, true);
   assert.equal(valid.success && valid.data.messagingComplianceType, 'TOLL_FREE_VERIFICATION');
-  assert.equal(invalid.success, false);
+  assert.equal(legacy.success, true);
+  assert.equal(legacy.success && legacy.data.messagingComplianceType, 'TOLL_FREE_VERIFICATION');
 });

--- a/tests/twilio-compliance.test.ts
+++ b/tests/twilio-compliance.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import { MessagingComplianceType } from '@prisma/client';
 
+import { businessTwilioAdminOverrideSchema } from '../lib/validators.ts';
 import {
   getMessagingComplianceSidValidationError,
   getOptionalTwilioSidError,
@@ -11,7 +12,7 @@ import {
 
 test('toll-free compliance accepts BU verification SIDs without A2P identifiers', () => {
   const error = getMessagingComplianceSidValidationError({
-    messagingComplianceType: MessagingComplianceType.TOLL_FREE,
+    messagingComplianceType: MessagingComplianceType.TOLL_FREE_VERIFICATION,
     a2pCustomerProfileSid: null,
     a2pBrandSid: null,
     a2pCampaignSid: null,
@@ -23,7 +24,7 @@ test('toll-free compliance accepts BU verification SIDs without A2P identifiers'
 
 test('toll-free compliance ignores missing brand and campaign SIDs', () => {
   const error = getMessagingComplianceSidValidationError({
-    messagingComplianceType: MessagingComplianceType.TOLL_FREE,
+    messagingComplianceType: MessagingComplianceType.TOLL_FREE_VERIFICATION,
     a2pCustomerProfileSid: null,
     a2pBrandSid: null,
     a2pCampaignSid: null,
@@ -35,7 +36,7 @@ test('toll-free compliance ignores missing brand and campaign SIDs', () => {
 
 test('invalid toll-free verification SIDs return a friendly validation error', () => {
   const error = getMessagingComplianceSidValidationError({
-    messagingComplianceType: MessagingComplianceType.TOLL_FREE,
+    messagingComplianceType: MessagingComplianceType.TOLL_FREE_VERIFICATION,
     a2pCustomerProfileSid: null,
     a2pBrandSid: null,
     a2pCampaignSid: null,
@@ -61,4 +62,21 @@ test('shared helpers keep generic Twilio SID validation strict', () => {
   assert.equal(getOptionalTwilioSidError('PN123', 'PN', 'Twilio number SID'), 'Twilio number SID must be a valid Twilio SID starting with PN.');
   assert.equal(getOptionalTwilioSidError('PNd2b9b67869f08c15f570d9f81d920dad', 'PN', 'Twilio number SID'), null);
   assert.equal(normalizeOptionalSid('   '), null);
+});
+
+test('settings save schema accepts toll-free verification enum and rejects stale toll-free enum values', () => {
+  const valid = businessTwilioAdminOverrideSchema.safeParse({
+    messagingComplianceType: 'TOLL_FREE_VERIFICATION',
+    tollFreeVerificationStatus: 'APPROVED',
+    tollFreeVerificationSid: 'BUd2b9b67869f08c15f570d9f81d920dad',
+  });
+  const invalid = businessTwilioAdminOverrideSchema.safeParse({
+    messagingComplianceType: 'TOLL_FREE',
+    tollFreeVerificationStatus: 'APPROVED',
+    tollFreeVerificationSid: 'BUd2b9b67869f08c15f570d9f81d920dad',
+  });
+
+  assert.equal(valid.success, true);
+  assert.equal(valid.success && valid.data.messagingComplianceType, 'TOLL_FREE_VERIFICATION');
+  assert.equal(invalid.success, false);
 });

--- a/tests/twilio-setup-flow.test.ts
+++ b/tests/twilio-setup-flow.test.ts
@@ -141,7 +141,7 @@ test('messaging compliance step switches to toll-free verification copy', () => 
     business: createBusiness({
       twilioAccountMode: TwilioAccountMode.MAIN_ACCOUNT,
       twilioSubaccountSid: null,
-      messagingComplianceType: MessagingComplianceType.TOLL_FREE,
+      messagingComplianceType: MessagingComplianceType.TOLL_FREE_VERIFICATION,
       managedTwilioStatus: ManagedTwilioStatus.DRAFT,
       a2pCustomerProfileSid: null,
       a2pBrandSid: null,


### PR DESCRIPTION
## Summary
- align `MessagingComplianceType` with the live Postgres enum value `TOLL_FREE_VERIFICATION`
- normalize legacy `TOLL_FREE` form input on the server before Prisma writes
- keep toll-free verification separate from A2P requirements and preserve existing readiness behavior

## Root cause
Production Postgres accepts `UNKNOWN`, `LOCAL_A2P`, and `TOLL_FREE_VERIFICATION`, but `main` still submitted `TOLL_FREE` from the messaging compliance form and related server-side paths. That let `TOLL_FREE` reach `prisma.business.update()` and caused Postgres `22P02` enum failures.

## What changed
- updated Prisma schema and checked-in migration history to use `TOLL_FREE_VERIFICATION`
- added a safe enum-alignment migration that renames legacy `TOLL_FREE` to `TOLL_FREE_VERIFICATION` only when needed
- updated UI, validators, shared readiness helpers, and tests to use `TOLL_FREE_VERIFICATION`
- added server-side preprocessing so legacy `TOLL_FREE` inputs are normalized before Prisma updates

## Validation
- `npx prisma generate`
- `npx prisma migrate deploy`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run vercel-build`
