### PR TITLE
Fix toll-free test SMS readiness gate

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -46,6 +46,7 @@ import {
   getBusinessTwilioSaveErrorMessage,
   getMessagingComplianceSidValidationError,
   getOptionalTwilioSidError,
+  getTestSmsSuppressionMessage,
   normalizeOptionalSid,
 } from '@/lib/twilio-compliance';
 import { sendAndPersistOutboundMessage } from '@/lib/twilio-messaging';
@@ -1798,6 +1799,10 @@ export async function sendBusinessTestSmsAction(formData: FormData) {
       messagingServiceSid: business.twilioMessagingServiceSid,
       managedTwilioStatus: business.managedTwilioStatus,
       a2pFailureReason: business.a2pFailureReason,
+      messagingComplianceType: business.messagingComplianceType,
+      tollFreeVerificationStatus: business.tollFreeVerificationStatus,
+      tollFreeVerificationSid: business.tollFreeVerificationSid,
+      tollFreeVerificationNote: business.tollFreeVerificationNote,
     });
 
     if (result.suppressed) {
@@ -1816,7 +1821,7 @@ export async function sendBusinessTestSmsAction(formData: FormData) {
         business.id,
         withReturnStepParam(
           {
-            error: `Test SMS was suppressed: ${result.reason.replace(/_/g, ' ')}.`,
+            error: getTestSmsSuppressionMessage(result.reason),
           },
           returnStep
         )

--- a/app/api/twilio/status/route.ts
+++ b/app/api/twilio/status/route.ts
@@ -426,6 +426,10 @@ export async function POST(request: Request) {
               messagingServiceSid: business.twilioMessagingServiceSid,
               managedTwilioStatus: business.managedTwilioStatus,
               a2pFailureReason: business.a2pFailureReason,
+              messagingComplianceType: business.messagingComplianceType,
+              tollFreeVerificationStatus: business.tollFreeVerificationStatus,
+              tollFreeVerificationSid: business.tollFreeVerificationSid,
+              tollFreeVerificationNote: business.tollFreeVerificationNote,
             });
             if (notifyResult.suppressed) {
               logTwilioWarn('status', 'usage_limit_owner_notify_suppressed', {
@@ -435,7 +439,7 @@ export async function POST(request: Request) {
                 eventType: 'dial_status_callback',
                 businessId: business.id,
                 leadId: lead.id,
-                decision: 'owner_notification_suppressed_opted_out',
+                decision: notifyResult.reason,
               });
               return withCorrelation(xmlOk());
             }

--- a/app/app/settings/actions.ts
+++ b/app/app/settings/actions.ts
@@ -23,6 +23,7 @@ import {
   getBusinessTwilioSaveErrorMessage,
   getMessagingComplianceSidValidationError,
   getOptionalTwilioSidError,
+  getTestSmsSuppressionMessage,
   normalizeOptionalSid,
 } from '@/lib/twilio-compliance';
 import { getTwilioBusinessClient } from '@/lib/twilio-client';
@@ -434,6 +435,10 @@ export async function sendBusinessTwilioTestSmsAction(formData: FormData) {
       messagingServiceSid: business.twilioMessagingServiceSid,
       managedTwilioStatus: business.managedTwilioStatus,
       a2pFailureReason: business.a2pFailureReason,
+      messagingComplianceType: business.messagingComplianceType,
+      tollFreeVerificationStatus: business.tollFreeVerificationStatus,
+      tollFreeVerificationSid: business.tollFreeVerificationSid,
+      tollFreeVerificationNote: business.tollFreeVerificationNote,
     });
 
     if (result.suppressed) {
@@ -448,7 +453,7 @@ export async function sendBusinessTwilioTestSmsAction(formData: FormData) {
           reason: result.reason,
         },
       });
-      redirectPath = `/app/settings?error=${encodeURIComponent(`Test SMS was suppressed: ${result.reason.replace(/_/g, ' ')}.`)}`;
+      redirectPath = `/app/settings?error=${encodeURIComponent(getTestSmsSuppressionMessage(result.reason))}`;
     } else {
       await recordBusinessOperatorEvent({
         businessId: business.id,

--- a/lib/missed-call-flow.ts
+++ b/lib/missed-call-flow.ts
@@ -21,7 +21,11 @@ type LeadFlowBusiness = Pick<
   | 'twilioPhoneNumber'
   | 'twilioPrimaryPhoneNumber'
   | 'managedTwilioStatus'
+  | 'messagingComplianceType'
   | 'a2pFailureReason'
+  | 'tollFreeVerificationStatus'
+  | 'tollFreeVerificationSid'
+  | 'tollFreeVerificationNote'
   | 'subscriptionStatus'
   | 'provisioningStatus'
   | 'archivedAt'
@@ -67,6 +71,10 @@ async function deliverLeadMessage(params: {
   twilioMessagingServiceSid?: string | null;
   managedTwilioStatus?: Business['managedTwilioStatus'];
   a2pFailureReason?: string | null;
+  messagingComplianceType?: Business['messagingComplianceType'];
+  tollFreeVerificationStatus?: Business['tollFreeVerificationStatus'];
+  tollFreeVerificationSid?: string | null;
+  tollFreeVerificationNote?: string | null;
 }) {
   if (params.transport === 'simulated' || params.isSimulator) {
     const message = await persistOutboundMessageRecord({
@@ -91,6 +99,10 @@ async function deliverLeadMessage(params: {
     messagingServiceSid: params.twilioMessagingServiceSid,
     managedTwilioStatus: params.managedTwilioStatus,
     a2pFailureReason: params.a2pFailureReason,
+    messagingComplianceType: params.messagingComplianceType,
+    tollFreeVerificationStatus: params.tollFreeVerificationStatus,
+    tollFreeVerificationSid: params.tollFreeVerificationSid,
+    tollFreeVerificationNote: params.tollFreeVerificationNote,
   });
 }
 
@@ -185,6 +197,10 @@ export async function startMissedCallRecovery(params: StartRecoveryParams) {
     twilioMessagingServiceSid: params.business.twilioMessagingServiceSid,
     managedTwilioStatus: params.business.managedTwilioStatus,
     a2pFailureReason: params.business.a2pFailureReason,
+    messagingComplianceType: params.business.messagingComplianceType,
+    tollFreeVerificationStatus: params.business.tollFreeVerificationStatus,
+    tollFreeVerificationSid: params.business.tollFreeVerificationSid,
+    tollFreeVerificationNote: params.business.tollFreeVerificationNote,
   });
 
   if (!sendResult.suppressed) {
@@ -283,6 +299,10 @@ export async function processLeadInboundReply(params: ProcessReplyParams) {
     twilioMessagingServiceSid: params.business.twilioMessagingServiceSid,
     managedTwilioStatus: params.business.managedTwilioStatus,
     a2pFailureReason: params.business.a2pFailureReason,
+    messagingComplianceType: params.business.messagingComplianceType,
+    tollFreeVerificationStatus: params.business.tollFreeVerificationStatus,
+    tollFreeVerificationSid: params.business.tollFreeVerificationSid,
+    tollFreeVerificationNote: params.business.tollFreeVerificationNote,
   });
 
   if (!sendResult.suppressed) {

--- a/lib/owner-notifications.ts
+++ b/lib/owner-notifications.ts
@@ -25,7 +25,11 @@ type NotificationLeadRecord = Lead & {
     | 'twilioPrimaryPhoneNumber'
     | 'twilioPhoneNumber'
     | 'managedTwilioStatus'
+    | 'messagingComplianceType'
     | 'a2pFailureReason'
+    | 'tollFreeVerificationStatus'
+    | 'tollFreeVerificationSid'
+    | 'tollFreeVerificationNote'
   >;
 };
 
@@ -140,7 +144,11 @@ async function getLeadForOwnerNotifications(leadId: string) {
           twilioPrimaryPhoneNumber: true,
           twilioPhoneNumber: true,
           managedTwilioStatus: true,
+          messagingComplianceType: true,
           a2pFailureReason: true,
+          tollFreeVerificationStatus: true,
+          tollFreeVerificationSid: true,
+          tollFreeVerificationNote: true,
           provisioningStatus: true,
           archivedAt: true,
         },
@@ -240,6 +248,10 @@ export async function sendOwnerLeadSms(leadId: string) {
       messagingServiceSid: lead.business.twilioMessagingServiceSid,
       managedTwilioStatus: lead.business.managedTwilioStatus,
       a2pFailureReason: lead.business.a2pFailureReason,
+      messagingComplianceType: lead.business.messagingComplianceType,
+      tollFreeVerificationStatus: lead.business.tollFreeVerificationStatus,
+      tollFreeVerificationSid: lead.business.tollFreeVerificationSid,
+      tollFreeVerificationNote: lead.business.tollFreeVerificationNote,
     });
 
     if (result.suppressed) {

--- a/lib/simulator.ts
+++ b/lib/simulator.ts
@@ -51,7 +51,11 @@ export async function getSimulatorBusiness() {
       twilioPhoneNumber: true,
       twilioPrimaryPhoneNumber: true,
       managedTwilioStatus: true,
+      messagingComplianceType: true,
       a2pFailureReason: true,
+      tollFreeVerificationStatus: true,
+      tollFreeVerificationSid: true,
+      tollFreeVerificationNote: true,
       subscriptionStatus: true,
       provisioningStatus: true,
       archivedAt: true,
@@ -87,7 +91,11 @@ export async function getSimulatorRun(publicId: string) {
           twilioPhoneNumber: true,
           twilioPrimaryPhoneNumber: true,
           managedTwilioStatus: true,
+          messagingComplianceType: true,
           a2pFailureReason: true,
+          tollFreeVerificationStatus: true,
+          tollFreeVerificationSid: true,
+          tollFreeVerificationNote: true,
           provisioningStatus: true,
           archivedAt: true,
           serviceLabel1: true,
@@ -111,7 +119,11 @@ export type SimulatorRunRecord = SimulatorRun & {
     | 'twilioPhoneNumber'
     | 'twilioPrimaryPhoneNumber'
     | 'managedTwilioStatus'
+    | 'messagingComplianceType'
     | 'a2pFailureReason'
+    | 'tollFreeVerificationStatus'
+    | 'tollFreeVerificationSid'
+    | 'tollFreeVerificationNote'
     | 'provisioningStatus'
     | 'archivedAt'
     | 'serviceLabel1'

--- a/lib/twilio-compliance.ts
+++ b/lib/twilio-compliance.ts
@@ -1,4 +1,6 @@
-import { MessagingComplianceType, Prisma } from '@prisma/client';
+import { ManagedTwilioStatus, MessagingComplianceType, Prisma, TollFreeVerificationStatus } from '@prisma/client';
+
+import { getManagedTwilioStatusSummary } from '@/lib/managed-twilio-status';
 
 const TWILIO_SID_BODY = '[0-9a-fA-F]{32}';
 
@@ -39,6 +41,123 @@ export function getMessagingComplianceSidValidationError(input: {
   }
 
   return null;
+}
+
+export type OutboundMessagingSuppressionReason =
+  | 'recipient_opted_out'
+  | 'messaging_compliance_type_required'
+  | 'a2p_compliance_pending'
+  | 'a2p_compliance_blocked'
+  | 'toll_free_verification_required'
+  | 'toll_free_verification_pending'
+  | 'toll_free_verification_blocked';
+
+export type OutboundMessagingComplianceGate = {
+  reason: Exclude<OutboundMessagingSuppressionReason, 'recipient_opted_out'>;
+  detail: string;
+  nextStep: string;
+};
+
+export function getOutboundMessagingComplianceGate(input: {
+  twilioSubaccountSid?: string | null;
+  messagingServiceSid?: string | null;
+  managedTwilioStatus?: ManagedTwilioStatus | null;
+  a2pFailureReason?: string | null;
+  messagingComplianceType?: MessagingComplianceType | null;
+  tollFreeVerificationStatus?: TollFreeVerificationStatus | null;
+  tollFreeVerificationSid?: string | null;
+  tollFreeVerificationNote?: string | null;
+}) {
+  const summary = getManagedTwilioStatusSummary({
+    managedTwilioStatus: input.managedTwilioStatus ?? ManagedTwilioStatus.DRAFT,
+    twilioAccountMode: input.twilioSubaccountSid ? 'BUSINESS_SUBACCOUNT' : 'MAIN_ACCOUNT',
+    twilioSubaccountSid: input.twilioSubaccountSid ?? null,
+    twilioPrimaryPhoneNumber: null,
+    twilioPhoneNumber: null,
+    twilioPrimaryNumberSid: null,
+    twilioPhoneNumberSid: null,
+    twilioMessagingServiceSid: input.messagingServiceSid ?? null,
+    twilioWebhookSyncedAt: null,
+    messagingComplianceType: input.messagingComplianceType ?? MessagingComplianceType.UNKNOWN,
+    a2pFailureReason: input.a2pFailureReason ?? null,
+    a2pApprovedAt: null,
+    a2pCampaignSid: null,
+    a2pBrandSid: null,
+    a2pCustomerProfileSid: null,
+    tollFreeVerificationStatus: input.tollFreeVerificationStatus ?? TollFreeVerificationStatus.NOT_STARTED,
+    tollFreeVerificationSid: input.tollFreeVerificationSid ?? null,
+    tollFreeVerificationNote: input.tollFreeVerificationNote ?? null,
+  });
+
+  if (summary.complianceReady) {
+    return null;
+  }
+
+  if (summary.complianceTypeUnknown) {
+    return {
+      reason: 'messaging_compliance_type_required',
+      detail: 'Choose number type before live messaging can be evaluated.',
+      nextStep: summary.nextStep,
+    } satisfies OutboundMessagingComplianceGate;
+  }
+
+  if (summary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION) {
+    if (summary.attentionRequired) {
+      return {
+        reason: 'toll_free_verification_blocked',
+        detail: 'Resolve the toll-free verification issue before live messaging resumes.',
+        nextStep: summary.nextStep,
+      } satisfies OutboundMessagingComplianceGate;
+    }
+
+    if (summary.compliancePendingReview) {
+      return {
+        reason: 'toll_free_verification_pending',
+        detail: 'Toll-free verification is pending Twilio review.',
+        nextStep: summary.nextStep,
+      } satisfies OutboundMessagingComplianceGate;
+    }
+
+    return {
+      reason: 'toll_free_verification_required',
+      detail: 'Record the toll-free verification status before live messaging starts.',
+      nextStep: summary.nextStep,
+    } satisfies OutboundMessagingComplianceGate;
+  }
+
+  if (summary.attentionRequired) {
+    return {
+      reason: 'a2p_compliance_blocked',
+      detail: 'Resolve the A2P compliance issue before live messaging resumes.',
+      nextStep: summary.nextStep,
+    } satisfies OutboundMessagingComplianceGate;
+  }
+
+  return {
+    reason: 'a2p_compliance_pending',
+    detail: 'A2P approval is still pending.',
+    nextStep: summary.nextStep,
+  } satisfies OutboundMessagingComplianceGate;
+}
+
+export function getTestSmsSuppressionMessage(reason: OutboundMessagingSuppressionReason) {
+  switch (reason) {
+    case 'recipient_opted_out':
+      return 'Test SMS was suppressed because that destination has opted out of SMS.';
+    case 'messaging_compliance_type_required':
+      return 'Choose number type before sending a live test SMS.';
+    case 'toll_free_verification_required':
+    case 'toll_free_verification_pending':
+      return 'Test SMS is blocked until toll-free verification is approved.';
+    case 'toll_free_verification_blocked':
+      return 'Test SMS is blocked until the toll-free verification issue is resolved.';
+    case 'a2p_compliance_blocked':
+      return 'Test SMS is blocked until the A2P compliance issue is resolved.';
+    case 'a2p_compliance_pending':
+      return 'Test SMS is blocked until A2P approval is complete.';
+    default:
+      return 'Unable to send the test SMS until messaging compliance is ready.';
+  }
 }
 
 function getUniqueTarget(error: Prisma.PrismaClientKnownRequestError) {

--- a/lib/twilio-messaging.ts
+++ b/lib/twilio-messaging.ts
@@ -1,10 +1,10 @@
 import { ManagedTwilioStatus, MessageParticipant, MessagingComplianceType, Prisma, TollFreeVerificationStatus } from '@prisma/client';
 
 import { db } from '@/lib/db';
-import { getManagedTwilioStatusSummary } from '@/lib/managed-twilio';
 import { type OutboundMessageContext } from '@/lib/outbound-message-events';
 import { formatPhoneDetail, recordBusinessOperatorEvent } from '@/lib/operator-events';
 import { normalizePhoneNumber } from '@/lib/phone';
+import { getOutboundMessagingComplianceGate, type OutboundMessagingSuppressionReason } from '@/lib/twilio-compliance';
 import { logTwilioError, logTwilioInfo, logTwilioWarn } from '@/lib/twilio-logging';
 import { isSmsRecipientOptedOut } from '@/lib/twilio-sms-compliance';
 import { getTwilioBusinessClient, getTwilioMessageStatusCallbackUrl } from '@/lib/twilio';
@@ -83,6 +83,10 @@ export async function sendAndPersistOutboundMessage(params: {
   messagingServiceSid?: string | null;
   managedTwilioStatus?: ManagedTwilioStatus | null;
   a2pFailureReason?: string | null;
+  messagingComplianceType?: MessagingComplianceType | null;
+  tollFreeVerificationStatus?: TollFreeVerificationStatus | null;
+  tollFreeVerificationSid?: string | null;
+  tollFreeVerificationNote?: string | null;
   allowUnapproved?: boolean;
 }) {
   const from = normalizePhoneNumber(params.fromPhone) || params.fromPhone;
@@ -120,38 +124,20 @@ export async function sendAndPersistOutboundMessage(params: {
     };
   }
 
-  if (
-    !params.allowUnapproved &&
-    typeof params.managedTwilioStatus === 'string' &&
-    params.managedTwilioStatus !== ManagedTwilioStatus.COMPLIANT_LIVE
-  ) {
-    const managedSummary = getManagedTwilioStatusSummary({
-      managedTwilioStatus: params.managedTwilioStatus,
-      twilioAccountMode: params.twilioSubaccountSid ? 'BUSINESS_SUBACCOUNT' : 'MAIN_ACCOUNT',
-      twilioSubaccountSid: params.twilioSubaccountSid ?? null,
-      twilioPrimaryPhoneNumber: from,
-      twilioPhoneNumber: from,
-      twilioPrimaryNumberSid: null,
-      twilioPhoneNumberSid: null,
-      twilioMessagingServiceSid: params.messagingServiceSid ?? null,
-      twilioWebhookSyncedAt: null,
-      messagingComplianceType: MessagingComplianceType.LOCAL_A2P,
-      a2pFailureReason: params.a2pFailureReason ?? null,
-      a2pApprovedAt: null,
-      a2pCampaignSid: null,
-      a2pBrandSid: null,
-      a2pCustomerProfileSid: null,
-      tollFreeVerificationStatus: TollFreeVerificationStatus.NOT_STARTED,
-      tollFreeVerificationSid: null,
-      tollFreeVerificationNote: null,
-    });
+  const complianceGate = params.allowUnapproved
+    ? null
+    : getOutboundMessagingComplianceGate({
+        twilioSubaccountSid: params.twilioSubaccountSid,
+        messagingServiceSid: params.messagingServiceSid,
+        managedTwilioStatus: params.managedTwilioStatus,
+        a2pFailureReason: params.a2pFailureReason,
+        messagingComplianceType: params.messagingComplianceType,
+        tollFreeVerificationStatus: params.tollFreeVerificationStatus,
+        tollFreeVerificationSid: params.tollFreeVerificationSid,
+        tollFreeVerificationNote: params.tollFreeVerificationNote,
+      });
 
-    const reason =
-      params.managedTwilioStatus === ManagedTwilioStatus.FAILED_REVIEW ||
-      params.managedTwilioStatus === ManagedTwilioStatus.PAUSED_NONCOMPLIANT
-        ? 'managed_twilio_compliance_blocked'
-        : 'managed_twilio_compliance_pending';
-
+  if (complianceGate) {
     await recordBusinessOperatorEvent({
       businessId: params.businessId,
       type: 'messaging.outbound_sms_suppressed',
@@ -159,24 +145,26 @@ export async function sendAndPersistOutboundMessage(params: {
       status: 'WARNING',
       summary: `Outbound ${recipientLabel} suppressed`,
       details: {
-        reason,
+        reason: complianceGate.reason,
         participant,
-        nextStep: managedSummary.nextStep,
+        detail: complianceGate.detail,
+        nextStep: complianceGate.nextStep,
       },
       relatedEntityType: params.leadId ? 'lead' : null,
       relatedEntityId: params.leadId ?? null,
     });
     logTwilioWarn('messaging', 'outbound_suppressed_managed_twilio_not_ready', {
-      decision: reason,
+      decision: complianceGate.reason,
       businessId: params.businessId,
       leadId: params.leadId ?? null,
       participant,
-      nextStep: managedSummary.nextStep,
+      nextStep: complianceGate.nextStep,
     });
 
     return {
       suppressed: true as const,
-      reason,
+      reason: complianceGate.reason as OutboundMessagingSuppressionReason,
+      detail: complianceGate.detail,
     };
   }
 

--- a/tests/test-sms-action-redirects.test.ts
+++ b/tests/test-sms-action-redirects.test.ts
@@ -27,7 +27,7 @@ test('customer test SMS action keeps redirect outside the catchable try/catch an
   assert.notEqual(catchStart, -1);
   assert.notEqual(finalRedirectStart, -1);
   assert.match(actionSection, /let redirectPath = '\/app\/settings\?twilioTestSms=1'/);
-  assert.match(actionSection, /Test SMS was suppressed:/);
+  assert.match(actionSection, /getTestSmsSuppressionMessage\(result\.reason\)/);
   assert.match(actionSection, /Test SMS failed:/);
   assert.doesNotMatch(catchSection, /redirect\(/);
   assert.doesNotMatch(trySection, /redirect\(/);
@@ -48,7 +48,7 @@ test('admin test SMS action keeps redirect outside the catchable try/catch and s
   assert.notEqual(catchStart, -1);
   assert.notEqual(finalRedirectStart, -1);
   assert.match(actionSection, /let redirectPath = buildAdminBusinessRedirectPath\(business\.id, withReturnStepParam\(\{ testSms: 1 \}, returnStep\)\)/);
-  assert.match(actionSection, /Test SMS was suppressed:/);
+  assert.match(actionSection, /getTestSmsSuppressionMessage\(result\.reason\)/);
   assert.match(actionSection, /Test SMS failed:/);
   assert.doesNotMatch(catchSection, /redirect\(/);
   assert.doesNotMatch(trySection, /redirect\(/);

--- a/tests/twilio-compliance.test.ts
+++ b/tests/twilio-compliance.test.ts
@@ -1,12 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { MessagingComplianceType } from '@prisma/client';
+import { ManagedTwilioStatus, MessagingComplianceType, TollFreeVerificationStatus } from '@prisma/client';
 
 import { businessTwilioAdminOverrideSchema } from '../lib/validators.ts';
 import {
+  getOutboundMessagingComplianceGate,
   getMessagingComplianceSidValidationError,
   getOptionalTwilioSidError,
+  getTestSmsSuppressionMessage,
   normalizeOptionalSid,
 } from '../lib/twilio-compliance.ts';
 
@@ -80,4 +82,52 @@ test('settings save schema accepts toll-free verification enum and normalizes st
   assert.equal(valid.success && valid.data.messagingComplianceType, 'TOLL_FREE_VERIFICATION');
   assert.equal(legacy.success, true);
   assert.equal(legacy.success && legacy.data.messagingComplianceType, 'TOLL_FREE_VERIFICATION');
+});
+
+test('verified toll-free compliance allows live outbound SMS', () => {
+  const gate = getOutboundMessagingComplianceGate({
+    managedTwilioStatus: ManagedTwilioStatus.DRAFT,
+    messagingComplianceType: MessagingComplianceType.TOLL_FREE_VERIFICATION,
+    tollFreeVerificationStatus: TollFreeVerificationStatus.APPROVED,
+    tollFreeVerificationSid: 'BUd2b9b67869f08c15f570d9f81d920dad',
+  });
+
+  assert.equal(gate, null);
+});
+
+test('pending toll-free compliance blocks live outbound SMS with toll-free-specific wording', () => {
+  const gate = getOutboundMessagingComplianceGate({
+    managedTwilioStatus: ManagedTwilioStatus.DRAFT,
+    messagingComplianceType: MessagingComplianceType.TOLL_FREE_VERIFICATION,
+    tollFreeVerificationStatus: TollFreeVerificationStatus.PENDING,
+    tollFreeVerificationSid: 'BUd2b9b67869f08c15f570d9f81d920dad',
+  });
+
+  assert.equal(gate?.reason, 'toll_free_verification_pending');
+  assert.equal(getTestSmsSuppressionMessage(gate!.reason), 'Test SMS is blocked until toll-free verification is approved.');
+});
+
+test('unknown messaging compliance type blocks live outbound SMS with number-type guidance', () => {
+  const gate = getOutboundMessagingComplianceGate({
+    managedTwilioStatus: ManagedTwilioStatus.DRAFT,
+    messagingComplianceType: MessagingComplianceType.UNKNOWN,
+  });
+
+  assert.equal(gate?.reason, 'messaging_compliance_type_required');
+  assert.equal(getTestSmsSuppressionMessage(gate!.reason), 'Choose number type before sending a live test SMS.');
+});
+
+test('local A2P compliance still blocks live outbound SMS before approval and allows after approval', () => {
+  const pendingGate = getOutboundMessagingComplianceGate({
+    managedTwilioStatus: ManagedTwilioStatus.CAMPAIGN_SUBMITTED,
+    messagingComplianceType: MessagingComplianceType.LOCAL_A2P,
+  });
+  const approvedGate = getOutboundMessagingComplianceGate({
+    managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+    messagingComplianceType: MessagingComplianceType.LOCAL_A2P,
+  });
+
+  assert.equal(pendingGate?.reason, 'a2p_compliance_pending');
+  assert.equal(getTestSmsSuppressionMessage(pendingGate!.reason), 'Test SMS is blocked until A2P approval is complete.');
+  assert.equal(approvedGate, null);
 });


### PR DESCRIPTION
## Summary\n- route outbound compliance gating through the shared messaging compliance summary instead of the A2P-only managed Twilio fallback\n- allow verified toll-free businesses to send live test SMS while keeping unknown, pending, rejected, and unapproved states blocked with specific user-facing messaging\n- pass messaging compliance fields into shared outbound SMS call sites and add regression coverage for toll-free, unknown, and local A2P states\n\n## Validation\n- npm run typecheck\n- npm run lint\n- npm test\n- npm run build\n- npm run vercel-build