### PR TITLE
Tighten admin operator triage state and actions

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import { BusinessProvisioningStatus } from '@prisma/client';
 
 import {
   archiveBusinessAction,
@@ -7,7 +6,6 @@ import {
   createDemoBusinessAction,
   deleteTestBusinessAction,
   founderDeleteAllBusinessesAction,
-  provisionBusinessAction,
   resyncBusinessWebhooksAction,
   restoreBusinessAction,
   sendBusinessTestSmsAction,
@@ -17,21 +15,19 @@ import { buildAdminCustomerOpenHref } from '@/lib/admin-customer-paths';
 import { FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION } from '@/lib/admin-business-lifecycle';
 import {
   adminBoardFilterOptions,
+  buildAdminBusinessCardState,
   buildAdminOnboardingConfidence,
   buildAdminBusinessPickerLabel,
   buildAdminNextStep,
   canDeleteTestBusiness,
   getDeleteTestBusinessBlockedReason,
   isBusinessArchived,
-  matchesAdminBoardFilter,
+  matchesAdminBoardFilterState,
   type AdminBoardFilter,
+  type AdminBusinessCardState,
 } from '@/lib/admin-dashboard';
 import { buildAdminMissedCallValidationTruth } from '@/lib/admin-operator-proof';
-import {
-  buildAdminBusinessIssue,
-  buildAdminTestSmsTruth,
-  getOperatorToneBadgeVariant,
-} from '@/lib/admin-operator-visibility';
+import { buildAdminBusinessIssue, buildAdminTestSmsTruth } from '@/lib/admin-operator-visibility';
 import { AdminBusinessPicker } from '@/components/admin-business-picker';
 import { requireAdmin } from '@/lib/admin';
 import { isTestDemoBusiness } from '@/lib/admin-test-data-reset';
@@ -66,42 +62,20 @@ function maxDate(...values: Array<Date | null | undefined>) {
   return new Date(Math.max(...timestamps));
 }
 
-function getOverallStatus(params: {
-  archived: boolean;
-  paused: boolean;
-  live: boolean;
-  needsAttention: boolean;
-}) {
-  if (params.archived) return { label: 'Archived', variant: 'outline' as const };
-  if (params.paused) return { label: 'Paused', variant: 'outline' as const };
-  if (params.needsAttention) return { label: 'Needs attention', variant: 'destructive' as const };
-  if (params.live) return { label: 'Live', variant: 'success' as const };
-  return { label: 'Pending', variant: 'secondary' as const };
+function buildAdminStepHref(businessId: string, stepKey: string | null) {
+  return stepKey ? `/admin/${businessId}?step=${stepKey}#step-${stepKey}` : `/admin/${businessId}`;
 }
 
-function getA2pStateLabel(params: {
-  complianceReady: boolean;
-  attentionRequired: boolean;
-  complianceStarted: boolean;
-  complianceTypeUnknown: boolean;
-  complianceTypeLabel: string;
-}) {
-  if (params.complianceReady) {
-    return { label: params.complianceTypeLabel === 'Toll-free verification' ? 'Verified' : 'Approved', variant: 'success' as const };
+function getCardPrimaryActionHref(businessId: string, cardState: AdminBusinessCardState) {
+  if (cardState.nextActionStepKey) {
+    return buildAdminStepHref(businessId, cardState.nextActionStepKey);
   }
-  if (params.attentionRequired) return { label: 'Needs attention', variant: 'destructive' as const };
-  if (params.complianceTypeUnknown) return { label: 'Not selected', variant: 'outline' as const };
-  if (params.complianceStarted) {
-    return { label: params.complianceTypeLabel === 'Toll-free verification' ? 'Pending verification' : 'Pending', variant: 'secondary' as const };
-  }
-  return { label: 'Not started', variant: 'outline' as const };
-}
 
-function compactCopy(value: string, maxLength = 110) {
-  const trimmed = value.trim();
-  if (!trimmed) return 'No issues recorded.';
-  if (trimmed.length <= maxLength) return trimmed;
-  return `${trimmed.slice(0, maxLength - 1)}…`;
+  if (cardState.primaryState === 'archived') {
+    return `/admin/${businessId}#advanced`;
+  }
+
+  return `/admin/${businessId}`;
 }
 
 function buildAdminBoardReturnPath(params: {
@@ -377,21 +351,6 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       messageActivityMap.get(business.id)
     );
     const assignedNumber = getManagedTextingNumber(business);
-    const archived = isBusinessArchived(business);
-    const paused = !archived && business.provisioningStatus === 'PAUSED';
-    const overallStatus = getOverallStatus({
-      archived,
-      paused,
-      live: business.provisioningStatus === 'LIVE' && managedSummary.messagingReady,
-      needsAttention: nextStep.tone === 'attention' || managedSummary.attentionRequired,
-    });
-    const a2pState = getA2pStateLabel({
-      complianceReady: managedSummary.complianceReady,
-      attentionRequired: managedSummary.attentionRequired,
-      complianceStarted: managedSummary.complianceStarted,
-      complianceTypeUnknown: managedSummary.complianceTypeUnknown,
-      complianceTypeLabel: managedSummary.complianceTypeLabel,
-    });
     const lastIssue = buildAdminBusinessIssue({
       events: latestIssueMap.has(business.id) ? [latestIssueMap.get(business.id)!] : [],
       currentStep: {
@@ -414,17 +373,18 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       operatorEvents: businessConfidenceEvents,
       missedCallValidation,
     });
-    const attentionSignal =
-      lastIssue.state === 'issue'
-        ? compactCopy(`${lastIssue.summary}. ${lastIssue.detail}`)
-        : nextStep.tone === 'healthy'
-          ? 'Healthy. No immediate operator action needed.'
-          : compactCopy(`${nextStep.title}. ${nextStep.detail}`);
     const operatorSignals = operatorSignalMap.get(business.id) || { failed: 0, warning: 0 };
-    const blockerStepHref = lastIssue.remediationStepKey
-      ? `/admin/${business.id}?step=${lastIssue.remediationStepKey}#step-${lastIssue.remediationStepKey}`
-      : null;
-
+    const cardState = buildAdminBusinessCardState({
+      business,
+      notificationSettings: business.notificationSettings,
+      ownerConnected,
+      nextStep,
+      managedSummary,
+      onboardingConfidence,
+      lastIssue,
+      testSmsTruth,
+      missedCallValidation,
+    });
     return {
       business,
       ownerConnected,
@@ -436,31 +396,24 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       assignedNumber,
       lastActivityAt,
       lastIssue,
-      overallStatus,
-      a2pState,
-      attentionSignal,
       operatorSignals,
       testSmsTruth,
       missedCallValidation,
       onboardingConfidence,
       canSendTestSms: Boolean(assignedNumber && (business.notificationSettings?.ownerPhone || business.notifyPhone)),
-      blockerStepHref,
+      cardState,
     };
   });
 
   const filterCounts = new Map(
     adminBoardFilterOptions.map((option) => [
       option.key,
-      businessRows.filter((item) =>
-        matchesAdminBoardFilter(item.business, item.business.notificationSettings, item.ownerConnected, option.key)
-      ).length,
+      businessRows.filter((item) => matchesAdminBoardFilterState(item.cardState, option.key)).length,
     ])
   );
 
   const visibleRows = businessRows.filter((item) =>
-    selectedBusinessId
-      ? item.business.id === selectedBusinessId
-      : matchesAdminBoardFilter(item.business, item.business.notificationSettings, item.ownerConnected, view)
+    selectedBusinessId ? item.business.id === selectedBusinessId : matchesAdminBoardFilterState(item.cardState, view)
   );
   const pickerOptions = businessPickerOptions.map((business) => ({
     id: business.id,
@@ -480,10 +433,12 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
   });
 
   const summaryStats = [
-    { label: 'Pending setup', value: businessRows.filter((row) => row.business.provisioningStatus === BusinessProvisioningStatus.DRAFT).length },
-    { label: 'In setup', value: businessRows.filter((row) => row.business.provisioningStatus === BusinessProvisioningStatus.ONBOARDING).length },
-    { label: 'Needs attention', value: businessRows.filter((row) => row.onboardingConfidence.state === 'needs_attention').length },
-    { label: 'Ready for live', value: businessRows.filter((row) => row.onboardingConfidence.state === 'ready_to_go_live').length },
+    { label: 'Needs attention', value: businessRows.filter((row) => row.cardState.shouldAppearInNeedsAttention).length },
+    { label: 'Pending compliance', value: businessRows.filter((row) => row.cardState.shouldAppearInPendingCompliance).length },
+    { label: 'Ready for test', value: businessRows.filter((row) => row.cardState.isReadyForTest).length },
+    { label: 'Ready for live', value: businessRows.filter((row) => row.cardState.isReadyForLive).length },
+    { label: 'Live', value: businessRows.filter((row) => row.cardState.isLive).length },
+    { label: 'Archived', value: businessRows.filter((row) => row.cardState.isArchived).length },
   ];
   const founderResetBusinessCount = businessPickerOptions.length;
   const founderResetBusinessPreview = businessPickerOptions.slice(0, 4).map((business) => business.name);
@@ -510,7 +465,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
               hunting through long pages.
             </p>
           </div>
-          <div className="grid gap-3 sm:grid-cols-4">
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
             {summaryStats.map((item) => (
               <Card key={item.label} className="bg-card/90">
                 <CardHeader className="pb-2">
@@ -556,206 +511,232 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
       <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
         <Card className="border-primary/20 bg-primary/5">
           <CardHeader>
-            <CardTitle>Fast onboard</CardTitle>
-            <CardDescription>
-              Create the workspace with the minimum founder-needed inputs. The guided Twilio flow, explicit account-mode choice, and owner decision stay inside the business setup panel.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <form action={createAdminBusinessAction} className="grid gap-4 md:grid-cols-2">
-              <input type="hidden" name="missedCallSeconds" value="20" />
-              <input type="hidden" name="serviceLabel1" value="Repair" />
-              <input type="hidden" name="serviceLabel2" value="Install" />
-              <input type="hidden" name="serviceLabel3" value="Maintenance" />
+            <div className="rounded-xl border bg-background/80 p-4">
+              <details>
+                <summary className="cursor-pointer list-none space-y-1">
+                  <CardTitle>Create new business</CardTitle>
+                  <CardDescription>
+                    Fast onboard stays available here, collapsed by default so the triage board stays easier to reach during daily operator use.
+                  </CardDescription>
+                </summary>
+                <div className="mt-4">
+                  <form action={createAdminBusinessAction} className="grid gap-4 md:grid-cols-2">
+                    <input type="hidden" name="missedCallSeconds" value="20" />
+                    <input type="hidden" name="serviceLabel1" value="Repair" />
+                    <input type="hidden" name="serviceLabel2" value="Install" />
+                    <input type="hidden" name="serviceLabel3" value="Maintenance" />
 
-              <div className="space-y-2">
-                <Label htmlFor="name">Business name</Label>
-                <Input id="name" name="name" placeholder="Acme Plumbing" required />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="ownerEmail">Owner email</Label>
-                <Input id="ownerEmail" name="ownerEmail" type="email" placeholder="owner@business.com" required />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="ownerName">Owner name</Label>
-                <Input id="ownerName" name="ownerName" placeholder="Casey Owner" />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="ownerPhone">Owner alert phone</Label>
-                <Input id="ownerPhone" name="ownerPhone" type="tel" placeholder="+1 555 123 4567" />
-              </div>
-              <div className="md:col-span-2 space-y-3 rounded-xl border bg-background/80 p-4">
-                <div className="space-y-1">
-                  <p className="text-sm font-medium">Business number path</p>
-                  <p className="text-sm text-muted-foreground">Choose whether this business will forward its current number, port it later, or use a new CallbackCloser number.</p>
-                </div>
-                <div className="grid gap-3">
-                  {businessPhonePathOptions.map((option, index) => (
-                    <label key={option.value} className="rounded-xl border bg-card/80 p-4 text-sm">
-                      <div className="flex items-start gap-3">
-                        <input defaultChecked={index === 0} name="phoneSetupPath" type="radio" value={option.value} />
-                        <div className="space-y-1">
-                          <p className="font-medium">{option.label}</p>
-                          <p className="text-muted-foreground">{option.description}</p>
-                        </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="name">Business name</Label>
+                      <Input id="name" name="name" placeholder="Acme Plumbing" required />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="ownerEmail">Owner email</Label>
+                      <Input id="ownerEmail" name="ownerEmail" type="email" placeholder="owner@business.com" required />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="ownerName">Owner name</Label>
+                      <Input id="ownerName" name="ownerName" placeholder="Casey Owner" />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="ownerPhone">Owner alert phone</Label>
+                      <Input id="ownerPhone" name="ownerPhone" type="tel" placeholder="+1 555 123 4567" />
+                    </div>
+                    <div className="md:col-span-2 space-y-3 rounded-xl border bg-background/80 p-4">
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium">Business number path</p>
+                        <p className="text-sm text-muted-foreground">
+                          Choose whether this business will forward its current number, port it later, or use a new CallbackCloser number.
+                        </p>
                       </div>
+                      <div className="grid gap-3">
+                        {businessPhonePathOptions.map((option, index) => (
+                          <label key={option.value} className="rounded-xl border bg-card/80 p-4 text-sm">
+                            <div className="flex items-start gap-3">
+                              <input defaultChecked={index === 0} name="phoneSetupPath" type="radio" value={option.value} />
+                              <div className="space-y-1">
+                                <p className="font-medium">{option.label}</p>
+                                <p className="text-muted-foreground">{option.description}</p>
+                              </div>
+                            </div>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="publicBusinessPhone">Public business number</Label>
+                      <Input id="publicBusinessPhone" name="publicBusinessPhone" type="tel" placeholder="+1 555 111 0000" />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="forwardingNumber">Owner forwarding / answer number</Label>
+                      <Input id="forwardingNumber" name="forwardingNumber" type="tel" placeholder="+1 555 222 0000" required />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="timezone">Timezone</Label>
+                      <Input id="timezone" name="timezone" defaultValue="America/New_York" />
+                    </div>
+
+                    <label className="md:col-span-2 flex items-start gap-2 rounded-xl border bg-background/80 p-3 text-sm">
+                      <input name="isTestBusiness" type="checkbox" value="true" />
+                      <span>Mark as a test/demo business so archive and delete stay safely separated from real customers.</span>
                     </label>
-                  ))}
+
+                    <div className="md:col-span-2 flex flex-wrap items-center gap-3">
+                      <Button type="submit">Create business workspace</Button>
+                      <p className="text-sm text-muted-foreground">
+                        CallbackCloser will auto-connect an existing owner account or send an invite if needed. Twilio account mode and number connection stay
+                        explicit on the next screen.
+                      </p>
+                    </div>
+                  </form>
                 </div>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="publicBusinessPhone">Public business number</Label>
-                <Input id="publicBusinessPhone" name="publicBusinessPhone" type="tel" placeholder="+1 555 111 0000" />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="forwardingNumber">Owner forwarding / answer number</Label>
-                <Input id="forwardingNumber" name="forwardingNumber" type="tel" placeholder="+1 555 222 0000" required />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="timezone">Timezone</Label>
-                <Input id="timezone" name="timezone" defaultValue="America/New_York" />
-              </div>
-
-              <label className="md:col-span-2 flex items-start gap-2 rounded-xl border bg-background/80 p-3 text-sm">
-                <input name="isTestBusiness" type="checkbox" value="true" />
-                <span>Mark as a test/demo business so archive and delete stay safely separated from real customers.</span>
-              </label>
-
-              <div className="md:col-span-2 flex flex-wrap items-center gap-3">
-                <Button type="submit">Create business workspace</Button>
-                <p className="text-sm text-muted-foreground">CallbackCloser will auto-connect an existing owner account or send an invite if needed. Twilio account mode and number connection stay explicit on the next screen.</p>
-              </div>
-            </form>
-          </CardContent>
+              </details>
+            </div>
+          </CardHeader>
+          <CardContent />
         </Card>
 
         <Card className="bg-card/90">
           <CardHeader>
-            <CardTitle>Demo / support tools</CardTitle>
-            <CardDescription>Keep demo traffic and founder troubleshooting inside the same operator flow.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-5">
-            <form action={createDemoBusinessAction} className="space-y-4 rounded-xl border bg-background/80 p-4">
-              <div className="space-y-2">
-                <Label htmlFor="demoOwnerPhone">Owner phone for previews</Label>
-                <Input
-                  id="demoOwnerPhone"
-                  name="ownerPhone"
-                  type="tel"
-                  defaultValue={adminBusiness?.notifyPhone || ''}
-                  placeholder="+1 555 123 4567"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="demoOwnerEmail">Owner email for previews</Label>
-                <Input
-                  id="demoOwnerEmail"
-                  name="ownerEmail"
-                  type="email"
-                  defaultValue={admin.email || ''}
-                  placeholder="owner@callbackcloser.com"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="demoForwardingNumber">Owner forwarding / answer number</Label>
-                <Input
-                  id="demoForwardingNumber"
-                  name="forwardingNumber"
-                  type="tel"
-                  defaultValue={adminBusiness?.forwardingNumber || ''}
-                  placeholder="+1 555 000 0001"
-                />
-              </div>
-              <Button type="submit" variant="outline">
-                Create demo workspace
-              </Button>
-            </form>
+            <div className="rounded-xl border bg-background/80 p-4">
+              <details>
+                <summary className="cursor-pointer list-none space-y-1">
+                  <CardTitle>Demo / support tools</CardTitle>
+                  <CardDescription>Keep demo traffic and founder troubleshooting available without crowding the triage board.</CardDescription>
+                </summary>
+                <div className="mt-4 space-y-5">
+                  <form action={createDemoBusinessAction} className="space-y-4 rounded-xl border bg-background/80 p-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="demoOwnerPhone">Owner phone for previews</Label>
+                      <Input
+                        id="demoOwnerPhone"
+                        name="ownerPhone"
+                        type="tel"
+                        defaultValue={adminBusiness?.notifyPhone || ''}
+                        placeholder="+1 555 123 4567"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="demoOwnerEmail">Owner email for previews</Label>
+                      <Input
+                        id="demoOwnerEmail"
+                        name="ownerEmail"
+                        type="email"
+                        defaultValue={admin.email || ''}
+                        placeholder="owner@callbackcloser.com"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="demoForwardingNumber">Owner forwarding / answer number</Label>
+                      <Input
+                        id="demoForwardingNumber"
+                        name="forwardingNumber"
+                        type="tel"
+                        defaultValue={adminBusiness?.forwardingNumber || ''}
+                        placeholder="+1 555 000 0001"
+                      />
+                    </div>
+                    <Button type="submit" variant="outline">
+                      Create demo workspace
+                    </Button>
+                  </form>
 
-            <div className="rounded-xl border bg-background/80 p-4 text-sm">
-              <p className="font-medium text-foreground">What this board should answer immediately</p>
-              <ul className="mt-3 space-y-2 text-muted-foreground">
-                <li>Which businesses are healthy</li>
-                <li>Which ones need intervention</li>
-                <li>What the next likely operator action is</li>
-              </ul>
+                  <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                    <p className="font-medium text-foreground">What this board should answer immediately</p>
+                    <ul className="mt-3 space-y-2 text-muted-foreground">
+                      <li>Which businesses are healthy</li>
+                      <li>Which ones need intervention</li>
+                      <li>What the next likely operator action is</li>
+                    </ul>
+                  </div>
+                </div>
+              </details>
             </div>
-          </CardContent>
+          </CardHeader>
+          <CardContent />
         </Card>
       </div>
 
       {admin.isFounder ? (
         <Card className="border-destructive/30 bg-destructive/5">
           <CardHeader>
-            <CardTitle>Founder reset</CardTitle>
-            <CardDescription>
-              Founder-only cleanup. Archive real customers. Hard delete test/demo businesses only, and only when the business is already archived.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground">
-              Delete one test/demo business is the primary founder cleanup tool. Real customer workspaces should be archived or disabled, not hard deleted.
-            </div>
-
-            <div>
-              <div className="mb-3 space-y-1">
-                <p className="text-base font-semibold text-foreground">Delete one test/demo business</p>
-                <p className="text-sm text-muted-foreground">
-                  Select a workspace, review whether it is test/demo or real, then type the exact business name before permanent deletion is allowed.
-                </p>
-              </div>
-              <FounderDeleteBusinessCard candidates={founderDeleteCandidates} deleteAction={deleteTestBusinessAction} />
-            </div>
-
-            <details className="rounded-xl border border-destructive/30 bg-background/80 p-4 text-sm">
-              <summary className="cursor-pointer font-medium text-foreground">Advanced founder reset: delete all current businesses</summary>
-              <div className="mt-4 grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
-                <div className="rounded-xl border bg-background/80 p-4 text-sm">
-                  <p className="font-medium text-foreground">
-                    {founderResetBusinessCount} current {founderResetBusinessCount === 1 ? 'business' : 'businesses'} would be deleted
-                  </p>
-                  <p className="mt-2 text-muted-foreground">
-                    This permanently deletes every current business record, including archived ones. Keep this as a last-resort cleanup path only.
-                  </p>
-                  {founderResetBusinessPreview.length > 0 ? (
-                    <p className="mt-3 text-muted-foreground">
-                      Preview: {founderResetBusinessPreview.join(', ')}
-                      {founderResetBusinessCount > founderResetBusinessPreview.length
-                        ? ` and ${founderResetBusinessCount - founderResetBusinessPreview.length} more.`
-                        : '.'}
-                    </p>
-                  ) : (
-                    <p className="mt-3 text-muted-foreground">No businesses are currently present.</p>
-                  )}
-                </div>
-
-                <form action={founderDeleteAllBusinessesAction} className="rounded-xl border border-destructive/30 bg-background/80 p-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="founderResetConfirmationText">Type {FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION}</Label>
-                    <Input
-                      id="founderResetConfirmationText"
-                      name="confirmationText"
-                      autoComplete="off"
-                      placeholder={FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION}
-                    />
+            <div className="rounded-xl border border-destructive/30 bg-background/80 p-4">
+              <details>
+                <summary className="cursor-pointer list-none space-y-1">
+                  <CardTitle>Advanced founder tools</CardTitle>
+                  <CardDescription>
+                    Founder-only cleanup. Archive real customers. Hard delete test/demo businesses only, and only when the business is already archived.
+                  </CardDescription>
+                </summary>
+                <div className="mt-4 space-y-4">
+                  <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground">
+                    Delete one test/demo business is the primary founder cleanup tool. Real customer workspaces should be archived or disabled, not hard deleted.
                   </div>
-                  <p className="mt-3 text-xs text-muted-foreground">
-                    This is irreversible. Deleting a business also removes its leads, calls, messages, owner notifications, business settings, operator events,
-                    simulator runs, SMS consent records, and other business-owned data through the existing schema cascades.
-                  </p>
-                  <Button className="mt-4" type="submit" variant="destructive" disabled={founderResetBusinessCount === 0}>
-                    Delete all current businesses
-                  </Button>
-                </form>
-              </div>
-            </details>
-          </CardContent>
+
+                  <div>
+                    <div className="mb-3 space-y-1">
+                      <p className="text-base font-semibold text-foreground">Delete one test/demo business</p>
+                      <p className="text-sm text-muted-foreground">
+                        Select a workspace, review whether it is test/demo or real, then type the exact business name before permanent deletion is allowed.
+                      </p>
+                    </div>
+                    <FounderDeleteBusinessCard candidates={founderDeleteCandidates} deleteAction={deleteTestBusinessAction} />
+                  </div>
+
+                  <details className="rounded-xl border border-destructive/30 bg-background/80 p-4 text-sm">
+                    <summary className="cursor-pointer font-medium text-foreground">Advanced founder reset: delete all current businesses</summary>
+                    <div className="mt-4 grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+                      <div className="rounded-xl border bg-background/80 p-4 text-sm">
+                        <p className="font-medium text-foreground">
+                          {founderResetBusinessCount} current {founderResetBusinessCount === 1 ? 'business' : 'businesses'} would be deleted
+                        </p>
+                        <p className="mt-2 text-muted-foreground">
+                          This permanently deletes every current business record, including archived ones. Keep this as a last-resort cleanup path only.
+                        </p>
+                        {founderResetBusinessPreview.length > 0 ? (
+                          <p className="mt-3 text-muted-foreground">
+                            Preview: {founderResetBusinessPreview.join(', ')}
+                            {founderResetBusinessCount > founderResetBusinessPreview.length
+                              ? ` and ${founderResetBusinessCount - founderResetBusinessPreview.length} more.`
+                              : '.'}
+                          </p>
+                        ) : (
+                          <p className="mt-3 text-muted-foreground">No businesses are currently present.</p>
+                        )}
+                      </div>
+
+                      <form action={founderDeleteAllBusinessesAction} className="rounded-xl border border-destructive/30 bg-background/80 p-4">
+                        <div className="space-y-2">
+                          <Label htmlFor="founderResetConfirmationText">Type {FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION}</Label>
+                          <Input
+                            id="founderResetConfirmationText"
+                            name="confirmationText"
+                            autoComplete="off"
+                            placeholder={FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION}
+                          />
+                        </div>
+                        <p className="mt-3 text-xs text-muted-foreground">
+                          This is irreversible. Deleting a business also removes its leads, calls, messages, owner notifications, business settings, operator
+                          events, simulator runs, SMS consent records, and other business-owned data through the existing schema cascades.
+                        </p>
+                        <Button className="mt-4" type="submit" variant="destructive" disabled={founderResetBusinessCount === 0}>
+                          Delete all current businesses
+                        </Button>
+                      </form>
+                    </div>
+                  </details>
+                </div>
+              </details>
+            </div>
+          </CardHeader>
+          <CardContent />
         </Card>
       ) : null}
 
       <Card className="bg-card/90">
         <CardHeader>
           <CardTitle>Business triage board</CardTitle>
-          <CardDescription>Compact rows with status, readiness, one clear attention signal, and the fastest next actions.</CardDescription>
+          <CardDescription>One primary state, one reason, one exact next action, and only the secondary badges that still matter.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="grid gap-4 lg:grid-cols-[1.2fr_1fr]">
@@ -811,11 +792,11 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
           </div>
 
           {selectedBusinessRow ? (
-            <Card className="border-primary/20 bg-primary/5">
-              <CardHeader className="gap-2">
-                <CardTitle className="text-xl">Selected business actions</CardTitle>
-                <CardDescription>
-                  Focused from the business picker. Archive stays the normal lifecycle action. Permanent delete only unlocks for archived demo/test
+          <Card className="border-primary/20 bg-primary/5">
+            <CardHeader className="gap-2">
+              <CardTitle className="text-xl">Selected business actions</CardTitle>
+              <CardDescription>
+                Focused from the business picker. Archive stays the normal lifecycle action. Permanent delete only unlocks for archived demo/test
                   workspaces.
                 </CardDescription>
               </CardHeader>
@@ -823,10 +804,12 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                 <div className="space-y-4 rounded-xl border bg-background/80 p-4 text-sm">
                   <div className="flex flex-wrap items-center gap-2">
                     <p className="text-base font-semibold">{selectedBusinessRow.business.name}</p>
-                    <Badge variant={selectedBusinessRow.overallStatus.variant}>{selectedBusinessRow.overallStatus.label}</Badge>
-                    <Badge variant={selectedBusinessRow.onboardingConfidence.stateVariant}>{selectedBusinessRow.onboardingConfidence.stateLabel}</Badge>
-                    {selectedBusinessRow.business.isTestBusiness ? <Badge variant="outline">Test</Badge> : null}
-                    {isBusinessArchived(selectedBusinessRow.business) ? <Badge variant="outline">Archived</Badge> : null}
+                    <Badge variant={selectedBusinessRow.cardState.primaryVariant}>{selectedBusinessRow.cardState.primaryLabel}</Badge>
+                    {selectedBusinessRow.cardState.badges.map((badge) => (
+                      <Badge key={badge.key} variant={badge.variant}>
+                        {badge.label}
+                      </Badge>
+                    ))}
                   </div>
                   <div className="grid gap-3 sm:grid-cols-2">
                     <div>
@@ -842,30 +825,26 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                       </p>
                     </div>
                     <div>
-                      <p className="font-medium">Go-live blocker</p>
-                      <p className="mt-1 text-muted-foreground">
-                        {selectedBusinessRow.onboardingConfidence.blockers[0]?.message || selectedBusinessRow.onboardingConfidence.summary}
-                      </p>
+                      <p className="font-medium">Current reason</p>
+                      <p className="mt-1 text-muted-foreground">{selectedBusinessRow.cardState.primaryReason}</p>
                     </div>
                     <div>
-                      <p className="font-medium">Test SMS</p>
-                      <div className="mt-1 flex flex-wrap gap-2">
-                        <Badge variant={getOperatorToneBadgeVariant(selectedBusinessRow.testSmsTruth.tone)}>
-                          {selectedBusinessRow.testSmsTruth.label}
-                        </Badge>
-                        <Badge variant={selectedBusinessRow.onboardingConfidence.readinessVariant}>{selectedBusinessRow.onboardingConfidence.readinessLabel}</Badge>
-                      </div>
+                      <p className="font-medium">Next action</p>
+                      <p className="mt-1 text-muted-foreground">{selectedBusinessRow.cardState.nextActionLabel}</p>
                     </div>
                   </div>
                   <div className="flex flex-wrap gap-2">
+                    {selectedBusinessRow.cardState.nextActionLabel !== 'No action needed' ? (
+                      <Link
+                        className={buttonVariants({ size: 'sm' })}
+                        href={getCardPrimaryActionHref(selectedBusinessRow.business.id, selectedBusinessRow.cardState)}
+                      >
+                        {selectedBusinessRow.cardState.nextActionLabel}
+                      </Link>
+                    ) : null}
                     <Link className={buttonVariants({ size: 'sm' })} href={`/admin/${selectedBusinessRow.business.id}`}>
                       Open business
                     </Link>
-                    {selectedBusinessRow.blockerStepHref ? (
-                      <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={selectedBusinessRow.blockerStepHref}>
-                        Open blocker step
-                      </Link>
-                    ) : null}
                     <Link
                       className={buttonVariants({ variant: 'outline', size: 'sm' })}
                       href={buildAdminCustomerOpenHref(selectedBusinessRow.business.id, '/app')}
@@ -878,7 +857,10 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                     >
                       Open customer settings
                     </Link>
-                    <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href={`/admin/${selectedBusinessRow.business.id}#advanced`}>
+                    <Link
+                      className={buttonVariants({ variant: 'ghost', size: 'sm' })}
+                      href={`/admin/${selectedBusinessRow.business.id}#advanced`}
+                    >
                       Open full advanced controls
                     </Link>
                     <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href={`/admin/${selectedBusinessRow.business.id}/workspace`}>
@@ -956,38 +938,31 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                   business,
                   ownerStatusLabel,
                   ownerStatusVariant,
-                  nextStep,
                   leadCount,
                   assignedNumber,
                   lastActivityAt,
                   lastIssue,
-                  overallStatus,
-                  a2pState,
-                  attentionSignal,
                   operatorSignals,
-                  testSmsTruth,
-                  missedCallValidation,
-                  onboardingConfidence,
                   canSendTestSms,
-                  blockerStepHref,
+                  cardState,
                 }) => (
-                  <div key={business.id} className="grid gap-4 border-t bg-background/80 px-5 py-4 first:border-t-0 xl:grid-cols-[1.7fr_1fr_1.15fr_0.95fr_1.3fr]">
+                  <div key={business.id} className="grid gap-4 border-t bg-background/80 px-5 py-4 first:border-t-0 xl:grid-cols-[1.7fr_1fr_1.1fr_1.35fr]">
                     <div className="space-y-3">
                       <div className="flex flex-wrap items-center gap-2">
                         <Link className="text-base font-semibold hover:underline" href={`/admin/${business.id}`}>
                           {business.name}
                         </Link>
-                        <Badge variant={overallStatus.variant}>{overallStatus.label}</Badge>
-                        {business.provisioningStatus === BusinessProvisioningStatus.DRAFT ? <Badge variant="secondary">Pending setup</Badge> : null}
-                        {business.provisioningStatus === BusinessProvisioningStatus.ONBOARDING ? <Badge variant="outline">In setup</Badge> : null}
-                        <Badge variant={onboardingConfidence.stateVariant}>{onboardingConfidence.stateLabel}</Badge>
-                        {business.isTestBusiness ? <Badge variant="outline">Test</Badge> : null}
-                        {isBusinessArchived(business) ? <Badge variant="outline">Archived</Badge> : null}
+                        <Badge variant={cardState.primaryVariant}>{cardState.primaryLabel}</Badge>
+                        {cardState.badges.map((badge) => (
+                          <Badge key={badge.key} variant={badge.variant}>
+                            {badge.label}
+                          </Badge>
+                        ))}
                       </div>
                       <div className="space-y-1 text-sm">
-                        <p className="font-medium">Needs attention</p>
-                        <p className={cn('text-muted-foreground', onboardingConfidence.state === 'needs_attention' || lastIssue.state === 'issue' ? 'text-destructive' : '')}>
-                          {onboardingConfidence.blockers[0]?.message || attentionSignal}
+                        <p className="font-medium">Current reason</p>
+                        <p className={cn('text-muted-foreground', cardState.shouldAppearInNeedsAttention || cardState.isLiveWithWarnings ? 'text-destructive' : '')}>
+                          {cardState.primaryReason}
                         </p>
                       </div>
                       <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
@@ -999,7 +974,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                       </div>
                     </div>
 
-                    <div className="space-y-2 text-sm">
+                    <div className="space-y-3 text-sm">
                       <p className="font-medium">Owner</p>
                       <p>{business.ownerName || 'Owner name missing'}</p>
                       <p className="text-muted-foreground">{business.notificationSettings?.ownerEmail || 'Owner email missing'}</p>
@@ -1009,57 +984,41 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                           <Badge variant="outline">{formatPhoneForDisplay(business.notificationSettings?.ownerPhone || business.notifyPhone)}</Badge>
                         ) : null}
                       </div>
-                    </div>
-
-                    <div className="grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-1">
-                      <div>
-                        <p className="font-medium">Readiness</p>
-                        <p className="mt-1">{onboardingConfidence.readinessLabel}</p>
-                        <p className="mt-1 text-xs text-muted-foreground">{onboardingConfidence.summary}</p>
-                      </div>
-                      <div>
-                        <p className="font-medium">Messaging compliance</p>
-                        <div className="mt-1 flex flex-wrap gap-2">
-                          <Badge variant={a2pState.variant}>{a2pState.label}</Badge>
-                        </div>
-                      </div>
                       <div>
                         <p className="font-medium">Assigned number</p>
                         <p className="mt-1 text-muted-foreground">{assignedNumber ? formatPhoneForDisplay(assignedNumber) : 'Not assigned yet'}</p>
                       </div>
                     </div>
 
-                    <div className="space-y-2 text-sm">
-                      <p className="font-medium">Next action</p>
-                      <p>{onboardingConfidence.nextAction}</p>
-                      <p className="text-muted-foreground">{nextStep.title}</p>
-                      <div className="flex flex-wrap gap-2">
-                        <Badge variant={getOperatorToneBadgeVariant(testSmsTruth.tone)}>Test SMS {testSmsTruth.label}</Badge>
-                        <Badge variant={onboardingConfidence.readinessVariant}>{onboardingConfidence.readinessLabel}</Badge>
-                        {!missedCallValidation.countsAsLaunchProof ? <Badge variant="outline">Missed-call proof missing</Badge> : null}
-                        {onboardingConfidence.state === 'live_with_warnings' ? <Badge variant="destructive">Live with warnings</Badge> : null}
-                        {lastIssue.state === 'issue' ? <Badge variant={getOperatorToneBadgeVariant(lastIssue.tone)}>Needs attention</Badge> : null}
+                    <div className="space-y-3 text-sm">
+                      <div>
+                        <p className="font-medium">Next action</p>
+                        <p>{cardState.nextActionLabel}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {cardState.nextActionLabel === 'No action needed'
+                            ? 'This business has no active operator blockers right now.'
+                            : 'Open the exact remediation step from the business control panel.'}
+                        </p>
                       </div>
                       {business.twilioWebhookSyncedAt ? (
                         <p className="text-xs text-muted-foreground">Webhook sync {formatRelativeTime(business.twilioWebhookSyncedAt)}</p>
-                      ) : (
+                      ) : !cardState.isArchived ? (
                         <p className="text-xs text-muted-foreground">Webhook sync still needed</p>
-                      )}
-                      {missedCallValidation.verifiedAt ? (
-                        <p className="text-xs text-muted-foreground">Missed-call proof {formatRelativeTime(missedCallValidation.verifiedAt)}</p>
                       ) : null}
-                      {lastIssue.createdAt ? <p className="text-xs text-destructive">Latest issue recorded {formatRelativeTime(lastIssue.createdAt)}</p> : null}
+                      {lastIssue.createdAt && !cardState.isArchived ? (
+                        <p className="text-xs text-destructive">Latest issue recorded {formatRelativeTime(lastIssue.createdAt)}</p>
+                      ) : null}
                     </div>
 
                     <div className="flex flex-wrap content-start gap-2">
+                      {cardState.nextActionLabel !== 'No action needed' ? (
+                        <Link className={buttonVariants({ size: 'sm' })} href={getCardPrimaryActionHref(business.id, cardState)}>
+                          {cardState.nextActionLabel}
+                        </Link>
+                      ) : null}
                       <Link className={buttonVariants({ size: 'sm' })} href={`/admin/${business.id}`}>
                         Open business
                       </Link>
-                      {blockerStepHref ? (
-                        <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={blockerStepHref}>
-                          Open blocker step
-                        </Link>
-                      ) : null}
                       <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} href={buildAdminCustomerOpenHref(business.id, '/app')}>
                         Open customer workspace
                       </Link>
@@ -1072,16 +1031,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                       <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href={`/admin/${business.id}/workspace`}>
                         View support workspace snapshot
                       </Link>
-                      {!isBusinessArchived(business) ? (
-                        <form action={provisionBusinessAction}>
-                          <input type="hidden" name="businessId" value={business.id} />
-                          <input type="hidden" name="mode" value="NEW_NUMBER" />
-                          <Button size="sm" type="submit" variant="outline">
-                            {assignedNumber ? 'Continue setup' : 'Provision business'}
-                          </Button>
-                        </form>
-                      ) : null}
-                      {assignedNumber ? (
+                      {assignedNumber && !cardState.isArchived ? (
                         <form action={resyncBusinessWebhooksAction}>
                           <input type="hidden" name="businessId" value={business.id} />
                           <input type="hidden" name="target" value="ALL" />
@@ -1100,7 +1050,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Recor
                         </form>
                       ) : null}
                       <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href={`/admin/${business.id}#advanced`}>
-                        {isBusinessArchived(business) ? 'Restore / manage' : 'Archive / manage'}
+                        {cardState.isArchived ? 'Restore business' : 'Archive business'}
                       </Link>
                     </div>
                   </div>

--- a/lib/admin-dashboard.ts
+++ b/lib/admin-dashboard.ts
@@ -15,9 +15,11 @@ import {
 import type { TwilioWebhookSnapshot } from '@/lib/admin-provisioning-presenters';
 import { DEMO_OWNER_CLERK_ID, isTestDemoBusiness } from '@/lib/admin-test-data-reset';
 import type { AdminMissedCallValidationTruth } from '@/lib/admin-operator-proof';
+import type { AdminBusinessIssue, AdminTestSmsTruth } from '@/lib/admin-operator-visibility';
 import { getBusinessPhoneSetupGate, getPublicBusinessPhone } from '@/lib/business-phone-setup';
-import { getManagedTextingNumber, getManagedTwilioStatusSummary } from '@/lib/managed-twilio-status';
+import { getManagedTextingNumber, getManagedTwilioStatusSummary, type ManagedTwilioSummary } from '@/lib/managed-twilio-status';
 import { formatMessageStatus, isMessageDeliveryIssueStatus } from '@/lib/lead-presenters';
+import type { TwilioSetupStepKey } from '@/lib/twilio-setup';
 
 type DashboardBusiness = Pick<
   Business,
@@ -159,6 +161,46 @@ export type AdminOnboardingConfidence = {
   hasRecentFailures: boolean;
 };
 
+export type AdminBusinessPrimaryState =
+  | 'archived'
+  | 'paused'
+  | 'provisioning_failed'
+  | 'owner_blocked'
+  | 'compliance_pending'
+  | 'needs_attention'
+  | 'ready_for_test'
+  | 'ready_for_live'
+  | 'live_with_warnings'
+  | 'live'
+  | 'draft'
+  | 'in_setup';
+
+export type AdminBusinessCardBadge = {
+  key: string;
+  label: string;
+  variant: 'success' | 'secondary' | 'outline' | 'destructive';
+};
+
+export type AdminBusinessCardState = {
+  primaryState: AdminBusinessPrimaryState;
+  primaryLabel: string;
+  primaryVariant: 'success' | 'secondary' | 'outline' | 'destructive';
+  primaryReason: string;
+  nextActionLabel: string;
+  nextActionStepKey: TwilioSetupStepKey | null;
+  badges: AdminBusinessCardBadge[];
+  shouldAppearInNeedsAttention: boolean;
+  shouldAppearInPendingCompliance: boolean;
+  isArchived: boolean;
+  isLive: boolean;
+  isLiveWithWarnings: boolean;
+  isReadyForTest: boolean;
+  isReadyForLive: boolean;
+  isDraft: boolean;
+  isInSetup: boolean;
+  isPaused: boolean;
+};
+
 export type AdminTestSmsConfidenceState = 'not_started' | 'pending_delivery' | 'delivered' | 'failed';
 
 export const adminBoardFilterOptions: AdminBoardFilterOption[] = [
@@ -272,7 +314,7 @@ export function buildAdminNextStep(params: {
       title: 'Provisioning needs attention',
       detail: business.provisioningError,
       tone: 'attention',
-      actionLabel: hasTextingNumber ? 'Re-run provisioning' : 'Finish provisioning',
+      actionLabel: 'Fix provisioning',
     };
   }
 
@@ -294,7 +336,7 @@ export function buildAdminNextStep(params: {
           : 'The business is saved, but the owner account still needs a deliberate admin action. Use Invite owner by email or Connect existing owner.'
         : 'Add the owner email first, then choose Invite owner by email or Connect existing owner.',
       tone: 'attention',
-      actionLabel: 'Review owner setup',
+      actionLabel: 'Invite or connect owner',
     };
   }
 
@@ -306,7 +348,7 @@ export function buildAdminNextStep(params: {
           ? 'This business is set to use the main Twilio account directly. Confirm the parent-account mapping before continuing.'
           : 'Managed provisioning cannot finish until the business has a Twilio subaccount attached.',
       tone: 'attention',
-      actionLabel: 'Re-run provisioning',
+      actionLabel: 'Fix provisioning',
     };
   }
 
@@ -315,7 +357,7 @@ export function buildAdminNextStep(params: {
       title: 'No texting number is assigned',
       detail: 'Provision a new number or attach the approved existing number so missed-call SMS can start.',
       tone: 'attention',
-      actionLabel: 'Provision number',
+      actionLabel: 'Fix provisioning',
     };
   }
 
@@ -324,7 +366,7 @@ export function buildAdminNextStep(params: {
       title: 'Messaging service is missing',
       detail: 'The business has a number, but Twilio messaging still needs a Messaging Service for compliant delivery.',
       tone: 'attention',
-      actionLabel: 'Re-run provisioning',
+      actionLabel: 'Fix provisioning',
     };
   }
 
@@ -351,7 +393,7 @@ export function buildAdminNextStep(params: {
       title: 'Toll-free verification still needs recording',
       detail: 'Messaging is wired up, but toll-free verification still needs to be recorded before compliant live texting can launch.',
       tone: 'pending',
-      actionLabel: 'Review toll-free verification',
+      actionLabel: 'Open toll-free verification',
     };
   }
 
@@ -360,7 +402,7 @@ export function buildAdminNextStep(params: {
       title: 'Business verification still needed',
       detail: 'Messaging is wired up, but the A2P business details still need to be completed before compliant live texting can launch.',
       tone: 'pending',
-      actionLabel: 'Review A2P readiness',
+      actionLabel: 'Open A2P readiness',
     };
   }
 
@@ -396,7 +438,7 @@ export function buildAdminNextStep(params: {
       title: 'Compliance review needs attention',
       detail: business.a2pFailureReason || business.tollFreeVerificationNote || managedSummary.nextStep,
       tone: 'attention',
-      actionLabel: 'Review compliance notes',
+      actionLabel: managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION ? 'Open toll-free verification' : 'Fix compliance',
     };
   }
 
@@ -405,16 +447,16 @@ export function buildAdminNextStep(params: {
       title: 'Ready to go live',
       detail: 'Infrastructure and compliance look ready. Mark the business live when you want automation active.',
       tone: 'pending',
-      actionLabel: 'Mark live',
+      actionLabel: 'Mark business live',
     };
   }
 
   if (managedSummary.messagingReady && business.provisioningStatus === BusinessProvisioningStatus.LIVE) {
     return {
-      title: 'Business is live and healthy',
-      detail: 'Twilio, webhooks, alerts, and rollout status all look ready for normal operator monitoring.',
+      title: 'Business is live',
+      detail: 'Core Twilio, webhook, alert, and rollout setup is active. Use the proof and issue signals to decide whether any follow-up is still needed.',
       tone: 'healthy',
-      actionLabel: 'Open support workspace',
+      actionLabel: 'No action needed',
     };
   }
 
@@ -693,7 +735,7 @@ export function buildAdminOnboardingConfidence(params: {
       stateVariant: 'outline',
       readinessLabel: 'Not ready',
       readinessVariant: 'outline',
-      nextAction: nextStep.title,
+      nextAction: nextStep.actionLabel,
       summary: 'Core onboarding details are still missing. Start with owner connection and Twilio setup.',
     },
     in_setup: {
@@ -701,7 +743,7 @@ export function buildAdminOnboardingConfidence(params: {
       stateVariant: 'secondary',
       readinessLabel: 'Not ready',
       readinessVariant: 'outline',
-      nextAction: nextStep.title,
+      nextAction: nextStep.actionLabel,
       summary: 'Onboarding is in progress, but at least one blocking setup step still needs attention.',
     },
     needs_attention: {
@@ -709,7 +751,7 @@ export function buildAdminOnboardingConfidence(params: {
       stateVariant: 'destructive',
       readinessLabel: 'Not ready',
       readinessVariant: 'destructive',
-      nextAction: nextStep.title,
+      nextAction: nextStep.actionLabel,
       summary: 'Something is broken or incomplete enough that the founder should stop and repair it before testing.',
     },
     waiting_on_a2p: {
@@ -731,7 +773,7 @@ export function buildAdminOnboardingConfidence(params: {
       nextAction: hasTestSmsSuccess
         ? 'Run a real missed-call test'
         : hasPendingTestSmsDelivery
-          ? 'Confirm test SMS delivery'
+          ? 'Send test SMS'
           : 'Send a test SMS',
       summary: 'The business looks ready for operator-led validation. Run the checks before you mark it live.',
     },
@@ -740,7 +782,7 @@ export function buildAdminOnboardingConfidence(params: {
       stateVariant: 'success',
       readinessLabel: 'Ready for live',
       readinessVariant: 'success',
-      nextAction: 'Mark this business live',
+      nextAction: 'Mark business live',
       summary: 'Setup, compliance, and operator validation checks are in place for a clean launch decision.',
     },
     live: {
@@ -748,7 +790,7 @@ export function buildAdminOnboardingConfidence(params: {
       stateVariant: 'success',
       readinessLabel: 'Ready for live',
       readinessVariant: 'success',
-      nextAction: 'Monitor normal activity',
+      nextAction: 'No action needed',
       summary: 'This business is live and the operator confidence checks are green.',
     },
     live_with_warnings: {
@@ -756,7 +798,7 @@ export function buildAdminOnboardingConfidence(params: {
       stateVariant: 'destructive',
       readinessLabel: 'Live with warnings',
       readinessVariant: 'destructive',
-      nextAction: nextStep.title,
+      nextAction: nextStep.actionLabel,
       summary: 'The business is live, but recent failures or missing validations mean the founder should review it closely.',
     },
     archived: {
@@ -781,47 +823,457 @@ export function buildAdminOnboardingConfidence(params: {
   } satisfies AdminOnboardingConfidence;
 }
 
+function buildSecondaryBadge(
+  key: string,
+  label: string,
+  variant: AdminBusinessCardBadge['variant']
+) {
+  return { key, label, variant } satisfies AdminBusinessCardBadge;
+}
+
+function dedupeAdminBusinessCardBadges(badges: AdminBusinessCardBadge[], limit = 3) {
+  const seen = new Set<string>();
+  const deduped: AdminBusinessCardBadge[] = [];
+
+  for (const badge of badges) {
+    const signature = `${badge.key}:${badge.label}`;
+    if (seen.has(signature)) continue;
+    seen.add(signature);
+    deduped.push(badge);
+    if (deduped.length >= limit) break;
+  }
+
+  return deduped;
+}
+
+function getTestSmsBadge(testSmsTruth: AdminTestSmsTruth) {
+  if (testSmsTruth.state === 'delivered') {
+    return buildSecondaryBadge('test_sms', 'Test SMS Delivered', 'success');
+  }
+
+  if (testSmsTruth.state === 'failed') {
+    return buildSecondaryBadge('test_sms', 'Test SMS Failed', 'destructive');
+  }
+
+  if (testSmsTruth.state === 'pending') {
+    return buildSecondaryBadge('test_sms', 'Test SMS Pending', 'outline');
+  }
+
+  return buildSecondaryBadge('test_sms', 'Test SMS Not Run', 'outline');
+}
+
+function getComplianceBadge(params: {
+  managedSummary: ManagedTwilioSummary;
+  business: Pick<DashboardBusiness, 'managedTwilioStatus'>;
+}) {
+  if (params.managedSummary.complianceTypeUnknown) {
+    return buildSecondaryBadge('compliance', 'Compliance Not Selected', 'outline');
+  }
+
+  if (params.managedSummary.attentionRequired) {
+    return buildSecondaryBadge('compliance', 'Compliance Needs Attention', 'destructive');
+  }
+
+  if (
+    params.managedSummary.compliancePendingReview ||
+    (params.managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION && !params.managedSummary.complianceStarted) ||
+    (params.managedSummary.complianceType === MessagingComplianceType.LOCAL_A2P &&
+      params.business.managedTwilioStatus === ManagedTwilioStatus.AWAITING_BUSINESS_VERIFICATION)
+  ) {
+    return buildSecondaryBadge('compliance', 'Compliance Pending', 'outline');
+  }
+
+  return null;
+}
+
+function getProvisioningRepairStepKey(
+  business: DashboardBusiness,
+  managedSummary: ManagedTwilioSummary
+): TwilioSetupStepKey {
+  if (!managedSummary.accountReady) return 'account_ready';
+  if (!getManagedTextingNumber(business) || !(business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid)) return 'number_assigned';
+  if (!business.twilioMessagingServiceSid) return 'messaging_service_ready';
+  if (!business.twilioWebhookSyncedAt) return 'voice_webhook_synced';
+  return 'account_ready';
+}
+
+function getAttentionReasonAndStep(params: {
+  business: DashboardBusiness;
+  managedSummary: ManagedTwilioSummary;
+  nextStep: AdminNextStep;
+  onboardingConfidence: AdminOnboardingConfidence;
+  lastIssue: AdminBusinessIssue;
+  testSmsTruth: AdminTestSmsTruth;
+  missedCallValidation: AdminMissedCallValidationTruth;
+}) {
+  const { business, managedSummary, nextStep, onboardingConfidence, lastIssue, testSmsTruth, missedCallValidation } = params;
+  const hasAssignedNumber = Boolean(getManagedTextingNumber(business) && (business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid));
+
+  if (lastIssue.eventType === 'webhooks.sync_failed' || (hasAssignedNumber && !business.twilioWebhookSyncedAt)) {
+    return {
+      primaryState: 'needs_attention' as const,
+      primaryLabel: 'Needs attention',
+      primaryVariant: 'destructive' as const,
+      primaryReason: 'Twilio webhooks are not synced to the current CallbackCloser URLs.',
+      nextActionLabel: 'Re-sync webhooks',
+      nextActionStepKey: 'voice_webhook_synced' as const,
+    };
+  }
+
+  if (testSmsTruth.state === 'failed') {
+    return {
+      primaryState: 'needs_attention' as const,
+      primaryLabel: 'Needs attention',
+      primaryVariant: 'destructive' as const,
+      primaryReason: 'The latest test SMS did not complete cleanly.',
+      nextActionLabel: 'Send test SMS',
+      nextActionStepKey: 'test_sms_delivered' as const,
+    };
+  }
+
+  if (onboardingConfidence.readyForTest && testSmsTruth.state !== 'delivered') {
+    return {
+      primaryState: 'ready_for_test' as const,
+      primaryLabel: 'Ready for test',
+      primaryVariant: 'secondary' as const,
+      primaryReason:
+        testSmsTruth.state === 'pending'
+          ? 'The latest test SMS is still waiting on delivery confirmation.'
+          : 'A delivered test SMS is still missing.',
+      nextActionLabel: 'Send test SMS',
+      nextActionStepKey: 'test_sms_delivered' as const,
+    };
+  }
+
+  if (onboardingConfidence.readyForTest && !missedCallValidation.countsAsLaunchProof) {
+    return {
+      primaryState: 'ready_for_test' as const,
+      primaryLabel: 'Ready for test',
+      primaryVariant: 'secondary' as const,
+      primaryReason: 'The missed-call flow has not been fully validated yet.',
+      nextActionLabel: 'Validate missed-call flow',
+      nextActionStepKey: 'missed_call_validated' as const,
+    };
+  }
+
+  return {
+    primaryState: nextStep.tone === 'attention' ? ('needs_attention' as const) : ('in_setup' as const),
+    primaryLabel: nextStep.tone === 'attention' ? 'Needs attention' : 'In setup',
+    primaryVariant: nextStep.tone === 'attention' ? ('destructive' as const) : ('secondary' as const),
+    primaryReason: nextStep.detail,
+    nextActionLabel: nextStep.actionLabel || 'Open blocker step',
+    nextActionStepKey: lastIssue.remediationStepKey,
+  };
+}
+
+export function buildAdminBusinessCardState(params: {
+  business: DashboardBusiness;
+  notificationSettings: DashboardNotificationSettings | null;
+  ownerConnected: boolean;
+  nextStep: AdminNextStep;
+  managedSummary: ManagedTwilioSummary;
+  onboardingConfidence: AdminOnboardingConfidence;
+  lastIssue: AdminBusinessIssue;
+  testSmsTruth: AdminTestSmsTruth;
+  missedCallValidation: AdminMissedCallValidationTruth;
+}) {
+  const { business, notificationSettings, ownerConnected, nextStep, managedSummary, onboardingConfidence, lastIssue, testSmsTruth, missedCallValidation } =
+    params;
+  const archived = isBusinessArchived(business);
+  const paused = !archived && business.provisioningStatus === BusinessProvisioningStatus.PAUSED;
+  const ownerEmail = notificationSettings?.ownerEmail?.trim() || null;
+  const ownerPhone = notificationSettings?.ownerPhone?.trim() || business.notifyPhone || null;
+  const missingOwnerContact = !ownerEmail && !ownerPhone;
+  const needsOwnerConnection = !ownerConnected;
+  const complianceNeedsOperatorAction =
+    managedSummary.attentionRequired ||
+    managedSummary.complianceTypeUnknown ||
+    (managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION && !managedSummary.complianceStarted) ||
+    (managedSummary.complianceType === MessagingComplianceType.LOCAL_A2P &&
+      business.managedTwilioStatus === ManagedTwilioStatus.AWAITING_BUSINESS_VERIFICATION);
+  const compliancePendingReview = managedSummary.compliancePendingReview;
+
+  let state: Pick<
+    AdminBusinessCardState,
+    'primaryState' | 'primaryLabel' | 'primaryVariant' | 'primaryReason' | 'nextActionLabel' | 'nextActionStepKey'
+  >;
+
+  if (archived) {
+    state = {
+      primaryState: 'archived',
+      primaryLabel: 'Archived',
+      primaryVariant: 'outline',
+      primaryReason: 'Automation is paused because this business is archived.',
+      nextActionLabel: 'Restore business',
+      nextActionStepKey: null,
+    };
+  } else if (paused) {
+    state = {
+      primaryState: 'paused',
+      primaryLabel: 'Paused',
+      primaryVariant: 'outline',
+      primaryReason: 'Automation is paused until you intentionally resume this business.',
+      nextActionLabel: 'Resume automation',
+      nextActionStepKey: 'safe_to_mark_live',
+    };
+  } else if (business.provisioningError || business.provisioningStatus === BusinessProvisioningStatus.NEEDS_ATTENTION) {
+    state = {
+      primaryState: 'provisioning_failed',
+      primaryLabel: 'Provisioning failed',
+      primaryVariant: 'destructive',
+      primaryReason: business.provisioningError || 'The latest provisioning run needs operator repair before this business can move forward.',
+      nextActionLabel: 'Fix provisioning',
+      nextActionStepKey: getProvisioningRepairStepKey(business, managedSummary),
+    };
+  } else if (missingOwnerContact) {
+    state = {
+      primaryState: 'owner_blocked',
+      primaryLabel: 'Owner blocked',
+      primaryVariant: 'destructive',
+      primaryReason: 'Owner contact information is missing, so invites and alerts cannot be trusted yet.',
+      nextActionLabel: 'Save owner contact info',
+      nextActionStepKey: 'owner_connected',
+    };
+  } else if (needsOwnerConnection) {
+    state = {
+      primaryState: 'owner_blocked',
+      primaryLabel: 'Owner blocked',
+      primaryVariant: 'destructive',
+      primaryReason: business.ownerInviteSentAt
+        ? 'The owner account is still not connected even though an invite was already sent.'
+        : 'The owner account still needs to be connected before this business can be trusted.',
+      nextActionLabel: 'Invite or connect owner',
+      nextActionStepKey: 'owner_connected',
+    };
+  } else if (business.provisioningStatus === BusinessProvisioningStatus.LIVE && onboardingConfidence.blockers.length > 0) {
+    state = testSmsTruth.state !== 'delivered'
+      ? {
+          primaryState: 'live_with_warnings',
+          primaryLabel: 'Live with warnings',
+          primaryVariant: 'destructive',
+          primaryReason:
+            testSmsTruth.state === 'pending'
+              ? 'The latest test SMS is still waiting on delivery confirmation.'
+              : 'The latest test SMS is not fully proven.',
+          nextActionLabel: 'Send test SMS',
+          nextActionStepKey: 'test_sms_delivered',
+        }
+      : !missedCallValidation.countsAsLaunchProof
+        ? {
+            primaryState: 'live_with_warnings',
+            primaryLabel: 'Live with warnings',
+            primaryVariant: 'destructive',
+            primaryReason: 'Missed-call flow has not been fully validated.',
+            nextActionLabel: 'Validate missed-call flow',
+            nextActionStepKey: 'missed_call_validated',
+          }
+        : {
+            primaryState: 'live_with_warnings',
+            primaryLabel: 'Live with warnings',
+            primaryVariant: 'destructive',
+            primaryReason: onboardingConfidence.blockers[0]?.message || 'This live business still has unresolved operator warnings.',
+            nextActionLabel: nextStep.actionLabel || 'Open blocker step',
+            nextActionStepKey: lastIssue.remediationStepKey,
+          };
+  } else if (business.provisioningStatus === BusinessProvisioningStatus.LIVE) {
+    state = {
+      primaryState: 'live',
+      primaryLabel: 'Live',
+      primaryVariant: 'success',
+      primaryReason: 'No active warnings are recorded for this live business.',
+      nextActionLabel: 'No action needed',
+      nextActionStepKey: null,
+    };
+  } else if (complianceNeedsOperatorAction || compliancePendingReview) {
+    state = {
+      primaryState: 'compliance_pending',
+      primaryLabel: managedSummary.attentionRequired ? 'Compliance blocked' : 'Pending compliance',
+      primaryVariant: managedSummary.attentionRequired ? 'destructive' : 'outline',
+      primaryReason: managedSummary.attentionRequired
+        ? business.a2pFailureReason || business.tollFreeVerificationNote || managedSummary.nextStep
+        : managedSummary.complianceTypeUnknown
+          ? 'Messaging compliance type has not been selected yet.'
+          : managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION && !managedSummary.complianceStarted
+            ? 'Toll-free verification has not been recorded yet.'
+            : managedSummary.nextStep,
+      nextActionLabel: managedSummary.complianceTypeUnknown
+        ? 'Choose number type'
+        : managedSummary.complianceType === MessagingComplianceType.TOLL_FREE_VERIFICATION
+          ? 'Open toll-free verification'
+          : managedSummary.attentionRequired
+            ? 'Fix compliance'
+            : 'Wait for approval',
+      nextActionStepKey: 'a2p_status_recorded',
+    };
+  } else if (onboardingConfidence.readyForLive) {
+    state = {
+      primaryState: 'ready_for_live',
+      primaryLabel: 'Ready for live',
+      primaryVariant: 'success',
+      primaryReason: 'Launch proof is in place and automation can go live safely.',
+      nextActionLabel: 'Mark business live',
+      nextActionStepKey: 'safe_to_mark_live',
+    };
+  } else if (onboardingConfidence.readyForTest) {
+    state = getAttentionReasonAndStep({
+      business,
+      managedSummary,
+      nextStep,
+      onboardingConfidence,
+      lastIssue,
+      testSmsTruth,
+      missedCallValidation,
+    });
+  } else if (onboardingConfidence.state === 'draft') {
+    state = {
+      primaryState: 'draft',
+      primaryLabel: 'Draft',
+      primaryVariant: 'outline',
+      primaryReason: onboardingConfidence.summary,
+      nextActionLabel: nextStep.actionLabel,
+      nextActionStepKey: lastIssue.remediationStepKey,
+    };
+  } else {
+    state = getAttentionReasonAndStep({
+      business,
+      managedSummary,
+      nextStep,
+      onboardingConfidence,
+      lastIssue,
+      testSmsTruth,
+      missedCallValidation,
+    });
+  }
+
+  const badges: AdminBusinessCardBadge[] = [];
+  badges.push(buildSecondaryBadge('customer_type', business.isTestBusiness ? 'Test' : 'Real customer', 'outline'));
+
+  if (!archived) {
+    if (
+      state.primaryState === 'ready_for_test' ||
+      state.primaryState === 'ready_for_live' ||
+      state.primaryState === 'live_with_warnings' ||
+      state.primaryState === 'live' ||
+      state.primaryState === 'needs_attention'
+    ) {
+      badges.push(getTestSmsBadge(testSmsTruth));
+    }
+
+    const complianceBadge = getComplianceBadge({ managedSummary, business });
+    if (complianceBadge) {
+      badges.push(complianceBadge);
+    }
+
+    if (
+      !missedCallValidation.countsAsLaunchProof &&
+      (state.primaryState === 'ready_for_test' ||
+        state.primaryState === 'ready_for_live' ||
+        state.primaryState === 'live_with_warnings' ||
+        state.primaryState === 'live')
+    ) {
+      badges.push(buildSecondaryBadge('missed_call_proof', 'Missed-call proof missing', 'outline'));
+    }
+  }
+
+  return {
+    ...state,
+    badges: dedupeAdminBusinessCardBadges(badges),
+    shouldAppearInNeedsAttention:
+      !archived &&
+      (state.primaryState === 'provisioning_failed' ||
+        state.primaryState === 'owner_blocked' ||
+        state.primaryState === 'needs_attention' ||
+        state.primaryState === 'live_with_warnings'),
+    shouldAppearInPendingCompliance: !archived && state.primaryState === 'compliance_pending',
+    isArchived: archived,
+    isLive: state.primaryState === 'live',
+    isLiveWithWarnings: state.primaryState === 'live_with_warnings',
+    isReadyForTest: state.primaryState === 'ready_for_test',
+    isReadyForLive: state.primaryState === 'ready_for_live',
+    isDraft: state.primaryState === 'draft',
+    isInSetup:
+      state.primaryState === 'draft' ||
+      state.primaryState === 'in_setup' ||
+      state.primaryState === 'ready_for_test' ||
+      state.primaryState === 'ready_for_live',
+    isPaused: state.primaryState === 'paused',
+  } satisfies AdminBusinessCardState;
+}
+
+export function matchesAdminBoardFilterState(state: AdminBusinessCardState, filter: AdminBoardFilter) {
+  if (filter === 'all') return true;
+  if (filter === 'archived') return state.isArchived;
+  if (state.isArchived) return false;
+
+  if (filter === 'paused') return state.isPaused;
+  if (filter === 'live') return state.isLive;
+  if (filter === 'pending_a2p') return state.shouldAppearInPendingCompliance;
+  if (filter === 'pending_setup') return state.isDraft;
+  if (filter === 'in_setup') return state.isInSetup;
+  if (filter === 'needs_attention') return state.shouldAppearInNeedsAttention;
+
+  return true;
+}
+
 export function matchesAdminBoardFilter(
   business: DashboardBusiness,
   notificationSettings: DashboardNotificationSettings | null,
   ownerConnected: boolean,
   filter: AdminBoardFilter
 ) {
-  if (filter === 'all') return true;
-
   const managedSummary = getManagedTwilioStatusSummary(business);
   const nextStep = buildAdminNextStep({ business, notificationSettings, ownerConnected });
-  const archived = isBusinessArchived(business);
-  const paused = isBusinessAutomationPaused(business) && !archived;
+  const onboardingConfidence = buildAdminOnboardingConfidence({
+    business,
+    notificationSettings,
+    ownerConnected,
+    successfulLeadCount: 0,
+    operatorEvents: [],
+  });
+  const state = buildAdminBusinessCardState({
+    business,
+    notificationSettings,
+    ownerConnected,
+    nextStep,
+    managedSummary,
+    onboardingConfidence,
+    lastIssue: {
+      state: 'healthy',
+      tone: 'neutral',
+      summary: 'No open issues recorded',
+      detail: 'Recent business events do not show an unresolved failure or blocker right now.',
+      createdAt: null,
+      categoryLabel: null,
+      statusLabel: null,
+      eventType: null,
+      remediationStepKey: null,
+    },
+    testSmsTruth: {
+      state: 'not_run',
+      label: 'Not run',
+      tone: 'neutral',
+      summary: 'No admin test SMS recorded',
+      detail: 'Run a test SMS from this page before treating delivery as proven.',
+      reason: null,
+      lastAttemptAt: null,
+      eventType: null,
+    },
+    missedCallValidation: {
+      state: 'not_run',
+      label: 'Not run',
+      tone: 'neutral',
+      summary: 'Missed-call flow not validated yet',
+      detail: 'Run one real missed call from start to finish, or record a manual confirmation note if you validated it outside this console.',
+      verifiedAt: null,
+      sourceLabel: null,
+      evidenceSummary: null,
+      relatedLeadId: null,
+      latestRelatedEventAt: null,
+      countsAsLaunchProof: false,
+    },
+  });
 
-  if (filter === 'archived') return archived;
-  if (archived) return false;
-
-  if (filter === 'paused') {
-    return paused || business.managedTwilioStatus === ManagedTwilioStatus.PAUSED_NONCOMPLIANT;
-  }
-
-  if (filter === 'live') {
-    return business.provisioningStatus === BusinessProvisioningStatus.LIVE && managedSummary.messagingReady;
-  }
-
-  if (filter === 'pending_a2p') {
-    return managedSummary.compliancePendingReview;
-  }
-
-  if (filter === 'pending_setup') {
-    return business.provisioningStatus === BusinessProvisioningStatus.DRAFT;
-  }
-
-  if (filter === 'in_setup') {
-    return business.provisioningStatus === BusinessProvisioningStatus.ONBOARDING || (!managedSummary.onboardingReady && ownerConnected);
-  }
-
-  if (filter === 'needs_attention') {
-    return nextStep.tone === 'attention';
-  }
-
-  return true;
+  return matchesAdminBoardFilterState(state, filter);
 }
 
 function compactBody(value: string, maxLength = 120) {

--- a/tests/admin-dashboard.test.ts
+++ b/tests/admin-dashboard.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@prisma/client';
 
 import {
+  buildAdminBusinessCardState,
   buildAdminBusinessPickerLabel,
   buildAdminOnboardingConfidence,
   buildAdminBusinessEvents,
@@ -22,7 +23,9 @@ import {
   getAdminTestSmsConfidenceState,
   getDeleteTestBusinessBlockedReason,
   matchesAdminBoardFilter,
+  matchesAdminBoardFilterState,
 } from '../lib/admin-dashboard.ts';
+import { getManagedTwilioStatusSummary } from '../lib/managed-twilio-status.ts';
 
 function createBusiness(overrides: Record<string, unknown> = {}) {
   return {
@@ -77,6 +80,96 @@ function createNotificationSettings(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createLastIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    state: 'healthy' as const,
+    tone: 'neutral' as const,
+    summary: 'No open issues recorded',
+    detail: 'Recent business events do not show an unresolved failure or blocker right now.',
+    createdAt: null,
+    categoryLabel: null,
+    statusLabel: null,
+    eventType: null,
+    remediationStepKey: null,
+    ...overrides,
+  };
+}
+
+function createTestSmsTruth(overrides: Record<string, unknown> = {}) {
+  return {
+    state: 'not_run' as const,
+    label: 'Not run',
+    tone: 'neutral' as const,
+    summary: 'No admin test SMS recorded',
+    detail: 'Run a test SMS from this page before treating delivery as proven.',
+    reason: null,
+    lastAttemptAt: null,
+    eventType: null,
+    ...overrides,
+  };
+}
+
+function createMissedCallValidation(overrides: Record<string, unknown> = {}) {
+  return {
+    state: 'not_run' as const,
+    label: 'Not run',
+    tone: 'neutral' as const,
+    summary: 'Missed-call flow not validated yet',
+    detail: 'Run one real missed call from start to finish, or record a manual confirmation note if you validated it outside this console.',
+    verifiedAt: null,
+    sourceLabel: null,
+    evidenceSummary: null,
+    relatedLeadId: null,
+    latestRelatedEventAt: null,
+    countsAsLaunchProof: false,
+    ...overrides,
+  };
+}
+
+function createCardState(params: {
+  business?: Record<string, unknown>;
+  notificationSettings?: Record<string, unknown>;
+  ownerConnected?: boolean;
+  successfulLeadCount?: number;
+  operatorEvents?: Array<{ type: string; status: OperatorEventStatus; createdAt: Date }>;
+  missedCallValidation?: Record<string, unknown>;
+  lastIssue?: Record<string, unknown>;
+}) {
+  const business = createBusiness(params.business);
+  const notificationSettings = createNotificationSettings(params.notificationSettings);
+  const nextStep = buildAdminNextStep({
+    business,
+    notificationSettings,
+    ownerConnected: params.ownerConnected ?? true,
+  });
+  const onboardingConfidence = buildAdminOnboardingConfidence({
+    business,
+    notificationSettings,
+    ownerConnected: params.ownerConnected ?? true,
+    successfulLeadCount: params.successfulLeadCount ?? 0,
+    operatorEvents: params.operatorEvents || [],
+    missedCallValidation: params.missedCallValidation ? createMissedCallValidation(params.missedCallValidation) : undefined,
+  });
+
+  return buildAdminBusinessCardState({
+    business,
+    notificationSettings,
+    ownerConnected: params.ownerConnected ?? true,
+    nextStep,
+    managedSummary: getManagedTwilioStatusSummary(business),
+    onboardingConfidence,
+    lastIssue: createLastIssue(params.lastIssue),
+    testSmsTruth: createTestSmsTruth(
+      params.operatorEvents?.some((event) => event.type === 'admin.test_sms_delivered')
+        ? { state: 'delivered', label: 'Delivered', tone: 'success', summary: 'Test SMS delivered', detail: 'Delivery confirmed.' }
+        : params.operatorEvents?.some((event) => event.type === 'admin.test_sms_failed' || event.type === 'admin.test_sms_delivery_failed')
+          ? { state: 'failed', label: 'Failed', tone: 'attention', summary: 'Test SMS failed', detail: 'Delivery failed.' }
+          : {}
+    ),
+    missedCallValidation: createMissedCallValidation(params.missedCallValidation),
+  });
+}
+
 test('next-step guidance calls out webhook recovery and live health clearly', () => {
   const webhookMissing = buildAdminNextStep({
     business: createBusiness({ twilioWebhookSyncedAt: null, managedTwilioStatus: ManagedTwilioStatus.AWAITING_BUSINESS_VERIFICATION }),
@@ -97,8 +190,9 @@ test('next-step guidance calls out webhook recovery and live health clearly', ()
     ownerConnected: true,
   });
 
-  assert.equal(healthy.title, 'Business is live and healthy');
+  assert.equal(healthy.title, 'Business is live');
   assert.equal(healthy.tone, 'healthy');
+  assert.equal(healthy.actionLabel, 'No action needed');
 });
 
 test('next-step guidance stays explicit for owner setup and pending A2P review', () => {
@@ -139,7 +233,7 @@ test('next-step guidance stays explicit for owner setup and pending A2P review',
   });
 
   assert.equal(invitedOwner.title, 'Owner invitation is still pending');
-  assert.equal(invitedOwner.actionLabel, 'Review owner setup');
+  assert.equal(invitedOwner.actionLabel, 'Invite or connect owner');
 
   const pendingA2p = buildAdminNextStep({
     business: createBusiness({
@@ -216,6 +310,167 @@ test('board filters and delete guard stay conservative', () => {
     getDeleteTestBusinessBlockedReason(createBusiness({ isTestBusiness: true })),
     'Archive this business instead. Permanent delete only unlocks after archive.'
   );
+});
+
+test('business card state turns missing live proof into live-with-warnings instead of healthy', () => {
+  const state = createCardState({
+    business: {
+      provisioningStatus: BusinessProvisioningStatus.LIVE,
+      managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+      a2pApprovedAt: new Date('2026-04-17T00:00:00.000Z'),
+    },
+    successfulLeadCount: 0,
+    operatorEvents: [
+      {
+        type: 'admin.test_sms_delivered',
+        status: OperatorEventStatus.SUCCESS,
+        createdAt: new Date('2026-04-17T12:00:00.000Z'),
+      },
+    ],
+  });
+
+  assert.equal(state.primaryState, 'live_with_warnings');
+  assert.equal(state.primaryLabel, 'Live with warnings');
+  assert.equal(state.primaryReason, 'Missed-call flow has not been fully validated.');
+  assert.equal(state.nextActionLabel, 'Validate missed-call flow');
+  assert.equal(state.badges.some((badge) => badge.label === 'Missed-call proof missing'), true);
+});
+
+test('business card state keeps a clean live business decisive', () => {
+  const state = createCardState({
+    business: {
+      provisioningStatus: BusinessProvisioningStatus.LIVE,
+      managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+      a2pApprovedAt: new Date('2026-04-17T00:00:00.000Z'),
+    },
+    successfulLeadCount: 1,
+    operatorEvents: [
+      {
+        type: 'admin.test_sms_delivered',
+        status: OperatorEventStatus.SUCCESS,
+        createdAt: new Date('2026-04-17T12:00:00.000Z'),
+      },
+    ],
+    missedCallValidation: {
+      countsAsLaunchProof: true,
+      detail: 'Recent event sequence proves the missed-call flow reached the owner alert path.',
+    },
+  });
+
+  assert.equal(state.primaryState, 'live');
+  assert.equal(state.nextActionLabel, 'No action needed');
+});
+
+test('archived businesses stay out of active needs-attention flow and point to restore', () => {
+  const state = createCardState({
+    business: {
+      archivedAt: new Date('2026-04-16T00:00:00.000Z'),
+      provisioningStatus: BusinessProvisioningStatus.LIVE,
+    },
+    operatorEvents: [
+      {
+        type: 'admin.test_sms_failed',
+        status: OperatorEventStatus.FAILED,
+        createdAt: new Date('2026-04-17T12:00:00.000Z'),
+      },
+    ],
+  });
+
+  assert.equal(state.primaryState, 'archived');
+  assert.equal(state.nextActionLabel, 'Restore business');
+  assert.equal(state.shouldAppearInNeedsAttention, false);
+  assert.equal(matchesAdminBoardFilterState(state, 'needs_attention'), false);
+  assert.equal(matchesAdminBoardFilterState(state, 'archived'), true);
+});
+
+test('business card state uses specific next actions for provisioning and test SMS failures', () => {
+  const provisioningFailed = createCardState({
+    business: {
+      provisioningError: 'Messaging service attach failed.',
+    },
+  });
+  assert.equal(provisioningFailed.primaryState, 'provisioning_failed');
+  assert.equal(provisioningFailed.nextActionLabel, 'Fix provisioning');
+
+  const smsFailed = createCardState({
+    business: {
+      managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+      a2pApprovedAt: new Date('2026-04-17T00:00:00.000Z'),
+    },
+    operatorEvents: [
+      {
+        type: 'admin.test_sms_failed',
+        status: OperatorEventStatus.FAILED,
+        createdAt: new Date('2026-04-17T12:00:00.000Z'),
+      },
+    ],
+  });
+  assert.equal(smsFailed.nextActionLabel, 'Send test SMS');
+});
+
+test('business card badges stay deduped and capped', () => {
+  const state = createCardState({
+    business: {
+      provisioningStatus: BusinessProvisioningStatus.LIVE,
+      managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+      a2pApprovedAt: new Date('2026-04-17T00:00:00.000Z'),
+    },
+    operatorEvents: [
+      {
+        type: 'admin.test_sms_delivered',
+        status: OperatorEventStatus.SUCCESS,
+        createdAt: new Date('2026-04-17T12:00:00.000Z'),
+      },
+    ],
+  });
+
+  const labels = state.badges.map((badge) => badge.label);
+  assert.equal(new Set(labels).size, labels.length);
+  assert.equal(labels.length <= 3, true);
+});
+
+test('state-based filters use the same card model as the board counts', () => {
+  const states = [
+    createCardState({
+      business: {
+        archivedAt: new Date('2026-04-16T00:00:00.000Z'),
+      },
+    }),
+    createCardState({
+      business: {
+        provisioningError: 'Messaging service attach failed.',
+      },
+    }),
+    createCardState({
+      business: {
+        managedTwilioStatus: ManagedTwilioStatus.CAMPAIGN_SUBMITTED,
+      },
+    }),
+    createCardState({
+      business: {
+        provisioningStatus: BusinessProvisioningStatus.LIVE,
+        managedTwilioStatus: ManagedTwilioStatus.COMPLIANT_LIVE,
+        a2pApprovedAt: new Date('2026-04-17T00:00:00.000Z'),
+      },
+      successfulLeadCount: 1,
+      operatorEvents: [
+        {
+          type: 'admin.test_sms_delivered',
+          status: OperatorEventStatus.SUCCESS,
+          createdAt: new Date('2026-04-17T12:00:00.000Z'),
+        },
+      ],
+      missedCallValidation: {
+        countsAsLaunchProof: true,
+        detail: 'Recent event sequence proves the missed-call flow reached the owner alert path.',
+      },
+    }),
+  ];
+
+  assert.equal(states.filter((state) => matchesAdminBoardFilterState(state, 'needs_attention')).length, 1);
+  assert.equal(states.filter((state) => matchesAdminBoardFilterState(state, 'pending_a2p')).length, 1);
+  assert.equal(states.filter((state) => matchesAdminBoardFilterState(state, 'archived')).length, 1);
+  assert.equal(states.filter((state) => matchesAdminBoardFilterState(state, 'live')).length, 1);
 });
 
 test('business picker labels keep the name primary and add a fast secondary identifier', () => {

--- a/tests/admin-operator-routes.test.ts
+++ b/tests/admin-operator-routes.test.ts
@@ -18,17 +18,17 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   const appLayout = read('app/app/layout.tsx');
 
   assert.match(adminHome, /Operator control panel/);
-  assert.match(adminHome, /Fast onboard/);
+  assert.match(adminHome, /Create new business/);
   assert.match(adminHome, /Create business workspace/);
-  assert.match(adminHome, /Founder reset/);
+  assert.match(adminHome, /Advanced founder tools/);
   assert.match(adminHome, /Delete one test\/demo business/);
   assert.match(adminHome, /Advanced founder reset: delete all current businesses/);
   assert.match(founderDeleteCard, /Delete this business/);
   assert.match(founderDeleteCard, /Type the exact business name/);
   assert.match(adminHome, /FOUNDER_DELETE_ALL_BUSINESSES_CONFIRMATION/);
   assert.match(adminHome, /Business triage board/);
-  assert.match(adminHome, /Go-live blocker/);
-  assert.match(adminHome, /Test SMS/);
+  assert.match(adminHome, /Current reason/);
+  assert.match(adminHome, /Next action/);
   assert.match(adminHome, /Open customer workspace/);
   assert.match(adminHome, /Delete demo\/test business permanently/);
   assert.match(adminHome, /Type business name to permanently delete/);
@@ -74,7 +74,7 @@ test('admin routes expose support workspace and safe lifecycle controls', () => 
   assert.match(adminDetail, /View support workspace snapshot/);
   assert.match(adminDetail, /canDeleteTestBusiness\(business\)/);
   assert.match(adminDetail, /getDeleteTestBusinessBlockedReason\(business\)/);
-  assert.match(adminHome, /Open blocker step/);
+  assert.match(adminHome, /Restore business/);
   assert.match(activityTimeline, /Recent activity/);
   assert.match(activityTimeline, /Show more activity/);
   assert.match(activityTimeline, /Collapse activity/);

--- a/tests/managed-customer-setup.test.ts
+++ b/tests/managed-customer-setup.test.ts
@@ -44,8 +44,8 @@ test('managed setup handoff is wired through customer and admin surfaces', () =>
   assert.match(auth, /getOrCreateOwnedBusinessForClerkUser/);
   assert.match(appLayout, /CustomerSetupWaitingPage/);
   assert.match(appLayout, /getCustomerWorkspaceNotice/);
-  assert.match(adminHome, /Pending setup/);
-  assert.match(adminHome, /In setup/);
+  assert.match(adminHome, /Create new business/);
+  assert.match(adminHome, /Business triage board/);
   assert.match(adminHome, /New public pilot signups land here waiting for founder setup/i);
   assert.match(adminDetail, /This business is waiting for founder setup/);
   assert.match(adminActions, /await sendCustomerReadyNotification\(business\.id\)/);


### PR DESCRIPTION
## Summary
- unify the admin business board around a single derived triage state per business
- stop archived businesses from polluting active needs-attention queues and collapse secondary admin/founder tools by default
- replace vague operator CTAs with specific next actions and add focused tests for state, badges, and filter counts

## Root cause
The admin home was composing multiple independent status systems at once: lifecycle status, onboarding confidence, latest issue state, proof badges, and readiness/filter logic. Those layers were not using the same precedence rules, so a single business could render as Live, Live with warnings, and Needs attention at the same time. Archived businesses also flowed through the same active attention logic.

## Validation run
- `npm run env:check` ✅
- `npm run preflight:providers` ✅
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` ✅
- `npm run build` ✅

## Notes
- PR base is `codex/fix-owner-invite-autolink` so the diff stays scoped to this admin/operator cleanup commit.