### PR TITLE
Fix test SMS delivery confirmation from Twilio status callbacks

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -1836,7 +1836,9 @@ export async function sendBusinessTestSmsAction(formData: FormData) {
         details: {
           destinationPhone: formatPhoneDetail(destinationPhone),
           fromPhone: formatPhoneDetail(fromPhone),
-          messageSid: maskSid(result.sent.sid),
+          messageSid: result.sent.sid,
+          messageSidMasked: maskSid(result.sent.sid),
+          messageStatus: result.sent.status,
         },
         relatedEntityType: 'message',
         relatedEntityId: result.message.id,

--- a/app/api/twilio/message-status/route.ts
+++ b/app/api/twilio/message-status/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 
+import { findBusinessByTwilioNumber } from '@/lib/business';
 import { db } from '@/lib/db';
 import { getCorrelationIdFromRequest, withCorrelationIdHeader } from '@/lib/observability';
+import { normalizePhoneNumber, normalizePhoneNumberToE164 } from '@/lib/phone';
 import {
   buildOutboundMessageStatusEvent,
   isTerminalOutboundMessageStatus,
@@ -23,6 +25,53 @@ function formField(formData: FormData, key: string) {
 
 function okResponse() {
   return new NextResponse(null, { status: 200 });
+}
+
+async function findFallbackAdminTestMessage(params: {
+  fromPhone: string | null;
+  toPhone: string | null;
+  messagingServiceSid: string | null;
+}) {
+  const { fromPhone, toPhone, messagingServiceSid } = params;
+  if (!fromPhone || !toPhone) {
+    return null;
+  }
+
+  const business =
+    (messagingServiceSid
+      ? await db.business.findFirst({
+          where: { twilioMessagingServiceSid: messagingServiceSid },
+          select: { id: true },
+        })
+      : null) || (await findBusinessByTwilioNumber(fromPhone));
+
+  if (!business) {
+    return null;
+  }
+
+  return db.message.findFirst({
+    where: {
+      businessId: business.id,
+      leadId: null,
+      direction: 'OUTBOUND',
+      participant: 'OWNER',
+      fromPhone,
+      toPhone,
+      OR: [{ body: { startsWith: 'CallbackCloser admin test:' } }, { body: { startsWith: 'CallbackCloser setup test:' } }],
+    },
+    orderBy: { createdAt: 'desc' },
+    select: {
+      id: true,
+      businessId: true,
+      leadId: true,
+      participant: true,
+      body: true,
+      fromPhone: true,
+      toPhone: true,
+      status: true,
+      rawPayload: true,
+    },
+  });
 }
 
 export async function POST(request: Request) {
@@ -89,6 +138,9 @@ export async function POST(request: Request) {
 
     messageSid = formField(formData, 'MessageSid') || formField(formData, 'SmsSid') || null;
     const messageStatus = normalizeOutboundMessageStatus(formField(formData, 'MessageStatus') || formField(formData, 'SmsStatus'));
+    const toPhone = normalizePhoneNumberToE164(formField(formData, 'To')) || normalizePhoneNumber(formField(formData, 'To'));
+    const fromPhone = normalizePhoneNumberToE164(formField(formData, 'From')) || normalizePhoneNumber(formField(formData, 'From'));
+    const messagingServiceSid = formField(formData, 'MessagingServiceSid') || null;
     const errorCode = formField(formData, 'ErrorCode') || null;
     const errorMessage = formField(formData, 'ErrorMessage') || null;
 
@@ -121,8 +173,9 @@ export async function POST(request: Request) {
         fromPhone: true,
         toPhone: true,
         status: true,
+        rawPayload: true,
       },
-    });
+    }) || (await findFallbackAdminTestMessage({ fromPhone, toPhone, messagingServiceSid }));
 
     if (!message) {
       logTwilioWarn('sms', 'message_status_message_not_found', {
@@ -130,6 +183,9 @@ export async function POST(request: Request) {
         correlationId,
         eventType: 'message_status_callback',
         decision: 'noop_message_not_found',
+        toPhone,
+        fromPhone,
+        messagingServiceSid,
       });
       return withCorrelation(okResponse());
     }
@@ -152,15 +208,18 @@ export async function POST(request: Request) {
           status: event.status,
           summary: event.summary,
           details: {
-            messageSid,
-            messageStatus,
-            toPhone: formatPhoneDetail(message.toPhone),
-            fromPhone: formatPhoneDetail(message.fromPhone),
-            errorCode,
-            errorMessage,
-          },
-          relatedEntityType: message.leadId ? 'lead' : 'message',
-          relatedEntityId: message.leadId ?? message.id,
+          messageSid,
+          messageStatus,
+          toPhone: formatPhoneDetail(message.toPhone),
+          fromPhone: formatPhoneDetail(message.fromPhone),
+          callbackToPhone: formatPhoneDetail(toPhone),
+          callbackFromPhone: formatPhoneDetail(fromPhone),
+          messagingServiceSid,
+          errorCode,
+          errorMessage,
+        },
+        relatedEntityType: message.leadId ? 'lead' : 'message',
+        relatedEntityId: message.leadId ?? message.id,
         });
       }
     }

--- a/app/app/settings/actions.ts
+++ b/app/app/settings/actions.ts
@@ -464,7 +464,9 @@ export async function sendBusinessTwilioTestSmsAction(formData: FormData) {
         details: {
           destinationPhone: formatPhoneDetail(destinationPhone),
           fromPhone: formatPhoneDetail(fromPhone),
-          messageSid: maskSid(result.sent.sid),
+          messageSid: result.sent.sid,
+          messageSidMasked: maskSid(result.sent.sid),
+          messageStatus: result.sent.status,
         },
         relatedEntityType: 'message',
         relatedEntityId: result.message.id,

--- a/lib/outbound-message-events.ts
+++ b/lib/outbound-message-events.ts
@@ -1,8 +1,19 @@
-import { OperatorEventCategory, OperatorEventStatus, type Message } from '@prisma/client';
+import { OperatorEventCategory, OperatorEventStatus, Prisma, type Message } from '@prisma/client';
 
 export type OutboundMessageContext = 'lead_recovery' | 'owner_alert' | 'admin_test';
 
-type OperatorMessageRecord = Pick<Message, 'leadId' | 'participant' | 'body'>;
+type OperatorMessageRecord = Pick<Message, 'leadId' | 'participant' | 'body' | 'rawPayload'>;
+
+const ADMIN_TEST_PREFIXES = ['CallbackCloser admin test:', 'CallbackCloser setup test:'];
+
+function readRawPayloadContext(rawPayload: Prisma.JsonValue | null | undefined) {
+  if (!rawPayload || Array.isArray(rawPayload) || typeof rawPayload !== 'object') {
+    return null;
+  }
+
+  const context = (rawPayload as Record<string, unknown>).context;
+  return typeof context === 'string' ? context.trim().toLowerCase() : null;
+}
 
 export function normalizeOutboundMessageStatus(status: string | null | undefined) {
   const normalized = status?.trim().toLowerCase();
@@ -20,7 +31,10 @@ export function isFailedOutboundMessageStatus(status: string | null | undefined)
 }
 
 export function getOutboundMessageContext(message: OperatorMessageRecord): OutboundMessageContext {
-  if (!message.leadId && message.participant === 'OWNER' && message.body.startsWith('CallbackCloser admin test:')) {
+  const rawPayloadContext = readRawPayloadContext(message.rawPayload);
+  const isAdminTestBody = ADMIN_TEST_PREFIXES.some((prefix) => message.body.startsWith(prefix));
+
+  if (!message.leadId && message.participant === 'OWNER' && (rawPayloadContext === 'admin_test' || isAdminTestBody)) {
     return 'admin_test';
   }
 

--- a/lib/outbound-message-persistence.ts
+++ b/lib/outbound-message-persistence.ts
@@ -1,0 +1,70 @@
+import { MessageParticipant, Prisma } from '@prisma/client';
+
+import { db } from '@/lib/db';
+import { type OutboundMessageContext } from '@/lib/outbound-message-events';
+import { normalizePhoneNumber } from '@/lib/phone';
+
+export async function persistOutboundMessageRecord(params: {
+  businessId: string;
+  leadId?: string | null;
+  twilioSid?: string | null;
+  fromPhone: string;
+  toPhone: string;
+  body: string;
+  participant?: MessageParticipant;
+  status?: string | null;
+  rawPayload?: Prisma.InputJsonValue;
+  twilioCreatedAt?: Date | null;
+}) {
+  const from = normalizePhoneNumber(params.fromPhone) || params.fromPhone;
+  const to = normalizePhoneNumber(params.toPhone) || params.toPhone;
+
+  return db.message.create({
+    data: {
+      businessId: params.businessId,
+      leadId: params.leadId ?? null,
+      twilioSid: params.twilioSid ?? null,
+      direction: 'OUTBOUND',
+      participant: params.participant ?? 'LEAD',
+      fromPhone: from,
+      toPhone: to,
+      body: params.body,
+      status: params.status ?? undefined,
+      rawPayload: params.rawPayload ?? undefined,
+      twilioCreatedAt: params.twilioCreatedAt ?? undefined,
+    },
+  });
+}
+
+export async function persistAcceptedOutboundMessage(params: {
+  businessId: string;
+  leadId?: string | null;
+  fromPhone: string;
+  toPhone: string;
+  body: string;
+  participant?: MessageParticipant;
+  twilioSid: string;
+  status?: string | null;
+  context: OutboundMessageContext;
+  statusCallback: string;
+  messagingServiceSid?: string | null;
+  twilioCreatedAt?: Date | null;
+}) {
+  return persistOutboundMessageRecord({
+    businessId: params.businessId,
+    leadId: params.leadId ?? null,
+    fromPhone: params.fromPhone,
+    toPhone: params.toPhone,
+    body: params.body,
+    participant: params.participant,
+    twilioSid: params.twilioSid,
+    status: params.status ?? null,
+    rawPayload: {
+      source: 'twilio_api',
+      context: params.context,
+      statusCallback: params.statusCallback,
+      messagingServiceSid: params.messagingServiceSid ?? null,
+    },
+    twilioCreatedAt: params.twilioCreatedAt ?? undefined,
+  });
+}

--- a/lib/twilio-messaging.ts
+++ b/lib/twilio-messaging.ts
@@ -1,13 +1,18 @@
 import { ManagedTwilioStatus, MessageParticipant, MessagingComplianceType, Prisma, TollFreeVerificationStatus } from '@prisma/client';
 
 import { db } from '@/lib/db';
+import { persistAcceptedOutboundMessage, persistOutboundMessageRecord } from '@/lib/outbound-message-persistence';
 import { type OutboundMessageContext } from '@/lib/outbound-message-events';
 import { formatPhoneDetail, recordBusinessOperatorEvent } from '@/lib/operator-events';
 import { normalizePhoneNumber } from '@/lib/phone';
 import { getOutboundMessagingComplianceGate, type OutboundMessagingSuppressionReason } from '@/lib/twilio-compliance';
 import { logTwilioError, logTwilioInfo, logTwilioWarn } from '@/lib/twilio-logging';
 import { isSmsRecipientOptedOut } from '@/lib/twilio-sms-compliance';
-import { getTwilioBusinessClient, getTwilioMessageStatusCallbackUrl } from '@/lib/twilio';
+import { type TwilioClient, getTwilioBusinessClient, getTwilioMessageStatusCallbackUrl } from '@/lib/twilio';
+
+type OutboundTwilioClient = Pick<TwilioClient, 'messages'>;
+
+export { persistOutboundMessageRecord } from '@/lib/outbound-message-persistence';
 
 export async function persistInboundMessage(params: {
   businessId: string;
@@ -88,6 +93,7 @@ export async function sendAndPersistOutboundMessage(params: {
   tollFreeVerificationSid?: string | null;
   tollFreeVerificationNote?: string | null;
   allowUnapproved?: boolean;
+  twilioClient?: OutboundTwilioClient;
 }) {
   const from = normalizePhoneNumber(params.fromPhone) || params.fromPhone;
   const to = normalizePhoneNumber(params.toPhone) || params.toPhone;
@@ -183,24 +189,25 @@ export async function sendAndPersistOutboundMessage(params: {
     relatedEntityId: params.leadId ?? null,
   });
 
-  const client = getTwilioBusinessClient(params.twilioSubaccountSid);
+  const statusCallback = getTwilioMessageStatusCallbackUrl();
+  const client = params.twilioClient ?? getTwilioBusinessClient(params.twilioSubaccountSid);
   const sent = await client.messages.create(
     params.messagingServiceSid
       ? {
           messagingServiceSid: params.messagingServiceSid,
           to,
           body: params.body,
-          statusCallback: getTwilioMessageStatusCallbackUrl(),
+          statusCallback,
         }
       : {
           from,
           to,
           body: params.body,
-          statusCallback: getTwilioMessageStatusCallbackUrl(),
+          statusCallback,
         }
   );
 
-  const message = await persistOutboundMessageRecord({
+  const message = await persistAcceptedOutboundMessage({
     businessId: params.businessId,
     leadId: params.leadId ?? null,
     fromPhone: from,
@@ -209,10 +216,9 @@ export async function sendAndPersistOutboundMessage(params: {
     participant,
     twilioSid: sent.sid,
     status: sent.status,
-    rawPayload: {
-      source: 'twilio_api',
-      context,
-    },
+    context,
+    statusCallback,
+    messagingServiceSid: params.messagingServiceSid,
     twilioCreatedAt: sent.dateCreated ?? undefined,
   });
   await recordBusinessOperatorEvent({
@@ -240,38 +246,6 @@ export async function sendAndPersistOutboundMessage(params: {
   });
 
   return { suppressed: false as const, sent, message };
-}
-
-export async function persistOutboundMessageRecord(params: {
-  businessId: string;
-  leadId?: string | null;
-  twilioSid?: string | null;
-  fromPhone: string;
-  toPhone: string;
-  body: string;
-  participant?: MessageParticipant;
-  status?: string | null;
-  rawPayload?: Prisma.InputJsonValue;
-  twilioCreatedAt?: Date | null;
-}) {
-  const from = normalizePhoneNumber(params.fromPhone) || params.fromPhone;
-  const to = normalizePhoneNumber(params.toPhone) || params.toPhone;
-
-  return db.message.create({
-    data: {
-      businessId: params.businessId,
-      leadId: params.leadId ?? null,
-      twilioSid: params.twilioSid ?? null,
-      direction: 'OUTBOUND',
-      participant: params.participant ?? 'LEAD',
-      fromPhone: from,
-      toPhone: to,
-      body: params.body,
-      status: params.status ?? undefined,
-      rawPayload: params.rawPayload ?? undefined,
-      twilioCreatedAt: params.twilioCreatedAt ?? undefined,
-    },
-  });
 }
 
 export function buildOwnerNotificationMessage(params: {

--- a/tests/twilio-message-status-route.test.ts
+++ b/tests/twilio-message-status-route.test.ts
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { MessageDirection, MessageParticipant, OperatorEventStatus } from '@prisma/client';
+
+import { POST } from '../app/api/twilio/message-status/route.ts';
+import { getAdminTestSmsConfidenceState } from '../lib/admin-dashboard.ts';
+import { buildAdminTestSmsTruth } from '../lib/admin-operator-visibility.ts';
+import { db } from '../lib/db.ts';
+import { cleanupTenantFixtures, seedTenantFixtures } from './tenant-fixtures.ts';
+
+async function withEnv<T>(overrides: Record<string, string | undefined>, fn: () => Promise<T> | T) {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(overrides)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test('message-status route marks a setup test SMS delivered and clears the checklist gate', async () => {
+  const fixtures = await seedTenantFixtures();
+
+  try {
+    const destinationPhone = '+15554443333';
+    await db.message.create({
+      data: {
+        businessId: fixtures.businessA.id,
+        direction: MessageDirection.OUTBOUND,
+        participant: MessageParticipant.OWNER,
+        fromPhone: fixtures.businessA.twilioPrimaryPhoneNumber!,
+        toPhone: destinationPhone,
+        body: `CallbackCloser setup test: ${fixtures.businessA.name} is using ${fixtures.businessA.twilioPrimaryPhoneNumber} for launch verification.`,
+        status: 'sent',
+        twilioSid: 'SM_setup_delivered_123',
+        rawPayload: {
+          source: 'twilio_api',
+          context: 'admin_test',
+        },
+      },
+    });
+
+    await withEnv(
+      {
+        NODE_ENV: 'development',
+        TWILIO_VALIDATE_SIGNATURE: 'true',
+        TWILIO_WEBHOOK_AUTH_TOKEN: 'dev-shared-token',
+      },
+      async () => {
+        const formData = new FormData();
+        formData.set('AccountSid', fixtures.businessA.twilioSubaccountSid!);
+        formData.set('MessageSid', 'SM_setup_delivered_123');
+        formData.set('MessageStatus', 'delivered');
+        formData.set('From', fixtures.businessA.twilioPrimaryPhoneNumber!);
+        formData.set('To', destinationPhone);
+        formData.set('MessagingServiceSid', fixtures.businessA.twilioMessagingServiceSid!);
+
+        const response = await POST(
+          new Request('https://app.callbackcloser.com/api/twilio/message-status?webhook_token=dev-shared-token', {
+            method: 'POST',
+            body: formData,
+          })
+        );
+
+        assert.equal(response.status, 200);
+      }
+    );
+
+    const updatedMessage = await db.message.findUniqueOrThrow({
+      where: { twilioSid: 'SM_setup_delivered_123' },
+      select: { status: true },
+    });
+    assert.equal(updatedMessage.status, 'delivered');
+
+    const operatorEvents = await db.businessOperatorEvent.findMany({
+      where: {
+        businessId: fixtures.businessA.id,
+        type: {
+          startsWith: 'admin.test_sms_',
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        type: true,
+        status: true,
+        summary: true,
+        detailsJson: true,
+        createdAt: true,
+      },
+    });
+
+    assert.equal(operatorEvents[0]?.type, 'admin.test_sms_delivered');
+    assert.equal(
+      getAdminTestSmsConfidenceState(
+        operatorEvents.map((event) => ({
+          type: event.type,
+          status: event.status,
+          createdAt: event.createdAt,
+        }))
+      ),
+      'delivered'
+    );
+  } finally {
+    await cleanupTenantFixtures({
+      businessAId: fixtures.businessA.id,
+      businessBId: fixtures.businessB.id,
+    });
+  }
+});
+
+test('message-status route surfaces undelivered setup test SMS failures from SmsSid and SmsStatus payloads', async () => {
+  const fixtures = await seedTenantFixtures();
+
+  try {
+    const destinationPhone = '+15556667777';
+    await db.message.create({
+      data: {
+        businessId: fixtures.businessA.id,
+        direction: MessageDirection.OUTBOUND,
+        participant: MessageParticipant.OWNER,
+        fromPhone: fixtures.businessA.twilioPrimaryPhoneNumber!,
+        toPhone: destinationPhone,
+        body: `CallbackCloser setup test: ${fixtures.businessA.name} is using ${fixtures.businessA.twilioPrimaryPhoneNumber} for launch verification.`,
+        status: 'sent',
+        twilioSid: 'SM_setup_failed_456',
+        rawPayload: {
+          source: 'twilio_api',
+          context: 'admin_test',
+        },
+      },
+    });
+
+    await withEnv(
+      {
+        NODE_ENV: 'development',
+        TWILIO_VALIDATE_SIGNATURE: 'true',
+        TWILIO_WEBHOOK_AUTH_TOKEN: 'dev-shared-token',
+      },
+      async () => {
+        const formData = new FormData();
+        formData.set('AccountSid', fixtures.businessA.twilioSubaccountSid!);
+        formData.set('SmsSid', 'SM_setup_failed_456');
+        formData.set('SmsStatus', 'undelivered');
+        formData.set('From', fixtures.businessA.twilioPrimaryPhoneNumber!);
+        formData.set('To', destinationPhone);
+        formData.set('MessagingServiceSid', fixtures.businessA.twilioMessagingServiceSid!);
+        formData.set('ErrorCode', '30007');
+        formData.set('ErrorMessage', 'Carrier violation');
+
+        const response = await POST(
+          new Request('https://app.callbackcloser.com/api/twilio/message-status?webhook_token=dev-shared-token', {
+            method: 'POST',
+            body: formData,
+          })
+        );
+
+        assert.equal(response.status, 200);
+      }
+    );
+
+    const updatedMessage = await db.message.findUniqueOrThrow({
+      where: { twilioSid: 'SM_setup_failed_456' },
+      select: { status: true },
+    });
+    assert.equal(updatedMessage.status, 'undelivered');
+
+    const operatorEvents = await db.businessOperatorEvent.findMany({
+      where: {
+        businessId: fixtures.businessA.id,
+        type: {
+          startsWith: 'admin.test_sms_',
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        type: true,
+        status: true,
+        summary: true,
+        detailsJson: true,
+        createdAt: true,
+      },
+    });
+
+    assert.equal(operatorEvents[0]?.type, 'admin.test_sms_delivery_failed');
+    assert.equal(operatorEvents[0]?.status, OperatorEventStatus.FAILED);
+    assert.equal(
+      getAdminTestSmsConfidenceState(
+        operatorEvents.map((event) => ({
+          type: event.type,
+          status: event.status,
+          createdAt: event.createdAt,
+        }))
+      ),
+      'failed'
+    );
+
+    const truth = buildAdminTestSmsTruth(operatorEvents);
+    assert.equal(truth.label, 'Failed');
+    assert.match(truth.detail, /Carrier violation/i);
+  } finally {
+    await cleanupTenantFixtures({
+      businessAId: fixtures.businessA.id,
+      businessBId: fixtures.businessB.id,
+    });
+  }
+});

--- a/tests/twilio-messaging.test.ts
+++ b/tests/twilio-messaging.test.ts
@@ -3,7 +3,10 @@ import test from 'node:test';
 
 import { OperatorEventCategory, OperatorEventStatus } from '@prisma/client';
 
+import { db } from '../lib/db.ts';
+import { persistAcceptedOutboundMessage } from '../lib/outbound-message-persistence.ts';
 import { buildOutboundMessageStatusEvent, getOutboundMessageContext } from '../lib/outbound-message-events.ts';
+import { cleanupTenantFixtures, seedTenantFixtures } from './tenant-fixtures.ts';
 
 test('outbound message context distinguishes admin test, owner alert, and lead flows', () => {
   assert.equal(
@@ -11,6 +14,17 @@ test('outbound message context distinguishes admin test, owner alert, and lead f
       leadId: null,
       participant: 'OWNER',
       body: 'CallbackCloser admin test: Acme Plumbing is using +15550001111 for live support verification.',
+      rawPayload: null,
+    }),
+    'admin_test'
+  );
+
+  assert.equal(
+    getOutboundMessageContext({
+      leadId: null,
+      participant: 'OWNER',
+      body: 'CallbackCloser setup test: Acme Plumbing is using +15550001111 for launch verification.',
+      rawPayload: { context: 'admin_test' },
     }),
     'admin_test'
   );
@@ -20,6 +34,7 @@ test('outbound message context distinguishes admin test, owner alert, and lead f
       leadId: 'lead_123',
       participant: 'OWNER',
       body: 'CallbackCloser lead for Acme Plumbing: Emergency repair.',
+      rawPayload: null,
     }),
     'owner_alert'
   );
@@ -29,6 +44,7 @@ test('outbound message context distinguishes admin test, owner alert, and lead f
       leadId: 'lead_456',
       participant: 'LEAD',
       body: 'What service do you need help with?',
+      rawPayload: null,
     }),
     'lead_recovery'
   );
@@ -40,6 +56,7 @@ test('terminal outbound message status events stay founder-facing', () => {
       leadId: null,
       participant: 'OWNER',
       body: 'CallbackCloser admin test: Acme Plumbing is using +15550001111 for live support verification.',
+      rawPayload: null,
     },
     'delivered'
   );
@@ -56,6 +73,7 @@ test('terminal outbound message status events stay founder-facing', () => {
       leadId: 'lead_123',
       participant: 'OWNER',
       body: 'CallbackCloser lead for Acme Plumbing: Emergency repair.',
+      rawPayload: null,
     },
     'undelivered'
   );
@@ -66,4 +84,47 @@ test('terminal outbound message status events stay founder-facing', () => {
     status: OperatorEventStatus.FAILED,
     summary: 'Owner SMS alert delivery failed',
   });
+});
+
+test('outbound setup test SMS persists the Twilio sid and destination on the message record', async () => {
+  const fixtures = await seedTenantFixtures();
+
+  try {
+    const stored = await persistAcceptedOutboundMessage({
+      businessId: fixtures.businessA.id,
+      fromPhone: fixtures.businessA.twilioPrimaryPhoneNumber!,
+      toPhone: '+15554443333',
+      body: `CallbackCloser setup test: ${fixtures.businessA.name} is using ${fixtures.businessA.twilioPrimaryPhoneNumber} for launch verification.`,
+      participant: 'OWNER',
+      twilioSid: 'SMsetup1234567890',
+      status: 'queued',
+      context: 'admin_test',
+      statusCallback: 'https://app.callbackcloser.com/api/twilio/message-status',
+      messagingServiceSid: fixtures.businessA.twilioMessagingServiceSid,
+      twilioCreatedAt: new Date('2026-05-24T14:15:00.000Z'),
+    });
+
+    const storedMessage = await db.message.findUniqueOrThrow({
+      where: { id: stored.id },
+      select: {
+        twilioSid: true,
+        toPhone: true,
+        rawPayload: true,
+      },
+    });
+
+    assert.equal(storedMessage.twilioSid, 'SMsetup1234567890');
+    assert.equal(storedMessage.toPhone, '+15554443333');
+    assert.deepEqual(storedMessage.rawPayload, {
+      source: 'twilio_api',
+      context: 'admin_test',
+      statusCallback: 'https://app.callbackcloser.com/api/twilio/message-status',
+      messagingServiceSid: fixtures.businessA.twilioMessagingServiceSid,
+    });
+  } finally {
+    await cleanupTenantFixtures({
+      businessAId: fixtures.businessA.id,
+      businessBId: fixtures.businessB.id,
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- setup/admin test SMS now persists MessageSid and admin_test context
- /api/twilio/message-status now emits admin.test_sms_delivered/admin.test_sms_delivery_failed events
- checklist now flips out of Waiting after a fresh delivered callback
- validation passed: typecheck, lint, test, build