### PR TITLE
Redirect completed lead outcomes back to the inbox

### DIFF
--- a/app/app/leads/[leadId]/page.tsx
+++ b/app/app/leads/[leadId]/page.tsx
@@ -52,12 +52,14 @@ function LeadStatusActionForm({
   leadId,
   status,
   redirectTo,
+  successRedirectTo,
   label,
   variant,
 }: {
   leadId: string;
   status: 'CONTACTED' | 'BOOKED' | 'LOST';
   redirectTo: string;
+  successRedirectTo: string;
   label: string;
   variant?: 'default' | 'outline' | 'destructive';
 }) {
@@ -66,6 +68,7 @@ function LeadStatusActionForm({
       <input type="hidden" name="leadId" value={leadId} />
       <input type="hidden" name="status" value={status} />
       <input type="hidden" name="redirectTo" value={redirectTo} />
+      <input type="hidden" name="successRedirectTo" value={successRedirectTo} />
       <Button className="w-full" type="submit" variant={variant}>
         {label}
       </Button>
@@ -100,7 +103,9 @@ export default async function LeadDetailPage({
   const primaryLabel = lead.callerName || lead.contactName || formatPhoneForDisplay(lead.callerPhoneNormalized || lead.callerPhone);
   const secondaryLabel =
     lead.callerName || lead.contactName ? formatPhoneForDisplay(lead.callerPhoneNormalized || lead.callerPhone) : 'Caller name not captured yet';
-  const redirectTo = `/app/leads/${lead.id}`;
+  const detailRedirectTo =
+    returnPath === '/app/leads' ? `/app/leads/${lead.id}` : `/app/leads/${lead.id}?from=${encodeURIComponent(returnPath)}`;
+  const successRedirectTo = '/app/leads';
   const recordingHref = lead.call?.recordingUrl ? `/api/leads/${lead.id}/recording` : null;
   const nextStepLabel = getLeadNextStepLabel(lead.status);
   const isOpenLead = isLeadOpenStatus(lead.status);
@@ -151,9 +156,29 @@ export default async function LeadDetailPage({
               <Link className={buttonVariants({ className: 'w-full' })} href={`tel:${lead.callerPhoneNormalized || lead.callerPhone}`}>
                 Call now
               </Link>
-              <LeadStatusActionForm leadId={lead.id} status="CONTACTED" redirectTo={redirectTo} label="Mark contacted" variant="outline" />
-              <LeadStatusActionForm leadId={lead.id} status="BOOKED" redirectTo={redirectTo} label="Mark as Closed (Won)" />
-              <LeadStatusActionForm leadId={lead.id} status="LOST" redirectTo={redirectTo} label="Mark as Lost" variant="destructive" />
+              <LeadStatusActionForm
+                leadId={lead.id}
+                status="CONTACTED"
+                redirectTo={detailRedirectTo}
+                successRedirectTo={successRedirectTo}
+                label="Mark contacted"
+                variant="outline"
+              />
+              <LeadStatusActionForm
+                leadId={lead.id}
+                status="BOOKED"
+                redirectTo={detailRedirectTo}
+                successRedirectTo={successRedirectTo}
+                label="Mark as Closed (Won)"
+              />
+              <LeadStatusActionForm
+                leadId={lead.id}
+                status="LOST"
+                redirectTo={detailRedirectTo}
+                successRedirectTo={successRedirectTo}
+                label="Mark as Lost"
+                variant="destructive"
+              />
             </div>
           </div>
         </CardHeader>

--- a/app/app/leads/actions.ts
+++ b/app/app/leads/actions.ts
@@ -18,6 +18,7 @@ function resolveSafeAppRedirect(value: FormDataEntryValue | null, fallback: stri
 export async function updateLeadStatusAction(formData: FormData) {
   const fallbackPath = '/app/leads';
   const redirectTo = resolveSafeAppRedirect(formData.get('redirectTo'), fallbackPath);
+  const successRedirectTo = resolveSafeAppRedirect(formData.get('successRedirectTo'), redirectTo);
 
   const business = await requireBusiness();
   const parsed = leadStatusSchema.safeParse(Object.fromEntries(formData));
@@ -38,5 +39,5 @@ export async function updateLeadStatusAction(formData: FormData) {
   revalidatePath('/app');
   revalidatePath('/app/conversations');
   revalidatePath(`/app/leads/${lead.id}`);
-  redirect(`${redirectTo}${redirectTo.includes('?') ? '&' : '?'}saved=1`);
+  redirect(`${successRedirectTo}${successRedirectTo.includes('?') ? '&' : '?'}saved=1`);
 }

--- a/tests/lead-status-action-redirects.test.ts
+++ b/tests/lead-status-action-redirects.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+function read(path: string) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+test('lead status action keeps failures on the detail page and redirects successful outcomes to the inbox', () => {
+  const actions = read('app/app/leads/actions.ts');
+
+  assert.match(actions, /const redirectTo = resolveSafeAppRedirect\(formData\.get\('redirectTo'\), fallbackPath\);/);
+  assert.match(actions, /const successRedirectTo = resolveSafeAppRedirect\(formData\.get\('successRedirectTo'\), redirectTo\);/);
+  assert.match(actions, /redirect\(`\$\{redirectTo\}\$\{redirectTo\.includes\('\?'\) \? '&' : '\?'\}error=Invalid%20status`\);/);
+  assert.match(actions, /redirect\(`\$\{redirectTo\}\$\{redirectTo\.includes\('\?'\) \? '&' : '\?'\}error=Lead%20not%20found`\);/);
+  assert.match(actions, /revalidatePath\('\/app\/leads'\);/);
+  assert.match(actions, /redirect\(`\$\{successRedirectTo\}\$\{successRedirectTo\.includes\('\?'\) \? '&' : '\?'\}saved=1`\);/);
+});
+
+test('lead detail outcome buttons post back to the detail page on failure and return to the inbox on success', () => {
+  const leadDetailPage = read('app/app/leads/[leadId]/page.tsx');
+
+  assert.match(
+    leadDetailPage,
+    /const detailRedirectTo =\s+returnPath === '\/app\/leads' \? `\/app\/leads\/\$\{lead\.id\}` : `\/app\/leads\/\$\{lead\.id\}\?from=\$\{encodeURIComponent\(returnPath\)\}`;/
+  );
+  assert.match(leadDetailPage, /const successRedirectTo = '\/app\/leads';/);
+  assert.match(leadDetailPage, /<input type="hidden" name="successRedirectTo" value=\{successRedirectTo\} \/>/);
+  assert.match(leadDetailPage, /status="CONTACTED"[\s\S]*redirectTo=\{detailRedirectTo\}[\s\S]*successRedirectTo=\{successRedirectTo\}/);
+  assert.match(leadDetailPage, /status="BOOKED"[\s\S]*redirectTo=\{detailRedirectTo\}[\s\S]*successRedirectTo=\{successRedirectTo\}/);
+  assert.match(leadDetailPage, /status="LOST"[\s\S]*redirectTo=\{detailRedirectTo\}[\s\S]*successRedirectTo=\{successRedirectTo\}/);
+});

--- a/tests/tenant-isolation.test.ts
+++ b/tests/tenant-isolation.test.ts
@@ -92,6 +92,7 @@ test('tenant-scoped helpers block cross-business reads and writes while preservi
     assert.equal(allowedUpdate?.status, LeadStatus.BOOKED);
 
     const allDashboardAAfterUpdate = await listAllDashboardLeadsForBusiness(fixtures.businessA.id);
+    assert.equal(allDashboardAAfterUpdate[0]?.status, LeadStatus.BOOKED);
     assert.deepEqual(getLeadOutcomeSummary(allDashboardAAfterUpdate), {
       totalLeads: 1,
       closedLeads: 1,


### PR DESCRIPTION
## Summary
- redirect successful final lead status updates from the lead detail page back to `/app/leads`
- keep invalid or cross-business updates on the lead detail page so existing error feedback still shows there
- preserve lead inbox freshness by revalidating the inbox paths after status changes
- add focused tests for the redirect contract and inbox-visible status updates

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build