### PR TITLE
Harden public routing and production security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # App
+# Required in production. Use your deployed app origin, e.g. https://callbackcloser.com
 NEXT_PUBLIC_APP_URL=
 
 # Database (Postgres)
@@ -6,13 +7,16 @@ DATABASE_URL=
 DIRECT_DATABASE_URL=
 
 # Clerk
+# Required in production
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=
 NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
 NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+# Optional comma-separated admin emails allowed into /admin
 ADMIN_EMAIL_ALLOWLIST=
 
 # Stripe
+# Required in production
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
@@ -43,6 +47,7 @@ RESEND_API_KEY=
 CALLBACKCLOSER_FROM_EMAIL=
 
 # Optional public simulator
+# Keep these disabled in production unless the public simulator is intentionally enabled.
 ENABLE_PUBLIC_MISSED_CALL_SIMULATOR=
 SIMULATOR_BUSINESS_ID=
 ENABLE_PUBLIC_SIMULATOR_REAL_SMS=

--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -1,13 +1,42 @@
+import { auth } from '@clerk/nextjs/server';
 import { SignIn } from '@clerk/nextjs';
+import { redirect } from 'next/navigation';
 
+import { getAdminSession } from '@/lib/admin';
+import { getBusinessForOwnerClerkId } from '@/lib/business-access';
 import { DEFAULT_CLERK_AFTER_AUTH_URL, getClerkAuthUrls } from '@/lib/clerk-config';
+import { resolveSignedInAppDestination } from '@/lib/public-auth-routing';
 
-export default function SignInPage() {
+export default async function SignInPage() {
+  const { userId } = await auth();
+  if (userId) {
+    const [adminSession, business] = await Promise.all([
+      getAdminSession(),
+      getBusinessForOwnerClerkId(userId),
+    ]);
+
+    redirect(
+      resolveSignedInAppDestination({
+        isAdmin: Boolean(adminSession?.isAdmin),
+        hasBusiness: Boolean(business),
+      })
+    );
+  }
+
   const { signInUrl, signUpUrl } = getClerkAuthUrls();
 
   return (
-    <main className="container flex min-h-screen items-center justify-center py-16">
-      <SignIn path={signInUrl} routing="path" signUpUrl={signUpUrl} fallbackRedirectUrl={DEFAULT_CLERK_AFTER_AUTH_URL} />
+    <main className="container grid min-h-screen gap-8 py-16 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+      <section className="space-y-4">
+        <p className="text-sm font-medium text-muted-foreground">Existing users</p>
+        <h1 className="text-3xl font-semibold tracking-tight">Sign in to your CallbackCloser workspace</h1>
+        <p className="text-muted-foreground">
+          Sign in is for existing owners and operators. If you need a new business workspace, create an account or start a free pilot from the public site instead.
+        </p>
+      </section>
+      <div className="flex justify-center lg:justify-end">
+        <SignIn path={signInUrl} routing="path" signUpUrl={signUpUrl} fallbackRedirectUrl={DEFAULT_CLERK_AFTER_AUTH_URL} />
+      </div>
     </main>
   );
 }

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,13 +1,67 @@
+import { auth } from '@clerk/nextjs/server';
 import { SignUp } from '@clerk/nextjs';
+import { redirect } from 'next/navigation';
 
+import { getAdminSession } from '@/lib/admin';
+import { getBusinessForOwnerClerkId } from '@/lib/business-access';
 import { DEFAULT_CLERK_AFTER_AUTH_URL, getClerkAuthUrls } from '@/lib/clerk-config';
+import { resolveSignedInAppDestination } from '@/lib/public-auth-routing';
 
-export default function SignUpPage() {
+function getIntentCopy(intent: string | undefined) {
+  if (intent === 'pilot') {
+    return {
+      label: 'Start Free Pilot',
+      title: 'Create your account and start pilot onboarding',
+      detail:
+        'This path is for a business owner creating a new CallbackCloser account. If you are already signed in, CallbackCloser will send you to onboarding, your dashboard, or the admin new-business flow based on your role.',
+    };
+  }
+
+  return {
+    label: 'Create Account',
+    title: 'Create your CallbackCloser account',
+    detail:
+      'Create a new owner account here. Founder-operated customer pilot setup is separate and stays inside the admin new-business flow.',
+  };
+}
+
+export default async function SignUpPage({
+  searchParams,
+}: {
+  searchParams?: Record<string, string | string[] | undefined>;
+}) {
+  const { userId } = await auth();
+  if (userId) {
+    const [adminSession, business] = await Promise.all([
+      getAdminSession(),
+      getBusinessForOwnerClerkId(userId),
+    ]);
+
+    redirect(
+      resolveSignedInAppDestination({
+        isAdmin: Boolean(adminSession?.isAdmin),
+        hasBusiness: Boolean(business),
+      })
+    );
+  }
+
   const { signInUrl, signUpUrl } = getClerkAuthUrls();
+  const intent = typeof searchParams?.intent === 'string' ? searchParams.intent : undefined;
+  const copy = getIntentCopy(intent);
 
   return (
-    <main className="container flex min-h-screen items-center justify-center py-16">
-      <SignUp path={signUpUrl} routing="path" signInUrl={signInUrl} fallbackRedirectUrl={DEFAULT_CLERK_AFTER_AUTH_URL} />
+    <main className="container grid min-h-screen gap-8 py-16 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+      <section className="space-y-4">
+        <p className="text-sm font-medium text-muted-foreground">{copy.label}</p>
+        <h1 className="text-3xl font-semibold tracking-tight">{copy.title}</h1>
+        <p className="text-muted-foreground">{copy.detail}</p>
+        <p className="text-sm text-muted-foreground">
+          Existing users should sign in. CallbackCloser operators setting up a customer pilot should use the admin new-business flow, not public signup.
+        </p>
+      </section>
+      <div className="flex justify-center lg:justify-end">
+        <SignUp path={signUpUrl} routing="path" signInUrl={signInUrl} fallbackRedirectUrl={DEFAULT_CLERK_AFTER_AUTH_URL} />
+      </div>
     </main>
   );
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -128,6 +128,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   const admin = await requireAdmin();
   const createdDemo = getQueryValue(searchParams, 'createdDemo') === '1';
   const createdBusinessId = getQueryValue(searchParams, 'createdBusinessId');
+  const setupIntent = getQueryValue(searchParams, 'intent');
   const selectedBusinessId = getQueryValue(searchParams, 'businessId');
   const archived = getQueryValue(searchParams, 'archived') === '1';
   const deleted = getQueryValue(searchParams, 'deleted') === '1';
@@ -526,6 +527,11 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
         <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">
           Demo business ready. Use <code className="rounded bg-background px-1 py-0.5">{createdBusinessId}</code> as `SIMULATOR_BUSINESS_ID`, or open the
           support workspace below.
+        </div>
+      ) : null}
+      {setupIntent === 'new-business-pilot' ? (
+        <div className="rounded-md border border-primary/30 bg-primary/5 p-3 text-sm">
+          Customer pilot setup starts here. Public signup is for business owners creating their own account; founder/operator setup for a real customer stays in this admin new-business flow.
         </div>
       ) : null}
 

--- a/app/api/twilio/provision-number/route.ts
+++ b/app/api/twilio/provision-number/route.ts
@@ -2,7 +2,9 @@ import { auth } from '@clerk/nextjs/server';
 import { NextResponse } from 'next/server';
 
 import { db } from '@/lib/db';
+import { getConfiguredAppBaseUrl } from '@/lib/env.server';
 import { getCorrelationIdFromRequest, withCorrelationIdHeader } from '@/lib/observability';
+import { isAllowedRequestOrigin } from '@/lib/request-origin';
 import { logTwilioError, logTwilioWarn } from '@/lib/twilio-logging';
 import { getTwilioProvisioningBlockReason, provisionPhoneNumber } from '@/lib/twilio-provision';
 
@@ -34,6 +36,10 @@ function buildBlockedResponse(blockReason: ReturnType<typeof getTwilioProvisioni
 export async function POST(request: Request) {
   const correlationId = getCorrelationIdFromRequest(request);
   const withCorrelation = (response: NextResponse) => withCorrelationIdHeader(response, correlationId);
+
+  if (process.env.NODE_ENV === 'production' && !isAllowedRequestOrigin(request, getConfiguredAppBaseUrl())) {
+    return withCorrelation(NextResponse.json({ error: 'Invalid request origin' }, { status: 403 }));
+  }
 
   const { userId } = await auth();
   if (!userId) {

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -4,6 +4,7 @@ import { PublicSiteFooter } from '@/components/public-site-footer';
 import { PublicSiteNav } from '@/components/public-site-nav';
 import { buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { PUBLIC_CREATE_ACCOUNT_PATH, PUBLIC_START_FREE_PILOT_PATH } from '@/lib/public-auth-routing';
 
 const outreachInputs = [
   'Business name and service type',
@@ -45,11 +46,15 @@ export default function ContactPage() {
                 For SMS consent, STOP or HELP behavior, or public trust-page questions, email support and reference{' '}
                 <span className="font-medium text-foreground">callbackcloser.com</span> so we can match the request to the live pilot setup.
               </p>
+              <p>Founder/operator customer pilot setup is separate from public signup and stays inside the admin new-business flow.</p>
               <div className="flex flex-wrap gap-3 pt-2">
-                <Link className={buttonVariants()} href="/sign-up">
+                <Link className={buttonVariants()} href={PUBLIC_START_FREE_PILOT_PATH}>
                   Start pilot onboarding
                 </Link>
-                <Link className={buttonVariants({ variant: 'outline' })} href="/pricing">
+                <Link className={buttonVariants({ variant: 'outline' })} href={PUBLIC_CREATE_ACCOUNT_PATH}>
+                  Create account
+                </Link>
+                <Link className={buttonVariants({ variant: 'ghost' })} href="/pricing">
                   View pricing
                 </Link>
                 <Link className={buttonVariants({ variant: 'ghost' })} href="/sms-consent">

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -16,6 +16,7 @@ import {
   demoTrustPoints,
   demoWorkflowSteps,
 } from '@/lib/demo-data';
+import { PUBLIC_START_FREE_PILOT_PATH } from '@/lib/public-auth-routing';
 import { cn } from '@/lib/utils';
 
 export const metadata: Metadata = {
@@ -61,6 +62,7 @@ export default function DemoPage() {
                   </Link>
                 </div>
                 <p className="text-sm text-muted-foreground">Get this live on your number fast, without changing how your team already works.</p>
+                <p className="text-xs text-muted-foreground">Demo only: fake business, fake callers, and no live customer or Twilio data.</p>
               </div>
 
               <div className="grid gap-3 sm:grid-cols-3">
@@ -221,7 +223,7 @@ export default function DemoPage() {
                   <Link className={buttonVariants()} href="/contact">
                     Want this on your business?
                   </Link>
-                  <Link className={buttonVariants({ variant: 'outline' })} href="/sign-up">
+                  <Link className={buttonVariants({ variant: 'outline' })} href={PUBLIC_START_FREE_PILOT_PATH}>
                     See it on your number
                   </Link>
                 </div>
@@ -261,7 +263,7 @@ export default function DemoPage() {
               </p>
             </div>
             <div className="flex flex-wrap items-center justify-center gap-3">
-              <Link className={buttonVariants({ size: 'lg' })} href="/sign-up">
+              <Link className={buttonVariants({ size: 'lg' })} href={PUBLIC_START_FREE_PILOT_PATH}>
                 See it on your number
               </Link>
               <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} href="/contact">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { PublicSiteNav } from '@/components/public-site-nav';
 import { Badge } from '@/components/ui/badge';
 import { buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { PUBLIC_CREATE_ACCOUNT_PATH, PUBLIC_START_FREE_PILOT_PATH } from '@/lib/public-auth-routing';
 
 const roiPoints = [
   {
@@ -145,14 +146,14 @@ export default function LandingPage() {
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-3">
-                  <Link className={buttonVariants({ size: 'lg' })} href="/sign-up">
+                  <Link className={buttonVariants({ size: 'lg' })} href={PUBLIC_START_FREE_PILOT_PATH}>
                     Start Free Pilot
                   </Link>
-                  <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} href="/demo">
-                    See Demo
+                  <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} href={PUBLIC_CREATE_ACCOUNT_PATH}>
+                    Create Account
                   </Link>
-                  <Link className={buttonVariants({ size: 'lg', variant: 'ghost' })} href="/pricing">
-                    Pricing
+                  <Link className={buttonVariants({ size: 'lg', variant: 'ghost' })} href="/demo">
+                    See Demo
                   </Link>
                 </div>
                 <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
@@ -162,6 +163,10 @@ export default function LandingPage() {
                   <span className="rounded-full border bg-card px-3 py-1">Less admin chasing</span>
                 </div>
                 <p className="text-base font-medium text-foreground">Close one extra job and this can pay for itself.</p>
+                <p className="max-w-2xl text-sm text-muted-foreground">
+                  Start Free Pilot creates a new account or takes an existing user to the right next step automatically.
+                  Founder-operated customer pilot setup stays separate in the admin new-business flow.
+                </p>
               </div>
 
               <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -5,6 +5,7 @@ import { PublicSiteNav } from '@/components/public-site-nav';
 import { Badge } from '@/components/ui/badge';
 import { buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { PUBLIC_CREATE_ACCOUNT_PATH, PUBLIC_START_FREE_PILOT_PATH } from '@/lib/public-auth-routing';
 
 const pricingPlans = [
   {
@@ -66,7 +67,7 @@ export default function PricingPage() {
             <a className="underline underline-offset-4" href="mailto:support@callbackcloser.com">
               support@callbackcloser.com
             </a>
-            .
+            . Founder-run customer pilot setup is separate from public signup.
           </p>
         </section>
 
@@ -87,7 +88,7 @@ export default function PricingPage() {
                       Contact Sales
                     </Link>
                   ) : (
-                    <Link className={buttonVariants()} href="/sign-up">
+                    <Link className={buttonVariants()} href={PUBLIC_START_FREE_PILOT_PATH}>
                       Start Free Pilot
                     </Link>
                   )}
@@ -122,6 +123,9 @@ export default function PricingPage() {
               <p>STOP, START, and HELP handling remain part of the live messaging flow, and the consent page stays public.</p>
               <p>Businesses remain responsible for lawful texting practices and consent requirements in their market.</p>
               <div className="flex flex-wrap gap-3 pt-2">
+                <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={PUBLIC_CREATE_ACCOUNT_PATH}>
+                  Create account
+                </Link>
                 <Link className={buttonVariants({ size: 'sm' })} href="/sms-consent">
                   Review SMS consent
                 </Link>

--- a/app/simulator/actions.ts
+++ b/app/simulator/actions.ts
@@ -38,7 +38,7 @@ export async function startSimulatorRunAction(formData: FormData) {
   const transport = realSmsEnabled ? 'twilio' : 'simulated';
   const notice = realSmsEnabled
     ? 'Simulator started. CallbackCloser should text the number you entered from the demo business texting line.'
-    : 'Preview mode active. This simulator run updates the transcript and owner alerts on-page, but it does not text your phone until a real demo texting line is assigned and ENABLE_PUBLIC_SIMULATOR_REAL_SMS=true.';
+    : 'Preview mode active. This simulator run updates the transcript and owner alerts on-page, but it does not text your phone until the demo texting line is configured for real SMS delivery.';
 
   const call = await db.call.create({
     data: {

--- a/app/simulator/page.tsx
+++ b/app/simulator/page.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { formatDateTime, getLeadStatusBadgeVariant, leadReadinessLabels, leadStatusLabels } from '@/lib/lead-presenters';
+import { PUBLIC_CREATE_ACCOUNT_PATH, PUBLIC_START_FREE_PILOT_PATH } from '@/lib/public-auth-routing';
 import { canSendRealSimulatorSms, getSimulatorBusiness, getSimulatorRun, isPlaceholderSimulatorNumber, isPublicSimulatorEnabled } from '@/lib/simulator';
 
 export const metadata: Metadata = {
@@ -101,7 +102,7 @@ export default async function SimulatorPage({
                   Demo number unavailable
                 </Button>
               )}
-              <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} href="/sign-up">
+              <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} href={PUBLIC_START_FREE_PILOT_PATH}>
                 Start Free Pilot
               </Link>
             </div>
@@ -115,7 +116,7 @@ export default async function SimulatorPage({
                   ? 'CallbackCloser will text the phone number you enter from the demo business texting line, then continue the rest of the flow in this page.'
                   : usingPlaceholderTextingLine
                     ? 'This demo workspace is still using the safe placeholder texting line, so CallbackCloser will show the recovery text and owner alerts on this page instead of sending a real SMS.'
-                    : 'ENABLE_PUBLIC_SIMULATOR_REAL_SMS is still off, so CallbackCloser will show the recovery text and owner alerts on this page instead of sending a real SMS.'}
+                    : 'Real SMS mode is not enabled for this environment yet, so CallbackCloser will show the recovery text and owner alerts on this page instead of sending a real SMS.'}
               </p>
             </div>
           </div>
@@ -258,14 +259,14 @@ export default async function SimulatorPage({
                   )}
 
                   <div className="flex flex-wrap gap-3">
-                    <Link className={buttonVariants()} href="/sign-up">
-                      Start trial
+                    <Link className={buttonVariants()} href={PUBLIC_CREATE_ACCOUNT_PATH}>
+                      Create account
                     </Link>
-                    <Link className={buttonVariants({ variant: 'outline' })} href="/contact">
-                      Request setup
+                    <Link className={buttonVariants({ variant: 'outline' })} href={PUBLIC_START_FREE_PILOT_PATH}>
+                      Start Free Pilot
                     </Link>
                     <Link className={buttonVariants({ variant: 'ghost' })} href="/pricing">
-                      Book demo
+                      View pricing
                     </Link>
                   </div>
                 </div>

--- a/app/start-free-pilot/page.tsx
+++ b/app/start-free-pilot/page.tsx
@@ -1,0 +1,27 @@
+import { auth } from '@clerk/nextjs/server';
+import { redirect } from 'next/navigation';
+
+import { getAdminSession } from '@/lib/admin';
+import { getBusinessForOwnerClerkId } from '@/lib/business-access';
+import { resolvePublicPilotDestination } from '@/lib/public-auth-routing';
+
+export default async function StartFreePilotPage() {
+  const { userId } = await auth();
+
+  if (!userId) {
+    redirect(resolvePublicPilotDestination({ isAuthenticated: false, isAdmin: false, hasBusiness: false }));
+  }
+
+  const [adminSession, business] = await Promise.all([
+    getAdminSession(),
+    getBusinessForOwnerClerkId(userId),
+  ]);
+
+  redirect(
+    resolvePublicPilotDestination({
+      isAuthenticated: true,
+      isAdmin: Boolean(adminSession?.isAdmin),
+      hasBusiness: Boolean(business),
+    })
+  );
+}

--- a/components/public-site-footer.tsx
+++ b/components/public-site-footer.tsx
@@ -1,6 +1,11 @@
 import Link from 'next/link';
 
+import { PUBLIC_CREATE_ACCOUNT_PATH, PUBLIC_SIGN_IN_PATH, PUBLIC_START_FREE_PILOT_PATH } from '@/lib/public-auth-routing';
+
 const footerLinks = [
+  { href: PUBLIC_CREATE_ACCOUNT_PATH, label: 'Create account' },
+  { href: PUBLIC_START_FREE_PILOT_PATH, label: 'Start Free Pilot' },
+  { href: PUBLIC_SIGN_IN_PATH, label: 'Sign in' },
   { href: '/pricing', label: 'Pricing' },
   { href: '/demo', label: 'Missed-Call Demo' },
   { href: '/contact', label: 'Contact' },

--- a/components/public-site-nav.tsx
+++ b/components/public-site-nav.tsx
@@ -2,14 +2,15 @@ import Link from 'next/link';
 
 import { Badge } from '@/components/ui/badge';
 import { buttonVariants } from '@/components/ui/button';
+import { PUBLIC_CREATE_ACCOUNT_PATH, PUBLIC_SIGN_IN_PATH, PUBLIC_START_FREE_PILOT_PATH } from '@/lib/public-auth-routing';
 
 const primaryLinks = [
+  { href: '/demo', label: 'Demo' },
   { href: '/pricing', label: 'Pricing' },
-  { href: '/#how-it-works', label: 'How it works' },
-  { href: '/#proof', label: 'Results' },
-  { href: '/demo', label: 'See demo' },
   { href: '/contact', label: 'Contact' },
   { href: '/sms-consent', label: 'SMS Consent' },
+  { href: '/privacy', label: 'Privacy' },
+  { href: '/terms', label: 'Terms' },
 ];
 
 export function PublicSiteNav() {
@@ -35,10 +36,13 @@ export function PublicSiteNav() {
           </nav>
 
           <div className="flex items-center gap-2">
-            <Link className={buttonVariants({ size: 'sm', variant: 'ghost' })} href="/sign-in">
+            <Link className={buttonVariants({ size: 'sm', variant: 'ghost' })} href={PUBLIC_SIGN_IN_PATH}>
               Sign in
             </Link>
-            <Link className={buttonVariants({ size: 'sm' })} href="/sign-up">
+            <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={PUBLIC_CREATE_ACCOUNT_PATH}>
+              Create account
+            </Link>
+            <Link className={buttonVariants({ size: 'sm' })} href={PUBLIC_START_FREE_PILOT_PATH}>
               Start Free Pilot
             </Link>
           </div>

--- a/lib/log-sanitization.ts
+++ b/lib/log-sanitization.ts
@@ -1,0 +1,73 @@
+import { maskPhoneForAudit } from '@/lib/phone';
+
+const SECRET_KEY_PATTERN = /(token|secret|authorization|api[-_]?key|signature)/i;
+const BODY_KEY_PATTERN = /(^body$|bodyPreview|messageBody|textBody)/i;
+const PHONE_KEY_PATTERN = /(phone|from|to|destination)/i;
+const SID_KEY_PATTERN = /sid/i;
+const TWILIO_SID_PATTERN = /^[A-Z]{2}[0-9a-fA-F]{32}$/;
+
+function maskSid(value: string) {
+  if (value.length <= 8) return value;
+  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+}
+
+function redactEmbeddedSecrets(value: string) {
+  return value
+    .replace(/(Bearer\s+)[^\s]+/gi, '$1[redacted]')
+    .replace(/(Basic\s+)[A-Za-z0-9+/=]+/gi, '$1[redacted]')
+    .replace(/([?&](?:token|webhook_token|auth|signature|api_key)=)[^&]+/gi, '$1[redacted]');
+}
+
+function sanitizeString(value: string, key: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return trimmed;
+
+  if (SECRET_KEY_PATTERN.test(key)) {
+    return '[redacted]';
+  }
+
+  if (BODY_KEY_PATTERN.test(key)) {
+    return `[redacted:${trimmed.length} chars]`;
+  }
+
+  if (SID_KEY_PATTERN.test(key) && TWILIO_SID_PATTERN.test(trimmed)) {
+    return maskSid(trimmed);
+  }
+
+  if (PHONE_KEY_PATTERN.test(key)) {
+    const maskedPhone = maskPhoneForAudit(trimmed);
+    if (maskedPhone) return maskedPhone;
+  }
+
+  const redacted = redactEmbeddedSecrets(trimmed);
+  return redacted.length > 240 ? `${redacted.slice(0, 239)}…` : redacted;
+}
+
+function sanitizeArray(values: unknown[], key: string, depth: number): unknown[] {
+  if (depth >= 3) return ['[truncated]'];
+  return values.slice(0, 12).map((value) => sanitizeLogValue(value, key, depth + 1));
+}
+
+function sanitizeObject(value: Record<string, unknown>, depth: number) {
+  if (depth >= 3) return '[truncated]';
+
+  const output: Record<string, unknown> = {};
+  for (const [entryKey, entryValue] of Object.entries(value).slice(0, 24)) {
+    output[entryKey] = sanitizeLogValue(entryValue, entryKey, depth + 1);
+  }
+  return output;
+}
+
+export function sanitizeLogValue(value: unknown, key = '', depth = 0): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'string') return sanitizeString(value, key);
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return sanitizeArray(value, key, depth);
+  if (typeof value === 'object') return sanitizeObject(value as Record<string, unknown>, depth);
+  return String(value);
+}
+
+export function sanitizeLogFields(fields: Record<string, unknown>) {
+  return sanitizeObject(fields, 0) as Record<string, unknown>;
+}

--- a/lib/observability.ts
+++ b/lib/observability.ts
@@ -81,13 +81,14 @@ export function withCorrelationIdHeader<T extends Response>(response: T, correla
 }
 
 export function reportApplicationError(input: ReportErrorInput) {
+  const metadata = sanitizeLogFields(input.metadata ?? {});
   const errorMessage = input.error === undefined ? 'unknown_error' : toErrorMessage(input.error);
   const payload: ErrorReportPayload = {
     source: input.source,
     event: input.event,
     correlationId: input.correlationId,
     error: errorMessage,
-    metadata: input.metadata ?? {},
+    metadata,
     timestamp: new Date().toISOString(),
   };
 
@@ -96,3 +97,4 @@ export function reportApplicationError(input: ReportErrorInput) {
   if (input.alert === false) return;
   void dispatchAlert(payload);
 }
+import { sanitizeLogFields } from '@/lib/log-sanitization';

--- a/lib/public-auth-routing.ts
+++ b/lib/public-auth-routing.ts
@@ -1,0 +1,35 @@
+export const PUBLIC_CREATE_ACCOUNT_PATH = '/sign-up?intent=create-account';
+export const PUBLIC_START_FREE_PILOT_PATH = '/start-free-pilot';
+export const PUBLIC_SIGN_IN_PATH = '/sign-in';
+export const OWNER_DASHBOARD_PATH = '/app';
+export const OWNER_ONBOARDING_PATH = '/app/onboarding?source=public-sign-up';
+export const ADMIN_NEW_BUSINESS_PILOT_PATH = '/admin?intent=new-business-pilot';
+
+type SignedInRoutingState = {
+  hasBusiness: boolean;
+  isAdmin: boolean;
+};
+
+type PublicPilotRoutingState = SignedInRoutingState & {
+  isAuthenticated: boolean;
+};
+
+export function resolveSignedInAppDestination(state: SignedInRoutingState) {
+  if (state.isAdmin) {
+    return ADMIN_NEW_BUSINESS_PILOT_PATH;
+  }
+
+  if (state.hasBusiness) {
+    return OWNER_DASHBOARD_PATH;
+  }
+
+  return OWNER_ONBOARDING_PATH;
+}
+
+export function resolvePublicPilotDestination(state: PublicPilotRoutingState) {
+  if (!state.isAuthenticated) {
+    return '/sign-up?intent=pilot';
+  }
+
+  return resolveSignedInAppDestination(state);
+}

--- a/lib/security-headers.ts
+++ b/lib/security-headers.ts
@@ -4,6 +4,25 @@ function isProductionEnv(env: EnvMap) {
   return env.NODE_ENV === 'production';
 }
 
+function buildContentSecurityPolicy() {
+  return [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    "form-action 'self' https://*.clerk.com https://*.clerk.accounts.dev https://checkout.stripe.com https://billing.stripe.com",
+    "script-src 'self' 'unsafe-inline' https://js.stripe.com https://*.clerk.com https://*.clerk.accounts.dev",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data: https://fonts.gstatic.com",
+    "connect-src 'self' https://api.stripe.com https://checkout.stripe.com https://billing.stripe.com https://*.clerk.com https://*.clerk.accounts.dev",
+    "frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://*.clerk.com https://*.clerk.accounts.dev",
+    "media-src 'self' blob:",
+    "manifest-src 'self'",
+    'upgrade-insecure-requests',
+  ].join('; ');
+}
+
 export function getSecurityHeaders(env: EnvMap = process.env): Record<string, string> {
   const headers: Record<string, string> = {
     'X-Content-Type-Options': 'nosniff',
@@ -14,6 +33,7 @@ export function getSecurityHeaders(env: EnvMap = process.env): Record<string, st
 
   if (isProductionEnv(env)) {
     headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains; preload';
+    headers['Content-Security-Policy'] = buildContentSecurityPolicy();
   }
 
   return headers;

--- a/lib/twilio-logging.ts
+++ b/lib/twilio-logging.ts
@@ -1,3 +1,4 @@
+import { sanitizeLogFields } from '@/lib/log-sanitization';
 import { reportApplicationError } from './observability.ts';
 
 type TwilioLogRoute = 'voice' | 'sms' | 'status' | 'messaging' | 'webhook-auth' | 'provisioning';
@@ -11,7 +12,7 @@ function errorMessage(error: unknown) {
 }
 
 function write(level: TwilioLogLevel, route: TwilioLogRoute, event: string, fields: TwilioLogFields) {
-  const payload = { route, event, ...fields };
+  const payload = { route, event, ...sanitizeLogFields(fields) };
   if (level === 'info') console.info(`twilio.${route}`, payload);
   if (level === 'warn') console.warn(`twilio.${route}`, payload);
   if (level === 'error') console.error(`twilio.${route}`, payload);

--- a/middleware.ts
+++ b/middleware.ts
@@ -13,8 +13,18 @@ import { RATE_LIMIT_PROTECTED_API_MAX, RATE_LIMIT_WINDOW_MS } from '@/lib/rate-l
 import { buildRateLimitHeaders, consumeRateLimit, getClientIpAddress } from '@/lib/rate-limit';
 import { withSecurityHeaders } from '@/lib/security-headers';
 
-const isProtectedRoute = createRouteMatcher(['/app(.*)', '/admin(.*)', '/api/stripe/checkout(.*)', '/api/stripe/portal(.*)']);
-const isProtectedApiMutationRoute = createRouteMatcher(['/api/stripe/checkout', '/api/stripe/portal']);
+const isProtectedRoute = createRouteMatcher([
+  '/app(.*)',
+  '/admin(.*)',
+  '/api/stripe/checkout(.*)',
+  '/api/stripe/portal(.*)',
+  '/api/twilio/provision-number(.*)',
+]);
+const isProtectedApiMutationRoute = createRouteMatcher([
+  '/api/stripe/checkout',
+  '/api/stripe/portal',
+  '/api/twilio/provision-number',
+]);
 let productionDemoGuardrailLogged = false;
 let productionDemoOverrideLogged = false;
 let missingClerkEnvLogged = false;

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import test from 'node:test';
 
 import { isFounderUserId } from '../lib/admin.ts';
+
+function read(relativePath: string) {
+  return readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+}
 
 test('isFounderUserId only authorizes the configured founder account', () => {
   const env = {
@@ -11,4 +17,24 @@ test('isFounderUserId only authorizes the configured founder account', () => {
   assert.equal(isFounderUserId('user_founder', env), true);
   assert.equal(isFounderUserId('user_customer', env), false);
   assert.equal(isFounderUserId(null, env), false);
+});
+
+test('admin pages and customer-mode routes require real admin authorization', () => {
+  const adminPage = read('app/admin/page.tsx');
+  const adminBusinessPage = read('app/admin/[businessId]/page.tsx');
+  const adminActions = read('app/admin/actions.ts');
+  const openCustomerRoute = read('app/admin/[businessId]/open-customer/route.ts');
+  const exitCustomerModeRoute = read('app/admin/exit-customer-mode/route.ts');
+  const appLayout = read('app/app/layout.tsx');
+  const adminContext = read('lib/admin-customer-context.ts');
+
+  assert.match(adminPage, /const admin = await requireAdmin\(\)/);
+  assert.match(adminBusinessPage, /await requireAdmin\(\)/);
+  assert.match(adminActions, /const admin = await requireAdmin\(\)/);
+  assert.match(openCustomerRoute, /const adminSession = await getAdminSession\(\)/);
+  assert.match(openCustomerRoute, /if \(!adminSession\.isAdmin\)/);
+  assert.match(exitCustomerModeRoute, /const adminSession = await getAdminSession\(\)/);
+  assert.match(exitCustomerModeRoute, /if \(!adminSession\.isAdmin\)/);
+  assert.match(appLayout, /const adminCustomerContext = await getAdminCustomerActingContext\(\)/);
+  assert.match(adminContext, /if \(!adminSession\?\.isAdmin\)/);
 });

--- a/tests/legal-pages.test.ts
+++ b/tests/legal-pages.test.ts
@@ -74,14 +74,25 @@ test('public-facing surfaces link to trust and contact routes', () => {
 
   assert.match(home, /href="\/pricing"/);
   assert.match(home, /href="\/sms-consent"/);
+  assert.match(home, /PUBLIC_CREATE_ACCOUNT_PATH/);
+  assert.match(home, /PUBLIC_START_FREE_PILOT_PATH/);
+  assert.match(nav, /href: '\/demo'/);
   assert.match(nav, /href: '\/pricing'/);
   assert.match(nav, /href: '\/contact'/);
   assert.match(nav, /href: '\/sms-consent'/);
+  assert.match(nav, /href: '\/privacy'/);
+  assert.match(nav, /href: '\/terms'/);
+  assert.match(nav, /PUBLIC_SIGN_IN_PATH/);
+  assert.match(nav, /PUBLIC_CREATE_ACCOUNT_PATH/);
+  assert.match(nav, /PUBLIC_START_FREE_PILOT_PATH/);
   assert.match(footer, /href: '\/privacy'/);
   assert.match(footer, /href: '\/terms'/);
   assert.match(footer, /href: '\/refund'/);
   assert.match(footer, /href: '\/contact'/);
   assert.match(footer, /href: '\/sms-consent'/);
+  assert.match(footer, /PUBLIC_CREATE_ACCOUNT_PATH/);
+  assert.match(footer, /PUBLIC_START_FREE_PILOT_PATH/);
+  assert.match(footer, /PUBLIC_SIGN_IN_PATH/);
 
   assert.match(billing, /href="\/pricing"/);
   assert.match(billing, /href="\/refund"/);

--- a/tests/log-sanitization.test.ts
+++ b/tests/log-sanitization.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { sanitizeLogFields, sanitizeLogValue } from '../lib/log-sanitization.ts';
+
+test('sanitizeLogFields redacts secrets, bodies, phones, and SIDs', () => {
+  const sanitized = sanitizeLogFields({
+    authToken: 'super-secret-token',
+    body: 'Customer said their AC is out and needs help now.',
+    fromPhone: '+15551234567',
+    messageSid: 'SM1234567890abcdef1234567890abcdef',
+    safeFlag: true,
+  });
+
+  assert.deepEqual(sanitized, {
+    authToken: '[redacted]',
+    body: '[redacted:49 chars]',
+    fromPhone: '+1***4567',
+    messageSid: 'SM12...cdef',
+    safeFlag: true,
+  });
+});
+
+test('sanitizeLogValue redacts embedded credentials and truncates deep payloads safely', () => {
+  const sanitizedUrl = sanitizeLogValue(
+    'Bearer supersecrettoken https://example.com/api/twilio/status?webhook_token=abc123',
+    'details'
+  );
+  const nested = sanitizeLogValue({
+    level1: {
+      level2: {
+        level3: {
+          level4: 'too deep',
+        },
+      },
+    },
+  });
+
+  assert.equal(sanitizedUrl, 'Bearer [redacted] https://example.com/api/twilio/status?webhook_token=[redacted]');
+  assert.deepEqual(nested, {
+    level1: {
+      level2: {
+        level3: '[truncated]',
+      },
+    },
+  });
+});

--- a/tests/public-auth-routing.test.ts
+++ b/tests/public-auth-routing.test.ts
@@ -3,6 +3,14 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 
+import {
+  ADMIN_NEW_BUSINESS_PILOT_PATH,
+  OWNER_DASHBOARD_PATH,
+  OWNER_ONBOARDING_PATH,
+  resolvePublicPilotDestination,
+  resolveSignedInAppDestination,
+} from '../lib/public-auth-routing.ts';
+
 function read(relativePath: string) {
   return readFileSync(path.join(process.cwd(), relativePath), 'utf8');
 }
@@ -12,10 +20,13 @@ const invalidNestedButtonPattern = /<Link[^>]*>\s*<Button/;
 test('public CTA links do not nest button elements inside next/link anchors', () => {
   const files = [
     'components/public-site-nav.tsx',
+    'components/public-site-footer.tsx',
     'components/upgrade-banner.tsx',
     'app/page.tsx',
     'app/pricing/page.tsx',
     'app/contact/page.tsx',
+    'app/demo/page.tsx',
+    'app/simulator/page.tsx',
     'app/app/billing/page.tsx',
   ];
 
@@ -28,11 +39,62 @@ test('clerk auth surfaces use explicit path routing and fallback redirects', () 
   const layout = read('app/layout.tsx');
   const signInPage = read('app/(auth)/sign-in/[[...sign-in]]/page.tsx');
   const signUpPage = read('app/(auth)/sign-up/[[...sign-up]]/page.tsx');
+  const pilotEntryPage = read('app/start-free-pilot/page.tsx');
 
   assert.match(layout, /signInFallbackRedirectUrl=\{DEFAULT_CLERK_AFTER_AUTH_URL\}/);
   assert.match(layout, /signUpFallbackRedirectUrl=\{DEFAULT_CLERK_AFTER_AUTH_URL\}/);
   assert.match(signInPage, /routing="path"/);
   assert.match(signInPage, /fallbackRedirectUrl=\{DEFAULT_CLERK_AFTER_AUTH_URL\}/);
+  assert.match(signInPage, /resolveSignedInAppDestination/);
   assert.match(signUpPage, /routing="path"/);
   assert.match(signUpPage, /fallbackRedirectUrl=\{DEFAULT_CLERK_AFTER_AUTH_URL\}/);
+  assert.match(signUpPage, /resolveSignedInAppDestination/);
+  assert.match(signUpPage, /Founder-operated customer pilot setup is separate/i);
+  assert.match(pilotEntryPage, /resolvePublicPilotDestination/);
+});
+
+test('public pilot routing keeps logged-out, owner, and admin flows separate', () => {
+  assert.equal(
+    resolvePublicPilotDestination({
+      isAuthenticated: false,
+      isAdmin: false,
+      hasBusiness: false,
+    }),
+    '/sign-up?intent=pilot'
+  );
+
+  assert.equal(
+    resolvePublicPilotDestination({
+      isAuthenticated: true,
+      isAdmin: false,
+      hasBusiness: false,
+    }),
+    OWNER_ONBOARDING_PATH
+  );
+
+  assert.equal(
+    resolvePublicPilotDestination({
+      isAuthenticated: true,
+      isAdmin: false,
+      hasBusiness: true,
+    }),
+    OWNER_DASHBOARD_PATH
+  );
+
+  assert.equal(
+    resolvePublicPilotDestination({
+      isAuthenticated: true,
+      isAdmin: true,
+      hasBusiness: true,
+    }),
+    ADMIN_NEW_BUSINESS_PILOT_PATH
+  );
+
+  assert.equal(
+    resolveSignedInAppDestination({
+      isAdmin: true,
+      hasBusiness: false,
+    }),
+    ADMIN_NEW_BUSINESS_PILOT_PATH
+  );
 });

--- a/tests/public-demo-route.test.ts
+++ b/tests/public-demo-route.test.ts
@@ -9,6 +9,8 @@ function read(relativePath: string) {
 
 test('public demo route is auth-free and built from isolated demo data', () => {
   const demoPage = read('app/demo/page.tsx');
+  const simulatorPage = read('app/simulator/page.tsx');
+  const simulatorActions = read('app/simulator/actions.ts');
   const demoData = read('lib/demo-data.ts');
   const middleware = read('middleware.ts');
 
@@ -16,9 +18,14 @@ test('public demo route is auth-free and built from isolated demo data', () => {
   assert.match(demoPage, /PublicDemoReplay/);
   assert.match(demoPage, /Stop losing jobs when you miss the call/i);
   assert.match(demoPage, /This is exactly what your customer sees after you miss their call/i);
+  assert.match(demoPage, /Demo only: fake business, fake callers, and no live customer or Twilio data\./);
   assert.match(demoData, /No login, no real customer data, no live Twilio traffic/i);
   assert.match(demoPage, /from ['"]@\/lib\/demo-data['"]/);
   assert.doesNotMatch(demoPage, /requireBusiness|getBusinessForOwnerClerkId|db\./);
+  assert.match(simulatorPage, /PUBLIC_START_FREE_PILOT_PATH/);
+  assert.match(simulatorPage, /PUBLIC_CREATE_ACCOUNT_PATH/);
+  assert.doesNotMatch(simulatorPage, /ENABLE_PUBLIC_SIMULATOR_REAL_SMS|SIMULATOR_BUSINESS_ID/);
+  assert.doesNotMatch(simulatorActions, /ENABLE_PUBLIC_SIMULATOR_REAL_SMS/);
   assert.doesNotMatch(middleware, /\/demo\(.\*\)/);
   assert.match(demoData, /Jamie Carter/);
   assert.match(demoData, /New HVAC lead/);

--- a/tests/security-headers.test.ts
+++ b/tests/security-headers.test.ts
@@ -16,4 +16,9 @@ test('getSecurityHeaders includes HSTS in production', () => {
   const headers = getSecurityHeaders({ NODE_ENV: 'production' });
 
   assert.equal(headers['Strict-Transport-Security'], 'max-age=31536000; includeSubDomains; preload');
+  assert.match(headers['Content-Security-Policy'] || '', /default-src 'self'/);
+  assert.match(headers['Content-Security-Policy'] || '', /form-action 'self' https:\/\/\*\.clerk\.com https:\/\/\*\.clerk\.accounts\.dev https:\/\/checkout\.stripe\.com https:\/\/billing\.stripe\.com/);
+  assert.match(headers['Content-Security-Policy'] || '', /script-src 'self' 'unsafe-inline' https:\/\/js\.stripe\.com https:\/\/\*\.clerk\.com https:\/\/\*\.clerk\.accounts\.dev/);
+  assert.match(headers['Content-Security-Policy'] || '', /frame-ancestors 'none'/);
+  assert.match(headers['Content-Security-Policy'] || '', /upgrade-insecure-requests/);
 });

--- a/tests/tenant-isolation-wiring.test.ts
+++ b/tests/tenant-isolation-wiring.test.ts
@@ -34,3 +34,18 @@ test('protected app surfaces use shared tenant-scoped access helpers', () => {
   assert.match(billingPage, /getBillingUsageSnapshotForBusiness/);
   assert.match(recordingRoute, /getLeadRecordingForOwnerClerkId/);
 });
+
+test('middleware protects owner and admin app surfaces plus sensitive authenticated mutations', () => {
+  const middleware = read('middleware.ts');
+  const twilioProvisionRoute = read('app/api/twilio/provision-number/route.ts');
+
+  assert.match(middleware, /'\/app\(\.\*\)'/);
+  assert.match(middleware, /'\/admin\(\.\*\)'/);
+  assert.match(middleware, /'\/api\/stripe\/checkout\(\.\*\)'/);
+  assert.match(middleware, /'\/api\/stripe\/portal\(\.\*\)'/);
+  assert.match(middleware, /'\/api\/twilio\/provision-number\(\.\*\)'/);
+  assert.match(middleware, /'\/api\/twilio\/provision-number'/);
+  assert.match(twilioProvisionRoute, /auth\(\)/);
+  assert.match(twilioProvisionRoute, /isAllowedRequestOrigin/);
+  assert.match(twilioProvisionRoute, /Invalid request origin/);
+});

--- a/tests/webhook-security.test.ts
+++ b/tests/webhook-security.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+async function withEnv<T>(overrides: Record<string, string | undefined>, fn: () => Promise<T> | T) {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(overrides)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+async function loadTwilioRoutes() {
+  const require = createRequire(import.meta.url);
+  const serverOnlyPath = require.resolve('server-only');
+  require.cache[serverOnlyPath] = {
+    id: serverOnlyPath,
+    filename: serverOnlyPath,
+    loaded: true,
+    exports: {},
+  } as NodeJS.Module;
+
+  return Promise.all([
+    import('../app/api/twilio/voice/route.ts'),
+    import('../app/api/twilio/status/route.ts'),
+    import('../app/api/twilio/sms/route.ts'),
+    import('../app/api/twilio/message-status/route.ts'),
+  ]);
+}
+
+test('twilio webhook routes reject unsigned requests in production', async () => {
+  await withEnv(
+    {
+      NODE_ENV: 'production',
+      TWILIO_VALIDATE_SIGNATURE: 'true',
+      TWILIO_AUTH_TOKEN: 'twilio_auth_token_fixture',
+      TWILIO_WEBHOOK_AUTH_TOKEN: undefined,
+    },
+    async () => {
+      const [
+        { POST: voicePost },
+        { POST: statusPost },
+        { POST: smsPost },
+        { POST: messageStatusPost },
+      ] = await loadTwilioRoutes();
+
+      const requests = [
+        voicePost(
+          new Request('https://app.callbackcloser.com/api/twilio/voice', {
+            method: 'POST',
+            body: new FormData(),
+          })
+        ),
+        statusPost(
+          new Request('https://app.callbackcloser.com/api/twilio/status', {
+            method: 'POST',
+            body: new FormData(),
+          })
+        ),
+        smsPost(
+          new Request('https://app.callbackcloser.com/api/twilio/sms', {
+            method: 'POST',
+            body: new FormData(),
+          })
+        ),
+        messageStatusPost(
+          new Request('https://app.callbackcloser.com/api/twilio/message-status', {
+            method: 'POST',
+            body: new FormData(),
+          })
+        ),
+      ];
+
+      const responses = await Promise.all(requests);
+      for (const response of responses) {
+        assert.equal(response.status, 401);
+      }
+    }
+  );
+});
+
+test('stripe webhook rejects missing configuration and invalid signatures', async () => {
+  const { POST } = await import('../app/api/stripe/webhook/route.ts');
+
+  await withEnv(
+    {
+      STRIPE_SECRET_KEY: undefined,
+      STRIPE_WEBHOOK_SECRET: undefined,
+    },
+    async () => {
+      const response = await POST(
+        new Request('https://app.callbackcloser.com/api/stripe/webhook', {
+          method: 'POST',
+          body: '{}',
+        })
+      );
+
+      assert.equal(response.status, 400);
+      assert.match(await response.text(), /Missing Stripe webhook configuration/);
+    }
+  );
+
+  await withEnv(
+    {
+      STRIPE_SECRET_KEY: 'sk_test_fixture_123',
+      STRIPE_WEBHOOK_SECRET: 'whsec_fixture_123',
+    },
+    async () => {
+      const response = await POST(
+        new Request('https://app.callbackcloser.com/api/stripe/webhook', {
+          method: 'POST',
+          body: JSON.stringify({ id: 'evt_test' }),
+          headers: {
+            'content-type': 'application/json',
+            'stripe-signature': 'bad-signature',
+          },
+        })
+      );
+
+      assert.equal(response.status, 400);
+      assert.match(await response.text(), /Invalid webhook signature|No signatures found matching the expected signature|Unable to extract timestamp and signatures from header/i);
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- make public CTA and auth routing intentional for logged-out visitors, signed-in owners, and founder/admin pilot setup
- add a dedicated public pilot entrypoint plus clear Create account / Sign in / Start Free Pilot messaging across the public site
- harden authenticated mutations and production logging with same-origin checks, sanitized Twilio/app logs, and production CSP headers
- add regression coverage for public routing, admin/auth boundaries, webhook rejection, CSP headers, tenant-isolation wiring, and log sanitization

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

## Remaining risks
- the public simulator still depends on explicit environment flags and a dedicated simulator business; it is safer now, but it remains an intentionally separate demo surface
- the CSP is conservative but still allows Clerk and Stripe inline/script requirements; future third-party embeds will need to be added deliberately
