### PR TITLE
Hotfix test SMS NEXT_REDIRECT handling

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -1755,7 +1755,14 @@ export async function sendBusinessTestSmsAction(formData: FormData) {
     redirectToBusinessActionError(formData, 'Business not found.', returnStep);
   }
 
-  const destinationPhone = normalizeOptionalE164Phone(parsed.data.destinationPhone, 'Test SMS destination');
+  let destinationPhone: string | null;
+  try {
+    destinationPhone = normalizeOptionalE164Phone(parsed.data.destinationPhone, 'Test SMS destination');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid test SMS destination.';
+    redirectToBusinessActionError(formData, message, returnStep);
+  }
+
   const fromPhone = business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber;
   if (!fromPhone) {
     redirect(
@@ -1765,6 +1772,8 @@ export async function sendBusinessTestSmsAction(formData: FormData) {
       )
     );
   }
+
+  let redirectPath = buildAdminBusinessRedirectPath(business.id, withReturnStepParam({ testSms: 1 }, returnStep));
 
   try {
     await recordBusinessOperatorEvent({
@@ -1803,46 +1812,45 @@ export async function sendBusinessTestSmsAction(formData: FormData) {
           reason: result.reason,
         },
       });
-      redirect(
-        buildAdminBusinessRedirectPath(business.id, {
-          ...withReturnStepParam(
-            {
-              error: `Test SMS was suppressed: ${result.reason.replace(/_/g, ' ')}.`,
-            },
-            returnStep
-          ),
-        })
+      redirectPath = buildAdminBusinessRedirectPath(
+        business.id,
+        withReturnStepParam(
+          {
+            error: `Test SMS was suppressed: ${result.reason.replace(/_/g, ' ')}.`,
+          },
+          returnStep
+        )
       );
+    } else {
+      await recordBusinessOperatorEvent({
+        businessId: business.id,
+        type: 'admin.test_sms_accepted',
+        category: 'ADMIN_ACTIONS',
+        status: 'SUCCESS',
+        summary: 'Test SMS accepted by Twilio',
+        details: {
+          destinationPhone: formatPhoneDetail(destinationPhone),
+          fromPhone: formatPhoneDetail(fromPhone),
+          messageSid: maskSid(result.sent.sid),
+        },
+        relatedEntityType: 'message',
+        relatedEntityId: result.message.id,
+      });
+
+      logAuditEvent({
+        event: 'admin_test_sms_sent',
+        actorType: 'user',
+        actorId: admin.userId,
+        businessId: business.id,
+        targetType: 'business',
+        targetId: business.id,
+        metadata: {
+          actorEmail: admin.email,
+          destinationPhone: maskPhoneForAudit(destinationPhone),
+          messageSid: result.sent.sid,
+        },
+      });
     }
-
-    await recordBusinessOperatorEvent({
-      businessId: business.id,
-      type: 'admin.test_sms_accepted',
-      category: 'ADMIN_ACTIONS',
-      status: 'SUCCESS',
-      summary: 'Test SMS accepted by Twilio',
-      details: {
-        destinationPhone: formatPhoneDetail(destinationPhone),
-        fromPhone: formatPhoneDetail(fromPhone),
-        messageSid: maskSid(result.sent.sid),
-      },
-      relatedEntityType: 'message',
-      relatedEntityId: result.message.id,
-    });
-
-    logAuditEvent({
-      event: 'admin_test_sms_sent',
-      actorType: 'user',
-      actorId: admin.userId,
-      businessId: business.id,
-      targetType: 'business',
-      targetId: business.id,
-      metadata: {
-        actorEmail: admin.email,
-        destinationPhone: maskPhoneForAudit(destinationPhone),
-        messageSid: result.sent.sid,
-      },
-    });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to send test SMS.';
     await recordBusinessOperatorEvent({
@@ -1856,11 +1864,14 @@ export async function sendBusinessTestSmsAction(formData: FormData) {
         error: message,
       },
     });
-    redirect(buildAdminBusinessRedirectPath(business.id, withReturnStepParam({ error: message }, returnStep)));
+    redirectPath = buildAdminBusinessRedirectPath(
+      business.id,
+      withReturnStepParam({ error: `Test SMS failed: ${message}` }, returnStep)
+    );
   }
 
   await revalidateAdminPaths(business.id);
-  redirect(buildAdminBusinessRedirectPath(business.id, withReturnStepParam({ testSms: 1 }, returnStep)));
+  redirect(redirectPath);
 }
 
 export async function archiveBusinessAction(formData: FormData) {

--- a/app/app/settings/actions.ts
+++ b/app/app/settings/actions.ts
@@ -395,11 +395,20 @@ export async function sendBusinessTwilioTestSmsAction(formData: FormData) {
     redirect(`/app/settings?error=${encodeURIComponent(parsed.error.issues[0]?.message || 'Invalid test SMS destination')}`);
   }
 
-  const destinationPhone = normalizeOptionalE164Phone(parsed.data.destinationPhone, 'Test SMS destination');
+  let destinationPhone: string | null;
+  try {
+    destinationPhone = normalizeOptionalE164Phone(parsed.data.destinationPhone, 'Test SMS destination');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid test SMS destination';
+    redirect(`/app/settings?error=${encodeURIComponent(message)}`);
+  }
+
   const fromPhone = business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber;
   if (!fromPhone) {
     redirect('/app/settings?error=Assign%20a%20business%20number%20before%20sending%20a%20test%20SMS');
   }
+
+  let redirectPath = '/app/settings?twilioTestSms=1';
 
   try {
     await recordBusinessOperatorEvent({
@@ -439,23 +448,23 @@ export async function sendBusinessTwilioTestSmsAction(formData: FormData) {
           reason: result.reason,
         },
       });
-      redirect(`/app/settings?error=${encodeURIComponent(`Test SMS was suppressed: ${result.reason.replace(/_/g, ' ')}.`)}`);
+      redirectPath = `/app/settings?error=${encodeURIComponent(`Test SMS was suppressed: ${result.reason.replace(/_/g, ' ')}.`)}`;
+    } else {
+      await recordBusinessOperatorEvent({
+        businessId: business.id,
+        type: 'admin.test_sms_accepted',
+        category: 'ADMIN_ACTIONS',
+        status: 'SUCCESS',
+        summary: 'Test SMS accepted by Twilio',
+        details: {
+          destinationPhone: formatPhoneDetail(destinationPhone),
+          fromPhone: formatPhoneDetail(fromPhone),
+          messageSid: maskSid(result.sent.sid),
+        },
+        relatedEntityType: 'message',
+        relatedEntityId: result.message.id,
+      });
     }
-
-    await recordBusinessOperatorEvent({
-      businessId: business.id,
-      type: 'admin.test_sms_accepted',
-      category: 'ADMIN_ACTIONS',
-      status: 'SUCCESS',
-      summary: 'Test SMS accepted by Twilio',
-      details: {
-        destinationPhone: formatPhoneDetail(destinationPhone),
-        fromPhone: formatPhoneDetail(fromPhone),
-        messageSid: maskSid(result.sent.sid),
-      },
-      relatedEntityType: 'message',
-      relatedEntityId: result.message.id,
-    });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Test SMS failed';
     await recordBusinessOperatorEvent({
@@ -468,11 +477,11 @@ export async function sendBusinessTwilioTestSmsAction(formData: FormData) {
         error: message,
       },
     });
-    redirect(`/app/settings?error=${encodeURIComponent(message)}`);
+    redirectPath = `/app/settings?error=${encodeURIComponent(`Test SMS failed: ${message}`)}`;
   }
 
   revalidatePath('/app/settings');
-  redirect('/app/settings?twilioTestSms=1');
+  redirect(redirectPath);
 }
 
 export async function buyTwilioNumberAction(formData: FormData) {

--- a/tests/test-sms-action-redirects.test.ts
+++ b/tests/test-sms-action-redirects.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+function read(path: string) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+function getActionSection(source: string, actionName: string, nextActionName: string) {
+  const actionStart = source.indexOf(`export async function ${actionName}`);
+  const nextActionStart = source.indexOf(`export async function ${nextActionName}`);
+  return source.slice(actionStart, nextActionStart);
+}
+
+test('customer test SMS action keeps redirect outside the catchable try/catch and shows friendly errors', () => {
+  const settingsActions = read('app/app/settings/actions.ts');
+  const actionSection = getActionSection(settingsActions, 'sendBusinessTwilioTestSmsAction', 'buyTwilioNumberAction');
+  const redirectPathStart = actionSection.indexOf("let redirectPath = '/app/settings?twilioTestSms=1';");
+  const tryStart = actionSection.indexOf('\n  try {', redirectPathStart);
+  const catchStart = actionSection.lastIndexOf('} catch (error) {');
+  const finalRedirectStart = actionSection.lastIndexOf('\n\n  revalidatePath(\'/app/settings\');\n  redirect(redirectPath);');
+  const catchSection = actionSection.slice(catchStart, finalRedirectStart);
+  const trySection = actionSection.slice(tryStart, catchStart);
+
+  assert.notEqual(redirectPathStart, -1);
+  assert.notEqual(tryStart, -1);
+  assert.notEqual(catchStart, -1);
+  assert.notEqual(finalRedirectStart, -1);
+  assert.match(actionSection, /let redirectPath = '\/app\/settings\?twilioTestSms=1'/);
+  assert.match(actionSection, /Test SMS was suppressed:/);
+  assert.match(actionSection, /Test SMS failed:/);
+  assert.doesNotMatch(catchSection, /redirect\(/);
+  assert.doesNotMatch(trySection, /redirect\(/);
+});
+
+test('admin test SMS action keeps redirect outside the catchable try/catch and shows friendly errors', () => {
+  const adminActions = read('app/admin/actions.ts');
+  const actionSection = getActionSection(adminActions, 'sendBusinessTestSmsAction', 'archiveBusinessAction');
+  const redirectPathStart = actionSection.indexOf('let redirectPath = buildAdminBusinessRedirectPath');
+  const tryStart = actionSection.indexOf('\n  try {', redirectPathStart);
+  const catchStart = actionSection.lastIndexOf('} catch (error) {');
+  const finalRedirectStart = actionSection.lastIndexOf('\n\n  await revalidateAdminPaths(business.id);\n  redirect(redirectPath);');
+  const catchSection = actionSection.slice(catchStart, finalRedirectStart);
+  const trySection = actionSection.slice(tryStart, catchStart);
+
+  assert.notEqual(redirectPathStart, -1);
+  assert.notEqual(tryStart, -1);
+  assert.notEqual(catchStart, -1);
+  assert.notEqual(finalRedirectStart, -1);
+  assert.match(actionSection, /let redirectPath = buildAdminBusinessRedirectPath\(business\.id, withReturnStepParam\(\{ testSms: 1 \}, returnStep\)\)/);
+  assert.match(actionSection, /Test SMS was suppressed:/);
+  assert.match(actionSection, /Test SMS failed:/);
+  assert.doesNotMatch(catchSection, /redirect\(/);
+  assert.doesNotMatch(trySection, /redirect\(/);
+});


### PR DESCRIPTION
## Summary
- fix customer and admin test SMS actions so `redirect()` is not caught and surfaced as `NEXT_REDIRECT`
- keep friendly user-facing errors for validation failures, suppressed sends, and Twilio send failures
- add regression tests that lock in the safe redirect pattern for both test SMS actions

## Root cause
Both test SMS server actions called `redirect()` inside a `try` block and then caught the special Next.js redirect signal as if it were a normal error. That caused the UI to surface `NEXT_REDIRECT` instead of redirecting cleanly.

## What changed
- moved test SMS actions to compute `redirectPath` inside the `try/catch` and call `redirect()` only after the catchable region
- converted invalid destination phone normalization into normal user-facing error redirects
- changed failure copy to `Test SMS failed: ...` and preserved a friendly suppressed-send message
- added regression tests ensuring the main send `try/catch` blocks do not contain `redirect()`

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run vercel-build`
