### PR TITLE
Simplify owner dashboard lead workflow

### DIFF
--- a/app/app/billing/page.tsx
+++ b/app/app/billing/page.tsx
@@ -7,7 +7,6 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { requireBusiness } from '@/lib/auth';
 import { getBillingUsageSnapshotForBusiness } from '@/lib/business-access';
 import { db } from '@/lib/db';
-import { getManagedTextingNumber } from '@/lib/managed-twilio';
 import { getPortfolioDemoBlockedCount, isPortfolioDemoMode } from '@/lib/portfolio-demo';
 import { getBusinessBillingAccessState } from '@/lib/subscription';
 import { getBillingDisplayLabel } from '@/lib/system-status';
@@ -165,12 +164,13 @@ export default async function BillingPage({ searchParams }: { searchParams?: Rec
   const currentPlanLabel = mapPlanLabel(stripeSnapshot?.stripePlanLabel, business.stripePriceId, process.env);
   const billingStatusLabel = getBillingDisplayLabel(business.subscriptionStatus, billingAccess.billingActive);
   const billingNeedsAttention = business.subscriptionStatus === 'PAST_DUE' || business.subscriptionStatus === 'CANCELED' || !subscriptionActive;
+  const hasBusinessTextingNumber = Boolean(business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber);
 
   const summaryItems = [
     { label: 'Current plan', value: currentPlanLabel },
     { label: 'Next charge date', value: stripeSnapshot ? formatDate(stripeSnapshot.nextChargeDate) : 'Shown in Stripe Billing Portal' },
     { label: 'Included usage', value: usage ? `${usage.limit} SMS-qualified conversations / month` : `Unavailable in ${demoModeLabel}` },
-    { label: 'Included number', value: getManagedTextingNumber(business) ? 'One business texting number is included' : 'Included once setup is finished' },
+    { label: 'Included number', value: hasBusinessTextingNumber ? 'One business texting number is included' : 'Included once setup is finished' },
     { label: 'Overage policy', value: 'One business texting number and standard setup are included. Automatic follow-up pauses at the limit until you upgrade.' },
     { label: 'Payment method', value: stripeSnapshot?.paymentMethodLabel || 'Add or update card in Stripe Billing Portal' },
     { label: 'Billing portal', value: business.stripeCustomerId ? 'Available below' : 'Available after your account is ready' },

--- a/app/app/billing/page.tsx
+++ b/app/app/billing/page.tsx
@@ -170,10 +170,10 @@ export default async function BillingPage({ searchParams }: { searchParams?: Rec
     { label: 'Current plan', value: currentPlanLabel },
     { label: 'Next charge date', value: stripeSnapshot ? formatDate(stripeSnapshot.nextChargeDate) : 'Shown in Stripe Billing Portal' },
     { label: 'Included usage', value: usage ? `${usage.limit} SMS-qualified conversations / month` : `Unavailable in ${demoModeLabel}` },
-    { label: 'Included number', value: getManagedTextingNumber(business) ? 'One business texting number is included' : 'Provisioned during setup' },
-    { label: 'Overage policy', value: 'One business texting number and standard setup are included. Automation pauses at the limit until you upgrade.' },
+    { label: 'Included number', value: getManagedTextingNumber(business) ? 'One business texting number is included' : 'Included once setup is finished' },
+    { label: 'Overage policy', value: 'One business texting number and standard setup are included. Automatic follow-up pauses at the limit until you upgrade.' },
     { label: 'Payment method', value: stripeSnapshot?.paymentMethodLabel || 'Add or update card in Stripe Billing Portal' },
-    { label: 'Billing portal', value: business.stripeCustomerId ? 'Available below' : 'Available after customer setup' },
+    { label: 'Billing portal', value: business.stripeCustomerId ? 'Available below' : 'Available after your account is ready' },
   ];
 
   const usageCards = [
@@ -323,11 +323,11 @@ export default async function BillingPage({ searchParams }: { searchParams?: Rec
         <Card className={requestedPlan === 'starter' ? 'border-primary/40 bg-primary/5' : 'bg-card/90'}>
           <CardHeader>
             <CardTitle>Starter</CardTitle>
-            <CardDescription>Cover missed calls with one managed texting number, standard setup, and a clean owner handoff.</CardDescription>
+            <CardDescription>Cover missed calls with one business texting number, standard setup, and a clean owner handoff.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-2 text-sm text-muted-foreground">
             <p>{planPrice(starterPriceId)}</p>
-            <p>Best for smaller service teams that want missed-call coverage live fast without managing line setup.</p>
+            <p>Best for smaller service teams that want missed-call coverage live fast without managing phone setup.</p>
           </CardContent>
           <CardFooter>
             <form action="/api/stripe/checkout" method="post" className="w-full">
@@ -342,7 +342,7 @@ export default async function BillingPage({ searchParams }: { searchParams?: Rec
         <Card className={requestedPlan === 'growth' ? 'border-primary/40 bg-primary/5' : 'bg-card/90'}>
           <CardHeader>
             <CardTitle>Growth</CardTitle>
-            <CardDescription>More follow-up capacity plus managed rollout help for teams with busier inbound traffic.</CardDescription>
+            <CardDescription>More follow-up capacity plus guided rollout help for teams with busier inbound traffic.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-2 text-sm text-muted-foreground">
             <p>{planPrice(growthPriceId)}</p>
@@ -364,7 +364,7 @@ export default async function BillingPage({ searchParams }: { searchParams?: Rec
             <CardDescription>For operators managing multiple brands, multiple locations, extra numbers, or white-glove launches.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-2 text-sm text-muted-foreground">
-            <p>Talk to us before activation so routing, billing, and onboarding structure match the operating model.</p>
+            <p>Talk to us before going live so routing, billing, and onboarding structure match the operating model.</p>
           </CardContent>
           <CardFooter className="flex flex-col gap-2">
             <Link className={buttonVariants({ className: 'w-full' })} href="/contact">

--- a/app/app/call-flow/page.tsx
+++ b/app/app/call-flow/page.tsx
@@ -1,243 +1,135 @@
 import Link from 'next/link';
 
-import {
-  getBusinessPhoneSetupGate,
-  getBusinessPhoneSetupPathLabel,
-  getBusinessRoutingNumber,
-  getPublicBusinessPhone,
-} from '@/lib/business-phone-setup';
 import { SetupChecklist } from '@/components/setup-checklist';
 import { Badge } from '@/components/ui/badge';
 import { buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { requireBusiness } from '@/lib/auth';
+import { getBusinessNotificationSettingsForBusiness } from '@/lib/business-access';
+import { getBusinessRoutingNumber, getPublicBusinessPhone } from '@/lib/business-phone-setup';
 import { db } from '@/lib/db';
-import { getManagedTextingNumber, getManagedTwilioStatusSummary } from '@/lib/managed-twilio';
 import { formatPhoneForDisplay } from '@/lib/phone';
 import { isPortfolioDemoMode } from '@/lib/portfolio-demo';
-import { getBusinessBillingAccessState } from '@/lib/subscription';
 import { getCustomerSystemStatus } from '@/lib/system-status';
-import { isSmsRecipientOptedOut } from '@/lib/twilio-sms-compliance';
+
+function formatMaybePhone(value: string | null | undefined, fallback: string) {
+  return value ? formatPhoneForDisplay(value) : fallback;
+}
 
 export default async function CallFlowPage() {
   const business = await requireBusiness();
   const demoMode = isPortfolioDemoMode();
-  const billingAccess = getBusinessBillingAccessState(business);
-  const ownerNotifyPhoneOptedOut =
-    demoMode || !business.notifyPhone
-      ? false
-      : await isSmsRecipientOptedOut({ businessId: business.id, phone: business.notifyPhone });
-  const successfulLeadCount = demoMode
-    ? 1
-    : await db.lead.count({
-        where: {
-          businessId: business.id,
-          OR: [{ ownerNotifiedAt: { not: null } }, { notifiedAt: { not: null } }],
-        },
-      });
-  const managedTextingNumber = getManagedTextingNumber(business);
-  const managedTwilioSummary = getManagedTwilioStatusSummary(business);
-  const phoneSetupGate = getBusinessPhoneSetupGate(business);
-  const publicBusinessPhone = getPublicBusinessPhone(business);
-  const routingNumber = getBusinessRoutingNumber(business);
-  const readiness = {
-    ready:
-      Boolean(business.forwardingNumber) &&
-      phoneSetupGate.complete &&
-      managedTwilioSummary.messagingReady &&
-      Boolean(business.notifyPhone) &&
-      !ownerNotifyPhoneOptedOut &&
-      billingAccess.billingActive,
-    blockers: [
-      !managedTextingNumber ? { key: 'texting_line', label: 'Texting line', detail: 'CallbackCloser still needs to provision your business texting line.' } : null,
-      !business.forwardingNumber ? { key: 'routing', label: 'Owner answer number', detail: 'Add the owner or staff number that should receive live forwarded calls.' } : null,
-      !phoneSetupGate.complete ? { key: 'phone_path', label: getBusinessPhoneSetupPathLabel(business.phoneSetupPath), detail: phoneSetupGate.detail } : null,
-      !managedTwilioSummary.onboardingReady
-        ? { key: 'messaging', label: 'Messaging infrastructure', detail: managedTwilioSummary.nextStep }
-        : null,
-      !managedTwilioSummary.complianceReady
-        ? {
-            key: 'compliance',
-            label:
-              managedTwilioSummary.usesSharedPilotMessaging
-                ? 'Pilot sender setup'
-                : managedTwilioSummary.complianceType === 'TOLL_FREE_VERIFICATION'
-                ? 'Toll-free verification'
-                : managedTwilioSummary.complianceTypeUnknown
-                  ? 'Number type'
-                  : 'A2P approval',
-            detail: managedTwilioSummary.description,
-          }
-        : null,
-      !business.notifyPhone || ownerNotifyPhoneOptedOut
-        ? {
-            key: 'owner_alerts',
-            label: 'Owner alerts',
-            detail: !business.notifyPhone
-              ? 'Add the owner mobile number so lead summaries reach the right phone.'
-              : 'The owner alert number is opted out and needs to reply START before go-live.'
-          }
-        : null,
-      !billingAccess.billingActive
-        ? { key: 'billing', label: 'Billing', detail: 'Activate billing so auto-texting can stay live on missed calls.' }
-        : null,
-    ].filter(Boolean) as Array<{ key: string; label: string; detail: string }>,
-  };
+  const [notificationSettings, successfulLeadCount] = demoMode
+    ? [null, 1]
+    : await Promise.all([
+        getBusinessNotificationSettingsForBusiness(business.id),
+        db.lead.count({
+          where: {
+            businessId: business.id,
+            OR: [{ ownerNotifiedAt: { not: null } }, { notifiedAt: { not: null } }],
+          },
+        }),
+      ]);
+
+  const customerFacingNumber = getPublicBusinessPhone(business) || getBusinessRoutingNumber(business);
+  const forwardingNumber = business.forwardingNumber;
+  const ownerAlertDestination = notificationSettings?.ownerPhone || business.notifyPhone || notificationSettings?.ownerEmail || null;
+  const systemStatus = getCustomerSystemStatus(business, successfulLeadCount);
+  const textRepliesReady = systemStatus.key === 'live';
 
   const setupItems = [
     {
-      key: 'routing',
-      label: 'Owner answer number ready',
-      detail: business.forwardingNumber
-        ? `Live calls ring ${formatPhoneForDisplay(business.forwardingNumber)}`
+      key: 'customer-number',
+      label: 'Customer calling number',
+      detail: customerFacingNumber
+        ? `Customers can call ${formatPhoneForDisplay(customerFacingNumber)}.`
+        : 'CallbackCloser is finishing the number customers should call.',
+      complete: Boolean(customerFacingNumber),
+    },
+    {
+      key: 'answer-number',
+      label: 'Team answer number',
+      detail: forwardingNumber
+        ? `Live calls ring ${formatPhoneForDisplay(forwardingNumber)}.`
         : 'Add the owner or staff number your team answers.',
-      complete: Boolean(business.forwardingNumber),
+      complete: Boolean(forwardingNumber),
     },
     {
-      key: 'phone_path',
-      label: getBusinessPhoneSetupPathLabel(business.phoneSetupPath),
-      detail: phoneSetupGate.detail,
-      complete: phoneSetupGate.complete,
+      key: 'text-replies',
+      label: 'Missed-call text replies',
+      detail: textRepliesReady
+        ? 'Missed callers can receive the follow-up text automatically.'
+        : 'CallbackCloser is finishing this before automatic text replies go fully live.',
+      complete: textRepliesReady,
     },
     {
-      key: 'twilio',
-      label: 'CallbackCloser routing number assigned',
-      detail: managedTextingNumber
-        ? `Your CallbackCloser routing number is ${formatPhoneForDisplay(managedTextingNumber)}.`
-        : 'CallbackCloser still needs to provision or map your routing number.',
-      complete: Boolean(managedTextingNumber),
-    },
-    {
-      key: 'messaging',
-      label: 'Messaging infrastructure ready',
-      detail: managedTwilioSummary.onboardingReady
-        ? 'Managed messaging, number assignment, and webhook sync are ready.'
-        : managedTwilioSummary.nextStep,
-      complete: managedTwilioSummary.onboardingReady,
-    },
-    {
-      key: 'compliance',
-      label: managedTwilioSummary.complianceReady
-        ? managedTwilioSummary.usesSharedPilotMessaging
-          ? 'Pilot sender ready'
-          : managedTwilioSummary.complianceType === 'TOLL_FREE_VERIFICATION'
-          ? 'Toll-free verification complete'
-          : 'A2P approved'
-        : managedTwilioSummary.usesSharedPilotMessaging
-          ? 'Pilot sender still needed'
-          : managedTwilioSummary.complianceType === 'TOLL_FREE_VERIFICATION'
-          ? 'Toll-free verification in progress'
-          : managedTwilioSummary.complianceTypeUnknown
-            ? 'Number type still needed'
-            : 'A2P approval in progress',
-      detail: managedTwilioSummary.description,
-      complete: managedTwilioSummary.complianceReady,
-    },
-    {
-      key: 'owner-alert',
-      label: 'Owner notifications ready',
-      detail: business.notifyPhone ? 'Owner notify phone is present for handoff texts.' : 'Add the owner mobile number for lead alerts.',
-      complete: Boolean(business.notifyPhone) && !ownerNotifyPhoneOptedOut,
-    },
-    {
-      key: 'billing',
-      label: 'Billing active',
-      detail: billingAccess.billingActive ? 'Automation can text back on live missed calls.' : 'Activate billing before live SMS follow-up resumes.',
-      complete: billingAccess.billingActive,
-    },
-    {
-      key: 'test',
-      label: 'Successful test lead',
-      detail: successfulLeadCount > 0 ? `${successfulLeadCount} lead${successfulLeadCount === 1 ? '' : 's'} reached owner-alert stage.` : 'Run a missed-call test and verify the owner alert.',
-      complete: successfulLeadCount > 0,
+      key: 'owner-alerts',
+      label: 'Owner alerts',
+      detail: ownerAlertDestination
+        ? `Lead summaries go to ${ownerAlertDestination.startsWith('+') ? formatPhoneForDisplay(ownerAlertDestination) : ownerAlertDestination}.`
+        : 'Add the phone or email that should receive lead summaries.',
+      complete: Boolean(ownerAlertDestination),
     },
   ];
-  const allChecklistComplete = setupItems.every((item) => item.complete);
-  const systemStatus = getCustomerSystemStatus(business, successfulLeadCount);
 
   const flowSteps = [
-      {
-        title: 'A caller reaches your connected business number',
-        detail:
-          business.phoneSetupPath === 'CURRENT_NUMBER_FORWARDING'
-            ? publicBusinessPhone && routingNumber
-              ? `Customers call ${formatPhoneForDisplay(publicBusinessPhone)}, which forwards into ${formatPhoneForDisplay(routingNumber)} so CallbackCloser can catch the missed-call moment.`
-              : phoneSetupGate.detail
-            : managedTextingNumber
-              ? `Calls hit ${formatPhoneForDisplay(managedTextingNumber)} so CallbackCloser can catch the missed-call moment.`
-              : 'CallbackCloser still needs to provision or map the routing number that will cover missed calls.',
+    {
+      title: 'A customer calls',
+      detail: customerFacingNumber
+        ? `They call ${formatPhoneForDisplay(customerFacingNumber)}, the number connected to missed-call recovery.`
+        : 'CallbackCloser will show the connected customer number here once setup is finished.',
     },
     {
-      title: 'CallbackCloser sees the missed call',
-      detail:
-        business.forwardedCallAnswerMode === 'PRESS_1_REQUIRED'
-          ? `Current missed-call timeout is ${business.missedCallSeconds} seconds. Forwarded calls only count as answered after your team presses 1, so voicemail pickups still fall back into recovery.`
-          : `Current missed-call timeout is ${business.missedCallSeconds} seconds before the recovery flow starts.`,
+      title: 'Your team gets the live call',
+      detail: forwardingNumber
+        ? `The call rings ${formatPhoneForDisplay(forwardingNumber)} so your team can answer normally.`
+        : 'Add the phone your team answers so live calls reach the right person.',
     },
-      {
-        title: 'The caller gets a text right away',
-        detail: managedTwilioSummary.complianceReady
-          ? managedTwilioSummary.usesSharedPilotMessaging
-            ? 'Pilot setup sends the conversation from the approved CallbackCloser messaging number while the business keeps its public number live.'
-            : 'The conversation collects the service type, urgency, ZIP, callback timing, and optional name without extra admin work.'
-          : managedTwilioSummary.complianceType === 'TOLL_FREE_VERIFICATION'
-            ? 'The automated SMS handoff stays pending until the managed Twilio setup and toll-free verification are complete.'
-            : managedTwilioSummary.complianceTypeUnknown
-              ? 'The automated SMS handoff stays pending until the number type is selected and messaging compliance is recorded.'
-              : 'The automated SMS handoff stays pending until the managed Twilio setup and A2P approval are complete.',
-      },
     {
-      title: 'You get the handoff ready to call',
-      detail: business.notifyPhone
-        ? `Qualified lead summaries are routed to ${formatPhoneForDisplay(business.notifyPhone)}.`
-        : 'Add an owner mobile number so the summary can be delivered.',
+      title: 'Missed callers get a quick text',
+      detail: 'If the call is missed, CallbackCloser asks what they need, how urgent it is, where they are, and when you should call back.',
+    },
+    {
+      title: 'You get a lead summary',
+      detail: ownerAlertDestination
+        ? `CallbackCloser sends the summary to ${ownerAlertDestination.startsWith('+') ? formatPhoneForDisplay(ownerAlertDestination) : ownerAlertDestination}.`
+        : 'Add an owner alert destination so qualified lead summaries reach you.',
     },
   ];
 
   return (
     <div className="space-y-6">
       <div className="space-y-2">
-        <Badge variant="outline">Call Flow</Badge>
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Call flow and activation</h1>
-          <p className="text-sm text-muted-foreground">
-            This is exactly what happens when a missed call occurs, what is already live, and what still needs attention before a confident first test.
-          </p>
+        <Badge variant="outline">How it works</Badge>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">How missed calls are handled</h1>
+            <p className="max-w-3xl text-sm text-muted-foreground">
+              A simple view of what callers experience, where live calls ring, and where lead summaries are sent.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link className={buttonVariants({ variant: 'outline' })} href="/app/settings">
+              Edit settings
+            </Link>
+            <Link className={buttonVariants({ variant: 'outline' })} href="/app/leads">
+              Open leads
+            </Link>
+          </div>
         </div>
       </div>
 
-      {allChecklistComplete ? (
-        <Card className="border-accent/40 bg-accent/20">
-          <CardHeader>
-            <CardTitle>🎉 Your system is live — run a test call now</CardTitle>
-            <CardDescription>
-              Messaging, compliance, and test-lead handoff are all complete. One more test call is the fastest way to confirm everything still feels right.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-wrap gap-3">
-            {managedTextingNumber ? (
-              <Link className={buttonVariants()} href={`tel:${managedTextingNumber}`}>
-                Run test call
-              </Link>
-            ) : null}
-            <Link className={buttonVariants({ variant: 'outline' })} href="/app/leads">
-              Open Recovered Leads
-            </Link>
-          </CardContent>
-        </Card>
-      ) : null}
-
       <SetupChecklist
-        title="Activation checklist"
-        description="The fastest path to value is still: get the texting line live, confirm routing, verify owner alerts, then run the missed-call test."
+        title="Missed-call setup"
+        description="The essentials owners need to know: what number callers use, where calls ring, whether texts are active, and where lead summaries go."
         items={setupItems}
       />
 
       <div className="grid gap-6 lg:grid-cols-[1.05fr_0.95fr]">
         <Card className="bg-card/90">
           <CardHeader>
-            <CardTitle>Current call flow</CardTitle>
-            <CardDescription>Business-facing steps from missed call to owner handoff.</CardDescription>
+            <CardTitle>Caller experience</CardTitle>
+            <CardDescription>From incoming call to ready-to-call lead summary.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             {flowSteps.map((step, index) => (
@@ -258,38 +150,39 @@ export default async function CallFlowPage() {
 
         <Card className="bg-card/90">
           <CardHeader>
-            <CardTitle>Next activation move</CardTitle>
-            <CardDescription>{systemStatus.description}</CardDescription>
+            <CardTitle>Current numbers</CardTitle>
+            <CardDescription>Use these to confirm the owner-facing call path.</CardDescription>
           </CardHeader>
-          <CardContent className="space-y-4 text-sm text-muted-foreground">
-            {readiness.ready ? (
-              <div className="rounded-xl border border-accent/40 bg-accent/20 p-4">
-                Routing, notifications, billing, managed setup, and messaging compliance look ready. Run the missed-call test and confirm the owner alert lands.
-              </div>
-            ) : (
-              <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-destructive">
-                <p className="font-medium">Action needed before go-live</p>
-                <p className="mt-1 text-sm text-destructive/80">
-                  {readiness.blockers.length} blocker{readiness.blockers.length === 1 ? '' : 's'} still need attention before the system is operationally ready for live customer messaging.
-                </p>
-                <ul className="mt-2 list-disc space-y-1 pl-5">
-                  {readiness.blockers.map((blocker) => (
-                    <li key={blocker.key}>
-                      {blocker.label}: {blocker.detail}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
+          <CardContent className="space-y-4 text-sm">
+            <div className="rounded-xl border bg-background/80 p-4">
+              <p className="font-medium">Number customers call</p>
+              <p className="mt-2 text-muted-foreground">{formatMaybePhone(customerFacingNumber, 'Setup in progress')}</p>
+            </div>
+            <div className="rounded-xl border bg-background/80 p-4">
+              <p className="font-medium">Number your team answers</p>
+              <p className="mt-2 text-muted-foreground">{formatMaybePhone(forwardingNumber, 'Not saved yet')}</p>
+            </div>
+            <div className="rounded-xl border bg-background/80 p-4">
+              <p className="font-medium">Lead summary destination</p>
+              <p className="mt-2 text-muted-foreground">
+                {ownerAlertDestination
+                  ? ownerAlertDestination.startsWith('+')
+                    ? formatPhoneForDisplay(ownerAlertDestination)
+                    : ownerAlertDestination
+                  : 'Not saved yet'}
+              </p>
+            </div>
             <div className="grid gap-3">
-              <Link className={buttonVariants()} href="/app/settings">
-                Open Business Settings
-              </Link>
-              <Link className={buttonVariants({ variant: 'outline' })} href="/app/leads">
-                Open Recovered Leads
+              {customerFacingNumber ? (
+                <Link className={buttonVariants()} href={`tel:${customerFacingNumber}`}>
+                  Place a test call
+                </Link>
+              ) : null}
+              <Link className={buttonVariants({ variant: 'outline' })} href="/app/settings">
+                Update business settings
               </Link>
               <Link className={buttonVariants({ variant: 'outline' })} href="/app/billing">
-                Open Billing
+                Open billing
               </Link>
             </div>
           </CardContent>

--- a/app/app/conversations/page.tsx
+++ b/app/app/conversations/page.tsx
@@ -1,11 +1,10 @@
 import Link from 'next/link';
-import { MessageDirection } from '@prisma/client';
 
 import { Badge } from '@/components/ui/badge';
 import { buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { requireBusiness } from '@/lib/auth';
-import { getConversationDetailForBusiness, listConversationsForBusiness } from '@/lib/business-access';
+import { listConversationsForBusiness } from '@/lib/business-access';
 import {
   formatDateTime,
   getLeadCallbackState,
@@ -15,21 +14,14 @@ import {
   leadStatusLabels,
 } from '@/lib/lead-presenters';
 import { formatPhoneForDisplay } from '@/lib/phone';
-import { getPortfolioDemoLeadDetail, getPortfolioDemoLeads, isPortfolioDemoMode } from '@/lib/portfolio-demo';
+import { getPortfolioDemoLeads, isPortfolioDemoMode } from '@/lib/portfolio-demo';
 
-export default async function ConversationsPage({ searchParams }: { searchParams?: Record<string, string | string[] | undefined> }) {
+export default async function ConversationsPage() {
   const business = await requireBusiness();
   const demoMode = isPortfolioDemoMode();
   const leads = demoMode
     ? getPortfolioDemoLeads(null).filter((lead) => lead.lastInboundAt || lead.lastOutboundAt)
     : await listConversationsForBusiness(business.id);
-
-  const selectedLeadId = typeof searchParams?.leadId === 'string' ? searchParams.leadId : leads[0]?.id;
-  const selectedLead = selectedLeadId
-    ? demoMode
-      ? getPortfolioDemoLeadDetail(selectedLeadId)
-      : await getConversationDetailForBusiness(business.id, selectedLeadId)
-    : null;
 
   return (
     <div className="space-y-6">
@@ -38,7 +30,7 @@ export default async function ConversationsPage({ searchParams }: { searchParams
           <Badge variant="outline">Conversations</Badge>
           <div>
             <h1 className="text-2xl font-semibold tracking-tight">Lead conversations</h1>
-            <p className="text-sm text-muted-foreground">Review the latest replies first, then jump back to the lead that is most likely to close.</p>
+            <p className="text-sm text-muted-foreground">See the latest caller replies. Open a lead to call back or mark the outcome.</p>
           </div>
         </div>
         <Link className={buttonVariants({ variant: 'outline' })} href="/app/leads">
@@ -46,111 +38,61 @@ export default async function ConversationsPage({ searchParams }: { searchParams
         </Link>
       </div>
 
-      <div className="grid gap-6 xl:grid-cols-[0.8fr_1.2fr]">
-        <Card className="bg-card/90">
-          <CardHeader>
-            <CardTitle>Open conversations</CardTitle>
-            <CardDescription>{leads.length} conversation{leads.length === 1 ? '' : 's'} where a missed caller texted back</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {leads.length === 0 ? (
-              <div className="rounded-xl border bg-muted/20 p-4 text-sm text-muted-foreground">
-                <p className="font-medium text-foreground">No conversations yet</p>
-                <p className="mt-2">Once your system is live, missed callers who text back will appear here automatically.</p>
-                <div className="mt-4 flex flex-wrap gap-2">
-                  <Link className={buttonVariants({ size: 'sm' })} href="/app/call-flow">
-                    Run your first test call
-                  </Link>
-                  <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href="/app/settings">
-                    Check setup
-                  </Link>
-                </div>
+      <Card className="bg-card/90">
+        <CardHeader>
+          <CardTitle>Latest conversations</CardTitle>
+          <CardDescription>{leads.length} conversation{leads.length === 1 ? '' : 's'} where a missed caller texted back</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {leads.length === 0 ? (
+            <div className="rounded-xl border bg-muted/20 p-4 text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">No conversations yet</p>
+              <p className="mt-2">Once missed callers reply by text, their conversations will appear here.</p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Link className={buttonVariants({ size: 'sm' })} href="/app/leads">
+                  Open leads
+                </Link>
+                <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href="/app/call-flow">
+                  How missed calls work
+                </Link>
               </div>
-            ) : (
-              leads.map((lead) => {
-                const latestMessage = lead.messages[0];
-                const selected = lead.id === selectedLead?.id;
-                return (
-                  <Link
-                    key={lead.id}
-                    href={`/app/conversations?leadId=${lead.id}`}
-                    className={`block rounded-xl border p-4 transition-colors hover:bg-muted/20 ${selected ? 'bg-primary/5' : 'bg-background/80'}`}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <p className="font-medium">{formatPhoneForDisplay(lead.callerPhoneNormalized || lead.callerPhone)}</p>
-                        <p className="text-xs text-muted-foreground">{lead.callerName || lead.contactName || 'Name pending'}</p>
-                      </div>
-                      <div className="flex flex-wrap gap-1">
-                        <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
-                        <Badge variant={lead.readiness === 'URGENT' ? 'destructive' : lead.readiness === 'QUALIFIED' ? 'secondary' : 'outline'}>
-                          {leadReadinessLabels[lead.readiness]}
-                        </Badge>
-                      </div>
+            </div>
+          ) : (
+            leads.map((lead) => {
+              const latestMessage = lead.messages[0];
+              return (
+                <Link
+                  key={lead.id}
+                  href={`/app/leads/${lead.id}?from=%2Fapp%2Fconversations`}
+                  className="block rounded-xl border bg-background/80 p-4 transition-colors hover:bg-muted/20"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <p className="font-medium">{lead.callerName || lead.contactName || formatPhoneForDisplay(lead.callerPhoneNormalized || lead.callerPhone)}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {lead.callerName || lead.contactName ? formatPhoneForDisplay(lead.callerPhoneNormalized || lead.callerPhone) : 'Name pending'}
+                      </p>
                     </div>
-                    <p className="mt-3 text-sm text-muted-foreground">
-                      {lead.summary || latestMessage?.body || 'No message preview available.'}
-                    </p>
-                    <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
-                      <span>{lead.serviceType || lead.serviceRequested || getLeadCallbackState(lead)}</span>
-                      <span>{formatDateTime(getLeadLastActivityAt(lead))}</span>
+                    <div className="flex flex-wrap gap-1 sm:justify-end">
+                      <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
+                      <Badge variant={lead.readiness === 'URGENT' ? 'destructive' : lead.readiness === 'QUALIFIED' ? 'secondary' : 'outline'}>
+                        {leadReadinessLabels[lead.readiness]}
+                      </Badge>
                     </div>
-                  </Link>
-                );
-              })
-            )}
-          </CardContent>
-        </Card>
-
-        <Card className="bg-card/90">
-          <CardHeader>
-            <CardTitle>Conversation detail</CardTitle>
-            <CardDescription>
-              {selectedLead ? formatPhoneForDisplay(selectedLead.callerPhoneNormalized || selectedLead.callerPhone) : 'Select a conversation'}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {!selectedLead ? (
-              <div className="rounded-xl border bg-muted/20 p-4 text-sm text-muted-foreground">
-                {leads.length === 0
-                  ? 'Once your system is live, conversations will appear here with the full SMS thread and callback context.'
-                  : 'Pick a conversation on the left to review the full thread.'}
-              </div>
-            ) : (
-              <>
-                <div className="flex flex-wrap items-center gap-2">
-                  <Badge variant={getLeadStatusBadgeVariant(selectedLead.status)}>{leadStatusLabels[selectedLead.status]}</Badge>
-                  <Badge variant="outline">{getLeadCallbackState(selectedLead)}</Badge>
-                  <Badge variant={selectedLead.readiness === 'URGENT' ? 'destructive' : selectedLead.readiness === 'QUALIFIED' ? 'secondary' : 'outline'}>
-                    {leadReadinessLabels[selectedLead.readiness]}
-                  </Badge>
-                  <Link className="text-sm underline underline-offset-4" href={`/app/leads/${selectedLead.id}?from=%2Fapp%2Fconversations`}>
-                    Open lead details
-                  </Link>
-                </div>
-                <div className="rounded-xl border bg-muted/20 p-4 text-sm">
-                  <p className="font-medium">Lead summary</p>
-                  <p className="mt-2 text-muted-foreground">{selectedLead.summary || 'CallbackCloser is still gathering the summary for this lead.'}</p>
-                </div>
-                <div className="space-y-3">
-                  {selectedLead.messages.map((message) => (
-                    <div
-                      key={message.id}
-                      className={`rounded-xl border p-3 text-sm ${message.direction === MessageDirection.OUTBOUND ? 'bg-primary/5' : 'bg-card'}`}
-                    >
-                      <div className="mb-1 flex items-center justify-between gap-3 text-xs text-muted-foreground">
-                        <span>{message.direction === MessageDirection.OUTBOUND ? 'CallbackCloser' : 'Lead'}</span>
-                        <span>{formatDateTime(message.createdAt)}</span>
-                      </div>
-                      <p className="whitespace-pre-wrap">{message.body}</p>
-                    </div>
-                  ))}
-                </div>
-              </>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+                  </div>
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    {latestMessage?.body || lead.summary || 'No message preview available.'}
+                  </p>
+                  <div className="mt-3 flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+                    <span>{lead.serviceType || lead.serviceRequested || getLeadCallbackState(lead)}</span>
+                    <span>Last activity {formatDateTime(getLeadLastActivityAt(lead))}</span>
+                  </div>
+                </Link>
+              );
+            })
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/app/app/conversations/page.tsx
+++ b/app/app/conversations/page.tsx
@@ -42,7 +42,7 @@ export default async function ConversationsPage({ searchParams }: { searchParams
           </div>
         </div>
         <Link className={buttonVariants({ variant: 'outline' })} href="/app/leads">
-          Open Recovered Leads
+          Open leads
         </Link>
       </div>
 

--- a/app/app/leads/[leadId]/page.tsx
+++ b/app/app/leads/[leadId]/page.tsx
@@ -34,7 +34,7 @@ function resolveSafeReturnPath(value: string | null | undefined) {
 
 function getLeadActionSummary(status: LeadStatus) {
   if (isLeadClosedWonStatus(status)) {
-    return 'This lead is marked Closed (Won). Keep the details here for reference.';
+    return 'This lead is marked booked. Keep the details here for reference.';
   }
 
   if (isLeadLostStatus(status)) {
@@ -45,7 +45,7 @@ function getLeadActionSummary(status: LeadStatus) {
     return 'You have already made contact. Update the final outcome when the customer decides.';
   }
 
-  return 'Call this lead back, then mark it Closed (Won) or Lost so your conversion summary stays accurate.';
+  return 'Call this lead back, then mark it contacted, booked, or lost.';
 }
 
 function LeadStatusActionForm({
@@ -113,6 +113,7 @@ export default async function LeadDetailPage({
   const recordingHref = lead.call?.recordingUrl ? `/api/leads/${lead.id}/recording` : null;
   const nextStepLabel = getLeadNextStepLabel(lead.status);
   const isOpenLead = isLeadOpenStatus(lead.status);
+  const createdLabel = formatDateTime(lead.createdAt);
 
   return (
     <div className="space-y-6">
@@ -173,14 +174,14 @@ export default async function LeadDetailPage({
                 status="BOOKED"
                 redirectTo={detailRedirectTo}
                 successRedirectTo={successRedirectTo}
-                label="Mark as Closed (Won)"
+                label="Mark booked"
               />
               <LeadStatusActionForm
                 leadId={lead.id}
                 status="LOST"
                 redirectTo={detailRedirectTo}
                 successRedirectTo={successRedirectTo}
-                label="Mark as Lost"
+                label="Mark lost"
                 variant="destructive"
               />
             </div>
@@ -192,6 +193,7 @@ export default async function LeadDetailPage({
             <p className="mt-2 font-medium">{customerName}</p>
             <p className="mt-2 text-muted-foreground">{customerPhone}</p>
             <p className="mt-2 text-muted-foreground">Created {formatRelativeTime(lead.createdAt)}.</p>
+            <p className="mt-2 text-muted-foreground">{createdLabel}</p>
           </div>
           <div className="rounded-2xl border bg-background/90 p-4 text-sm">
             <p className="text-xs uppercase tracking-wide text-muted-foreground">Service</p>
@@ -229,7 +231,7 @@ export default async function LeadDetailPage({
                   className={`rounded-2xl border p-3 text-sm ${message.direction === MessageDirection.OUTBOUND ? 'bg-primary/5' : 'bg-card'}`}
                 >
                   <div className="mb-1 flex items-center justify-between gap-3 text-xs text-muted-foreground">
-                    <span>{message.direction === MessageDirection.OUTBOUND ? 'CallbackCloser' : 'Lead'}</span>
+                    <span>{message.direction === MessageDirection.OUTBOUND ? 'CallbackCloser' : 'Caller replied'}</span>
                     <div className="flex items-center gap-2">
                       {message.status && message.status.toLowerCase() !== 'delivered' ? (
                         <Badge variant={isMessageDeliveryIssueStatus(message.status) ? 'destructive' : 'outline'}>

--- a/app/app/leads/page.tsx
+++ b/app/app/leads/page.tsx
@@ -2,13 +2,11 @@ import Link from 'next/link';
 import { LeadReadiness, LeadStatus } from '@prisma/client';
 
 import { CustomerLeadRow } from '@/components/customer-lead-row';
-import { LeadConversionSummaryCard } from '@/components/lead-conversion-summary-card';
 import { Badge } from '@/components/ui/badge';
 import { buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { requireBusiness } from '@/lib/auth';
 import { listAllDashboardLeadsForBusiness } from '@/lib/business-access';
-import { getLeadOutcomeSummary } from '@/lib/lead-outcomes';
 import { getLeadLastActivityAt, isLeadOpenStatus, leadStatusLabels } from '@/lib/lead-presenters';
 import { getPortfolioDemoLeads, isPortfolioDemoMode } from '@/lib/portfolio-demo';
 import { cn } from '@/lib/utils';
@@ -112,7 +110,6 @@ export default async function LeadsPage({ searchParams }: { searchParams?: Searc
   const view = statusFilter ? 'all' : parseInboxView(typeof searchParams?.view === 'string' ? searchParams.view : undefined);
   const allLeads = demoMode ? getPortfolioDemoLeads(null) : await listAllDashboardLeadsForBusiness(business.id);
   const hasLeads = allLeads.length > 0;
-  const outcomeSummary = getLeadOutcomeSummary(allLeads);
 
   const filteredLeads = statusFilter
     ? allLeads.filter((lead) => lead.status === statusFilter)
@@ -141,7 +138,7 @@ export default async function LeadsPage({ searchParams }: { searchParams?: Searc
     },
     {
       key: 'booked' as const,
-      label: 'Closed',
+      label: 'Booked',
       href: buildLeadsHref('booked'),
       count: allLeads.filter((lead) => lead.status === LeadStatus.BOOKED).length,
       active: !statusFilter && view === 'booked',
@@ -158,28 +155,23 @@ export default async function LeadsPage({ searchParams }: { searchParams?: Searc
   const listDescription = statusFilter
     ? `Showing ${leadStatusLabels[statusFilter].toLowerCase()} leads. Open a lead to act on it.`
     : view === 'attention'
-      ? 'Showing leads that still need action. Open one to call back or mark the final outcome.'
-      : 'Open any lead to review the conversation and mark it closed or lost from the detail page.';
+      ? 'Showing leads that still need action. Open one to call back or mark the outcome.'
+      : 'Open any lead to review the conversation and mark it contacted, booked, or lost.';
 
   return (
     <div className="space-y-6">
       <div className="space-y-3">
         <Badge variant="outline">Lead inbox</Badge>
         <div className="space-y-2">
-          <h1 className="text-2xl font-semibold tracking-tight">Scan the list. Open the lead. Take action.</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">Lead inbox</h1>
           <p className="max-w-2xl text-sm text-muted-foreground">
-            This page is only for scanning. Click a lead to open the detail page where the real follow-up work happens.
+            Scan missed-call leads, then open one to call back and mark the outcome.
           </p>
         </div>
       </div>
 
       {error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{error}</div> : null}
       {saved ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Lead updated.</div> : null}
-
-      <LeadConversionSummaryCard
-        description="Keep the win/loss numbers obvious so you can see whether missed calls are turning into booked jobs."
-        summary={outcomeSummary}
-      />
 
       {!hasLeads ? (
         <Card className="border-primary/20 bg-primary/5">
@@ -200,7 +192,7 @@ export default async function LeadsPage({ searchParams }: { searchParams?: Searc
         <Card className="bg-card/95">
           <CardHeader className="gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <CardTitle>Inbox</CardTitle>
+              <CardTitle>Leads</CardTitle>
               <CardDescription>{listDescription}</CardDescription>
             </div>
             <div className="flex flex-wrap gap-2">

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -204,11 +204,11 @@ export default async function AppHomePage({
       state: ownerAlertsReady ? ('complete' as const) : ('pending' as const),
     },
     {
-      key: 'texting-activation',
-      label: 'Texting activation in progress',
+      key: 'text-replies',
+      label: 'Text replies being prepared',
       detail:
         systemStatus.key === 'live'
-          ? 'Texting is live.'
+          ? 'Text replies are live.'
           : systemStatus.description,
       state:
         systemStatus.key === 'live'
@@ -228,7 +228,7 @@ export default async function AppHomePage({
     <HomeDashboard
       attentionLeads={attentionLeads}
       feedback={feedback}
-      finishActivationHref="/app/settings#twilio-setup-flow"
+      setupHref="/app/settings"
       hasRealLeadData={allLeads.length > 0}
       isDemoMode={demoMode}
       metrics={metrics}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,9 +1,8 @@
 import { LeadReadiness, LeadStatus } from '@prisma/client';
 
-import { HomeDashboard, type DashboardLeadCard } from '@/components/home-dashboard';
+import { HomeDashboard, type DashboardLeadCard, type DashboardStatusItem, type DashboardSummaryCard } from '@/components/home-dashboard';
 import { requireBusiness } from '@/lib/auth';
 import { listAllDashboardLeadsForBusiness } from '@/lib/business-access';
-import { buildRecoveryMetrics } from '@/lib/dashboard-home';
 import { db } from '@/lib/db';
 import { formatRelativeTime, getLeadLastActivityAt, isLeadOpenStatus } from '@/lib/lead-presenters';
 import { formatPhoneForDisplay } from '@/lib/phone';
@@ -12,10 +11,6 @@ import { getCustomerSystemStatus } from '@/lib/system-status';
 
 function buildLeadDetailHref(leadId: string) {
   return `/app/leads/${leadId}?from=%2Fapp`;
-}
-
-function buildConversationHref(leadId: string) {
-  return `/app/conversations?leadId=${leadId}`;
 }
 
 function getAttentionPriority(lead: {
@@ -61,9 +56,9 @@ function getRecommendedNextAction(lead: {
   readiness: LeadReadiness;
   lastInboundAt: Date | null;
 }) {
-  if (lead.status === LeadStatus.BOOKED) return 'Booked. Keep this lead as proof of recovered revenue.';
+  if (lead.status === LeadStatus.BOOKED) return 'Booked.';
   if (lead.status === LeadStatus.LOST) return 'No further action needed unless the customer comes back.';
-  if (lead.status === LeadStatus.CONTACTED) return 'Follow up again and confirm whether the job is booked.';
+  if (lead.status === LeadStatus.CONTACTED) return 'Follow up and mark booked or lost.';
   if (lead.readiness === LeadReadiness.URGENT) return 'Call now.';
   if (lead.status === LeadStatus.NOTIFIED || lead.status === LeadStatus.QUALIFIED) return 'Call now.';
   if (lead.lastInboundAt) return 'Reply by text, then call if the customer is ready.';
@@ -85,38 +80,29 @@ function toLeadCard(
     summary: string | null;
     status: LeadStatus;
     readiness: LeadReadiness;
-    qualifiedAt: Date | null;
-    notifiedAt: Date | null;
-    ownerNotifiedAt: Date | null;
     createdAt: Date;
     lastInteractionAt: Date | null;
     lastInboundAt: Date | null;
+    lastOutboundAt: Date | null;
   },
-  demoMode: boolean,
 ): DashboardLeadCard {
+  const phone = lead.callerPhoneNormalized || lead.callerPhone;
+
   return {
     id: lead.id,
     customerName: getCustomerName(lead),
+    customerPhone: formatPhoneForDisplay(phone),
     serviceNeeded: lead.serviceType || lead.serviceRequested || 'Service needed not captured yet',
     urgencyLabel: lead.urgency || (lead.readiness === LeadReadiness.URGENT ? 'Urgent' : lead.readiness === LeadReadiness.QUALIFIED ? 'Qualified' : 'Needs reply'),
-    locationLabel: lead.location || lead.zipCode || 'Location pending',
-    timeSinceMissedCall: formatRelativeTime(lead.createdAt),
+    createdLabel: formatRelativeTime(lead.createdAt),
+    lastActivityLabel: formatRelativeTime(getLeadLastActivityAt(lead)),
     summary:
       lead.summary ||
-      'CallbackCloser is still collecting the AI summary for this lead. Open the conversation or call back to keep the lead moving.',
+      'CallbackCloser is still collecting the summary for this lead. Open the lead or call back to keep it moving.',
     recommendedNextAction: getRecommendedNextAction(lead),
     status: lead.status,
-    countsAsRecovered:
-      lead.status === LeadStatus.BOOKED ||
-      lead.status === LeadStatus.CONTACTED ||
-      lead.status === LeadStatus.NOTIFIED ||
-      lead.status === LeadStatus.QUALIFIED ||
-      lead.readiness !== LeadReadiness.PENDING ||
-      Boolean(lead.qualifiedAt || lead.notifiedAt || lead.ownerNotifiedAt),
-    callHref: `tel:${lead.callerPhoneNormalized || lead.callerPhone}`,
-    sendTextHref: buildConversationHref(lead.id),
+    callHref: `tel:${phone}`,
     leadHref: buildLeadDetailHref(lead.id),
-    sourceLabel: demoMode ? 'Demo lead' : null,
   };
 }
 
@@ -127,6 +113,38 @@ function getDateKey(value: Date, timeZone: string) {
     month: '2-digit',
     day: '2-digit',
   }).format(value);
+}
+
+function getStatusItems(input: {
+  ownerAlertsReady: boolean;
+  systemStatus: ReturnType<typeof getCustomerSystemStatus>;
+}): DashboardStatusItem[] {
+  return [
+    {
+      label: 'Texting',
+      value: input.systemStatus.key === 'live' ? 'Active' : input.systemStatus.key === 'activating' ? 'Pending' : 'Not live',
+      detail:
+        input.systemStatus.key === 'live'
+          ? 'Missed callers can receive automatic text replies.'
+          : input.systemStatus.description,
+      tone: input.systemStatus.key === 'live' ? 'success' : input.systemStatus.key === 'activating' ? 'secondary' : 'outline',
+    },
+    {
+      label: 'Owner alerts',
+      value: input.ownerAlertsReady ? 'Active' : 'Needs setup',
+      detail: input.ownerAlertsReady ? 'Lead summaries can reach the owner.' : 'Add an owner phone or email in settings.',
+      tone: input.ownerAlertsReady ? 'success' : 'outline',
+    },
+  ];
+}
+
+function isMissedCallToday(
+  lead: unknown,
+  input: { timeZone: string; todayKey: string },
+) {
+  if (!lead || typeof lead !== 'object' || !('call' in lead)) return false;
+  const call = (lead as { call?: { missed: boolean; createdAt: Date } | null }).call;
+  return Boolean(call?.missed && getDateKey(call.createdAt, input.timeZone) === input.todayKey);
 }
 
 export default async function AppHomePage({
@@ -146,7 +164,11 @@ export default async function AppHomePage({
 
   const successfulLeadCount = allLeads.filter((lead) => lead.ownerNotifiedAt || lead.notifiedAt).length;
   const systemStatus = getCustomerSystemStatus(business, successfulLeadCount);
-  const metrics = buildRecoveryMetrics(allLeads, business.averageJobValueCents);
+  const todayKey = getDateKey(new Date(), business.timezone);
+  const missedCallsToday = allLeads.filter((lead) => isMissedCallToday(lead, { timeZone: business.timezone, todayKey })).length;
+  const needsFollowUpCount = allLeads.filter((lead) => isLeadOpenStatus(lead.status)).length;
+  const newLeadCount = allLeads.filter((lead) => lead.status === LeadStatus.NEW).length;
+  const bookedLeadCount = allLeads.filter((lead) => lead.status === LeadStatus.BOOKED).length;
 
   const attentionLeads = allLeads
     .filter((lead) => isLeadOpenStatus(lead.status))
@@ -164,21 +186,14 @@ export default async function AppHomePage({
 
       return rightPriority.activityAt - leftPriority.activityAt;
     })
-    .slice(0, 4)
-    .map((lead) => toLeadCard(lead, demoMode));
+    .slice(0, 6)
+    .map((lead) => toLeadCard(lead));
 
-  const queueAnchor =
-    demoMode && allLeads.length > 0
-      ? new Date(Math.max(...allLeads.map((lead) => lead.createdAt.getTime())))
-      : new Date();
-  const queueDateKey = getDateKey(queueAnchor, business.timezone);
-  const queueLeads = [...allLeads]
-    .filter((lead) => getDateKey(lead.createdAt, business.timezone) === queueDateKey)
+  const recentLeads = [...allLeads]
     .sort((left, right) => getLeadLastActivityAt(right).getTime() - getLeadLastActivityAt(left).getTime())
     .slice(0, 6)
-    .map((lead) => toLeadCard(lead, demoMode));
+    .map((lead) => toLeadCard(lead));
 
-  const phoneLineConnected = Boolean(business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber);
   const ownerAlertsReady = Boolean(
     business.notifyPhone ||
       notificationSettings?.ownerPhone ||
@@ -186,36 +201,30 @@ export default async function AppHomePage({
       (notificationSettings?.notifyEmail && notificationSettings.ownerEmail),
   );
 
-  const setupChecklistItems = [
+  const summaryCards: DashboardSummaryCard[] = [
     {
-      key: 'phone-line',
-      label: 'Phone line connected',
-      detail: phoneLineConnected
-        ? 'Business line ready.'
-        : 'Connect the line that should trigger missed-call recovery.',
-      state: phoneLineConnected ? ('complete' as const) : ('pending' as const),
+      label: 'New leads',
+      value: newLeadCount,
+      detail: 'Missed callers not worked yet.',
+      href: '/app/leads?status=new',
     },
     {
-      key: 'owner-alerts',
-      label: 'Owner alerts ready',
-      detail: ownerAlertsReady
-        ? 'Owner handoff route ready.'
-        : 'Add an owner phone or email for lead handoffs.',
-      state: ownerAlertsReady ? ('complete' as const) : ('pending' as const),
+      label: 'Needs follow-up',
+      value: needsFollowUpCount,
+      detail: 'Open leads that still need action.',
+      href: '/app/leads?view=attention',
     },
     {
-      key: 'text-replies',
-      label: 'Text replies being prepared',
-      detail:
-        systemStatus.key === 'live'
-          ? 'Text replies are live.'
-          : systemStatus.description,
-      state:
-        systemStatus.key === 'live'
-          ? ('complete' as const)
-          : systemStatus.key === 'activating'
-            ? ('in_progress' as const)
-            : ('pending' as const),
+      label: 'Booked leads',
+      value: bookedLeadCount,
+      detail: 'Leads marked booked.',
+      href: '/app/leads?view=booked',
+    },
+    {
+      label: 'Missed calls today',
+      value: missedCallsToday,
+      detail: 'Missed calls captured today.',
+      href: '/app/leads',
     },
   ];
 
@@ -228,14 +237,11 @@ export default async function AppHomePage({
     <HomeDashboard
       attentionLeads={attentionLeads}
       feedback={feedback}
-      setupHref="/app/settings"
-      hasRealLeadData={allLeads.length > 0}
       isDemoMode={demoMode}
-      metrics={metrics}
-      queueLeads={queueLeads}
-      setupChecklistItems={setupChecklistItems}
-      showSetupChecklist={systemStatus.key !== 'live'}
+      recentLeads={recentLeads}
       simulatorHref="/simulator"
+      statusItems={getStatusItems({ ownerAlertsReady, systemStatus })}
+      summaryCards={summaryCards}
     />
   );
 }

--- a/app/app/settings/page.tsx
+++ b/app/app/settings/page.tsx
@@ -1,143 +1,63 @@
 import Link from 'next/link';
 
-import { MessagingComplianceFields } from '@/components/messaging-compliance-fields';
-import { setBusinessProvisioningStatusAction } from '@/app/admin/actions';
-import { TwilioSetupChecklist } from '@/components/twilio-setup-checklist';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { getAdminSession } from '@/lib/admin';
-import { getAdminTestSmsConfidenceState } from '@/lib/admin-dashboard';
-import { getTwilioWebhookSnapshot } from '@/lib/admin-provisioning';
 import { requireBusiness } from '@/lib/auth';
+import { averageJobValueCentsToDollars } from '@/lib/business-settings';
 import { getBusinessNotificationSettingsForBusiness } from '@/lib/business-access';
-import {
-  TwilioSetupTone,
-  buildTwilioSetupFlow,
-  businessPhonePathOptions,
-  forwardedCallAnswerOptions,
-  messagingSetupOptions,
-  twilioAccountModeOptions,
-} from '@/lib/twilio-setup';
+import { getBusinessRoutingNumber, getPublicBusinessPhone } from '@/lib/business-phone-setup';
 import { db } from '@/lib/db';
-import {
-  getManagedTextingNumber,
-  managedTwilioStatusLabels,
-  messagingComplianceTypeLabels,
-  tollFreeVerificationStatusLabels,
-} from '@/lib/managed-twilio-status';
 import { formatPhoneForDisplay } from '@/lib/phone';
 import { isPortfolioDemoMode } from '@/lib/portfolio-demo';
-import { averageJobValueCentsToDollars } from '@/lib/business-settings';
+import { getCustomerSystemStatus } from '@/lib/system-status';
 
-import {
-  buyTwilioNumberAction,
-  resyncTwilioWebhooksAction,
-  saveBusinessSettingsAction,
-  saveBusinessTwilioAdminOverridesAction,
-  saveBusinessTwilioSetupChoiceAction,
-  sendBusinessTwilioTestSmsAction,
-} from './actions';
+import { saveBusinessSettingsAction } from './actions';
 
-const adminChangedFieldLabels: Record<string, string> = {
-  ownerPhone: 'owner alert phone',
-  twilioAccountMode: 'Twilio account mode',
-  phoneSetupPath: 'business number path',
-  forwardedCallAnswerMode: 'forwarded call answer mode',
-  messagingSetupMode: 'messaging setup mode',
-  twilioNumberSetupMode: 'routing number mode',
-  twilioSubaccountSid: 'Twilio subaccount SID',
-  twilioPhoneNumber: 'Twilio number',
-  twilioPhoneNumberSid: 'Twilio number SID',
-  twilioMessagingServiceSid: 'messaging service SID',
-  forwardingVerificationStatus: 'forwarding verification status',
-  forwardingVerificationNote: 'forwarding verification note',
-  portingStatus: 'porting status',
-  portingNotes: 'porting notes',
-  messagingComplianceType: 'number type',
-  a2pCustomerProfileSid: 'A2P customer profile SID',
-  a2pBrandSid: 'A2P brand SID',
-  a2pCampaignSid: 'A2P campaign SID',
-  a2pFailureReason: 'A2P blocker note',
-  tollFreeVerificationStatus: 'toll-free verification status',
-  tollFreeVerificationSid: 'toll-free verification SID',
-  tollFreeVerificationNote: 'toll-free blocker note',
-  managedTwilioStatus: 'A2P status',
-};
+type StatusTone = 'success' | 'secondary' | 'outline';
 
-type BusinessTwilioDefaults = {
-  twilioAccountMode: string;
-  phoneSetupPath: string;
-  forwardedCallAnswerMode: string;
-  messagingSetupMode: string;
-  twilioNumberSetupMode: string;
-  twilioSubaccountSid: string;
-  twilioPhoneNumber: string;
-  twilioPhoneNumberSid: string;
-  twilioMessagingServiceSid: string;
-  forwardingVerificationStatus: string;
-  forwardingVerificationNote: string;
-  portingStatus: string;
-  portingNotes: string;
-  messagingComplianceType: string;
-  a2pCustomerProfileSid: string;
-  a2pBrandSid: string;
-  a2pCampaignSid: string;
-  a2pFailureReason: string;
-  tollFreeVerificationStatus: string;
-  tollFreeVerificationSid: string;
-  tollFreeVerificationNote: string;
-  managedTwilioStatus: string;
-  ownerPhone: string;
-};
-
-function HiddenBusinessTwilioFields({
-  defaults,
-  exclude = [],
-}: {
-  defaults: BusinessTwilioDefaults;
-  exclude?: Array<keyof BusinessTwilioDefaults>;
-}) {
-  return (
-    <>
-      {Object.entries(defaults).map(([name, value]) => {
-        if (exclude.includes(name as keyof BusinessTwilioDefaults)) return null;
-        return <input key={name} name={name} type="hidden" value={value} />;
-      })}
-    </>
-  );
+function getStatusBadge(complete: boolean, pendingLabel = 'Needs attention') {
+  return {
+    label: complete ? 'Ready' : pendingLabel,
+    variant: complete ? ('success' as const) : ('outline' as const),
+  };
 }
 
-function getBadgeVariant(tone: TwilioSetupTone) {
-  if (tone === 'success') return 'success' as const;
-  if (tone === 'attention') return 'destructive' as const;
-  if (tone === 'pending') return 'outline' as const;
-  return 'secondary' as const;
+function getTextingStatus(systemStatus: ReturnType<typeof getCustomerSystemStatus>) {
+  if (systemStatus.key === 'live') {
+    return {
+      label: 'Text replies active',
+      detail: 'Missed callers can receive the follow-up text automatically.',
+      variant: 'success' as StatusTone,
+    };
+  }
+
+  if (systemStatus.key === 'activating') {
+    return {
+      label: 'Text replies being finished',
+      detail: 'CallbackCloser is still finishing the behind-the-scenes setup before automatic texting is fully live.',
+      variant: 'secondary' as StatusTone,
+    };
+  }
+
+  return {
+    label: 'Text replies not live yet',
+    detail: 'CallbackCloser will notify you when missed-call texting is ready to test.',
+    variant: 'outline' as StatusTone,
+  };
 }
 
 export default async function SettingsPage({ searchParams }: { searchParams?: Record<string, string | string[] | undefined> }) {
   const business = await requireBusiness();
-  const averageJobValue = averageJobValueCentsToDollars(business.averageJobValueCents);
   const demoMode = isPortfolioDemoMode();
-  const adminSession = demoMode ? null : await getAdminSession();
+  const averageJobValue = averageJobValueCentsToDollars(business.averageJobValueCents);
   const error = typeof searchParams?.error === 'string' ? searchParams.error : undefined;
   const saved = searchParams?.saved === '1';
-  const numberBought = searchParams?.numberBought === '1';
-  const twilioSynced = searchParams?.twilioSynced === '1';
-  const adminTwilioSaved = searchParams?.adminTwilioSaved === '1';
-  const twilioTestSms = searchParams?.twilioTestSms === '1';
-  const existingNumberIntent = searchParams?.existingNumberIntent === '1';
-  const adminChangedRaw = typeof searchParams?.adminChanged === 'string' ? searchParams.adminChanged : '';
-  const adminChanged = adminChangedRaw
-    .split(',')
-    .map((field) => field.trim())
-    .filter(Boolean)
-    .map((field) => adminChangedFieldLabels[field] || field);
 
-  const [notificationSettings, successfulLeadCount, testSmsEvents, webhookSnapshot] = demoMode
-    ? [null, 1, [], null]
+  const [notificationSettings, successfulLeadCount] = demoMode
+    ? [null, 1]
     : await Promise.all([
         getBusinessNotificationSettingsForBusiness(business.id),
         db.lead.count({
@@ -146,519 +66,66 @@ export default async function SettingsPage({ searchParams }: { searchParams?: Re
             OR: [{ ownerNotifiedAt: { not: null } }, { notifiedAt: { not: null } }],
           },
         }),
-        db.businessOperatorEvent.findMany({
-          where: {
-            businessId: business.id,
-            type: {
-              startsWith: 'admin.test_sms_',
-            },
-          },
-          orderBy: { createdAt: 'desc' },
-          take: 20,
-          select: {
-            type: true,
-            status: true,
-            createdAt: true,
-          },
-        }),
-        getTwilioWebhookSnapshot(business),
       ]);
 
-  const testSmsState = getAdminTestSmsConfidenceState(testSmsEvents);
-  const managedTextingNumber = getManagedTextingNumber(business);
-  const setupFlow = buildTwilioSetupFlow({
-    business,
-    notificationSettings,
-    ownerConnected: true,
-    successfulLeadCount,
-    testSmsState,
-    webhookSnapshot,
-  });
-  const twilioDefaults: BusinessTwilioDefaults = {
-    twilioAccountMode: business.twilioAccountMode,
-    phoneSetupPath: business.phoneSetupPath,
-    forwardedCallAnswerMode: business.forwardedCallAnswerMode,
-    messagingSetupMode: business.messagingSetupMode,
-    twilioNumberSetupMode: business.twilioNumberSetupMode,
-    twilioSubaccountSid: business.twilioSubaccountSid || '',
-    twilioPhoneNumber: business.twilioPrimaryPhoneNumber || business.twilioPhoneNumber || '',
-    twilioPhoneNumberSid: business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid || '',
-    twilioMessagingServiceSid: business.twilioMessagingServiceSid || '',
-    forwardingVerificationStatus: business.forwardingVerificationStatus,
-    forwardingVerificationNote: business.forwardingVerificationNote || '',
-    portingStatus: business.portingStatus,
-    portingNotes: business.portingNotes || '',
-    messagingComplianceType: business.messagingComplianceType,
-    a2pCustomerProfileSid: business.a2pCustomerProfileSid || '',
-    a2pBrandSid: business.a2pBrandSid || '',
-    a2pCampaignSid: business.a2pCampaignSid || '',
-    a2pFailureReason: business.a2pFailureReason || '',
-    tollFreeVerificationStatus: business.tollFreeVerificationStatus,
-    tollFreeVerificationSid: business.tollFreeVerificationSid || '',
-    tollFreeVerificationNote: business.tollFreeVerificationNote || '',
-    managedTwilioStatus: business.managedTwilioStatus,
-    ownerPhone: notificationSettings?.ownerPhone || business.notifyPhone || '',
-  };
+  const publicBusinessPhone = getPublicBusinessPhone(business);
+  const connectedNumber = getBusinessRoutingNumber(business);
+  const ownerAlertPhone = notificationSettings?.ownerPhone || business.notifyPhone || null;
+  const ownerAlertEmail = notificationSettings?.ownerEmail || null;
+  const systemStatus = getCustomerSystemStatus(business, successfulLeadCount);
+  const textingStatus = getTextingStatus(systemStatus);
+  const businessNumberStatus = getStatusBadge(Boolean(publicBusinessPhone || connectedNumber), 'Not connected yet');
+  const ownerAlertStatus = getStatusBadge(Boolean(ownerAlertPhone || ownerAlertEmail), 'Add destination');
 
-  const bannerAction =
-    setupFlow.banner.stepKey === 'voice_webhook_synced' ||
-    setupFlow.banner.stepKey === 'sms_webhook_synced' ||
-    setupFlow.banner.stepKey === 'status_callback_synced' ? (
-      <form action={resyncTwilioWebhooksAction}>
-        <Button size="sm" type="submit">
-          Sync webhooks
-        </Button>
-      </form>
-    ) : setupFlow.banner.stepKey === 'safe_to_mark_live' && adminSession?.isAdmin && setupFlow.safeToMarkLive && business.provisioningStatus !== 'LIVE' ? (
-      <form action={setBusinessProvisioningStatusAction}>
-        <input type="hidden" name="businessId" value={business.id} />
-        <input type="hidden" name="status" value="LIVE" />
-        <Button size="sm" type="submit">
-          Mark live
-        </Button>
-      </form>
-    ) : (
-      <Link
-        className={buttonVariants({ size: 'sm', variant: 'outline' })}
-        href={
-          setupFlow.banner.stepKey === 'account_mode'
-            ? '#account-mode-step'
-            : setupFlow.banner.stepKey === 'number_path'
-              ? '#number-path-step'
-              : setupFlow.banner.stepKey === 'test_sms_delivered'
-                ? '#test-sms-step'
-                : setupFlow.banner.stepKey === 'missed_call_validated'
-                  ? '/app/call-flow'
-                  : '#twilio-setup-flow'
-        }
-      >
-        {setupFlow.banner.stepKey === 'missed_call_validated' ? 'Open call flow' : 'Review step'}
-      </Link>
-    );
-
-  const setupSteps = setupFlow.steps.map((step) => {
-    if (step.key === 'owner_connected') {
-      return {
-        ...step,
-        body: (
-          <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-            <Badge variant="success">Connected</Badge>
-            <span>Your signed-in business account is already attached to this workspace.</span>
-          </div>
-        ),
-      };
-    }
-
-    if (step.key === 'account_mode') {
-      return {
-        ...step,
-        body: (
-          <form action={saveBusinessTwilioSetupChoiceAction} className="space-y-4" id="account-mode-step">
-            <input type="hidden" name="phoneSetupPath" value={setupFlow.phoneSetupPath} />
-            <input type="hidden" name="forwardedCallAnswerMode" value={setupFlow.forwardedCallAnswerMode} />
-            <input type="hidden" name="messagingSetupMode" value={setupFlow.messagingSetupMode} />
-            <div className="grid gap-3 md:grid-cols-2">
-              {twilioAccountModeOptions.map((option) => (
-                <label key={option.value} className="rounded-xl border bg-background/80 p-4 text-sm">
-                  <div className="flex items-start gap-3">
-                    <input defaultChecked={setupFlow.accountMode === option.value} name="twilioAccountMode" type="radio" value={option.value} />
-                    <div className="space-y-1">
-                      <p className="font-medium">{option.label}</p>
-                      <p className="text-muted-foreground">{option.description}</p>
-                    </div>
-                  </div>
-                </label>
-              ))}
-            </div>
-            <Button size="sm" type="submit">
-              Save account mode
-            </Button>
-          </form>
-        ),
-      };
-    }
-
-    if (step.key === 'number_path') {
-      return {
-        ...step,
-        body: (
-          <form action={saveBusinessTwilioSetupChoiceAction} className="space-y-4" id="number-path-step">
-            <input type="hidden" name="twilioAccountMode" value={setupFlow.accountMode} />
-            <div className="grid gap-3">
-              {businessPhonePathOptions.map((option) => (
-                <label key={option.value} className="rounded-xl border bg-background/80 p-4 text-sm">
-                  <div className="flex items-start gap-3">
-                    <input defaultChecked={setupFlow.phoneSetupPath === option.value} name="phoneSetupPath" type="radio" value={option.value} />
-                    <div className="space-y-1">
-                      <p className="font-medium">{option.label}</p>
-                      <p className="text-muted-foreground">{option.description}</p>
-                    </div>
-                  </div>
-                </label>
-              ))}
-            </div>
-            <div className="grid gap-3">
-              <p className="text-sm font-medium">Forwarded call answer confirmation</p>
-              {forwardedCallAnswerOptions.map((option) => (
-                <label key={option.value} className="rounded-xl border bg-background/80 p-4 text-sm">
-                  <div className="flex items-start gap-3">
-                    <input
-                      defaultChecked={setupFlow.forwardedCallAnswerMode === option.value}
-                      name="forwardedCallAnswerMode"
-                      type="radio"
-                      value={option.value}
-                    />
-                    <div className="space-y-1">
-                      <p className="font-medium">{option.label}</p>
-                      <p className="text-muted-foreground">{option.description}</p>
-                    </div>
-                  </div>
-                </label>
-              ))}
-            </div>
-            <div className="grid gap-3">
-              <p className="text-sm font-medium">Messaging setup mode</p>
-              {messagingSetupOptions.map((option) => (
-                <label key={option.value} className="rounded-xl border bg-background/80 p-4 text-sm">
-                  <div className="flex items-start gap-3">
-                    <input
-                      defaultChecked={setupFlow.messagingSetupMode === option.value}
-                      name="messagingSetupMode"
-                      type="radio"
-                      value={option.value}
-                    />
-                    <div className="space-y-1">
-                      <p className="font-medium">{option.label}</p>
-                      <p className="text-muted-foreground">{option.description}</p>
-                    </div>
-                  </div>
-                </label>
-              ))}
-            </div>
-            {setupFlow.phoneSetupPath === 'PORT_EXISTING_NUMBER' ? (
-              <p className="text-sm text-muted-foreground">{setupFlow.existingNumberMessage}</p>
-            ) : null}
-            <Button size="sm" type="submit" variant="outline">
-              Save call and messaging path
-            </Button>
-          </form>
-        ),
-      };
-    }
-
-    if (step.key === 'account_ready') {
-      return {
-        ...step,
-        body: adminSession?.isAdmin ? (
-          <form action={saveBusinessTwilioAdminOverridesAction} className="space-y-4">
-            <HiddenBusinessTwilioFields defaults={twilioDefaults} exclude={['twilioSubaccountSid']} />
-            {setupFlow.messagingSetupMode === 'SHARED_PILOT_MESSAGING_SERVICE' ? (
-              <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground">
-                Pilot setup uses the approved CallbackCloser sender, so a dedicated subaccount is optional during founder-operated onboarding.
-              </div>
-            ) : setupFlow.accountMode === 'BUSINESS_SUBACCOUNT' ? (
-              <div className="space-y-2">
-                <Label htmlFor="businessTwilioSubaccountSid">Business subaccount SID</Label>
-                <Input
-                  id="businessTwilioSubaccountSid"
-                  name="twilioSubaccountSid"
-                  defaultValue={business.twilioSubaccountSid || ''}
-                  placeholder="AC..."
-                />
-                <p className="text-xs text-muted-foreground">Paste a known subaccount SID to reuse it, or leave this blank and let provisioning create one.</p>
-              </div>
-            ) : (
-              <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground">
-                Main account mode is active. CallbackCloser will use the parent Twilio account directly for this business.
-              </div>
-            )}
-            <Button size="sm" type="submit" variant="outline">
-              Save account target
-            </Button>
-          </form>
-        ) : (
-          <p className="text-sm text-muted-foreground">
-            {setupFlow.messagingSetupMode === 'SHARED_PILOT_MESSAGING_SERVICE'
-              ? 'Pilot setup is founder-operated, so a dedicated business subaccount is optional while SMS uses the approved CallbackCloser sender.'
-              : setupFlow.accountMode === 'BUSINESS_SUBACCOUNT'
-              ? 'CallbackCloser will create or reuse a dedicated Twilio subaccount for this business during setup.'
-              : 'CallbackCloser will keep this business on the parent Twilio account.'}
-          </p>
-        ),
-      };
-    }
-
-    if (step.key === 'messaging_service_ready') {
-      return {
-        ...step,
-        body: adminSession?.isAdmin ? (
-          <form action={saveBusinessTwilioAdminOverridesAction} className="space-y-4">
-            <HiddenBusinessTwilioFields defaults={twilioDefaults} exclude={['twilioMessagingServiceSid']} />
-            {setupFlow.messagingSetupMode === 'SHARED_PILOT_MESSAGING_SERVICE' ? (
-              <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground">
-                Pilot setup: current number forwards to CallbackCloser; SMS sends from the approved CallbackCloser messaging number.
-              </div>
-            ) : null}
-            <div className="space-y-2">
-              <Label htmlFor="businessMessagingServiceSid">Messaging Service SID</Label>
-              <Input
-                id="businessMessagingServiceSid"
-                name="twilioMessagingServiceSid"
-                defaultValue={business.twilioMessagingServiceSid || ''}
-                placeholder="MG..."
-              />
-            </div>
-            <Button size="sm" type="submit" variant="outline">
-              Save Messaging Service
-            </Button>
-          </form>
-        ) : (
-          <p className="text-sm text-muted-foreground">
-            {setupFlow.messagingSetupMode === 'SHARED_PILOT_MESSAGING_SERVICE'
-              ? `Pilot sender: ${business.twilioMessagingServiceSid || 'Approved CallbackCloser Messaging Service not recorded yet.'}`
-              : `Current value: ${business.twilioMessagingServiceSid || 'Not recorded yet.'}`}
-          </p>
-        ),
-      };
-    }
-
-    if (step.key === 'number_assigned') {
-      return {
-        ...step,
-        body: (
-          <div className="space-y-4">
-            <div className="grid gap-3 md:grid-cols-2">
-              <div className="rounded-xl border bg-background/80 p-4 text-sm">
-                <p className="font-medium">Current number</p>
-                <p className="mt-2 text-muted-foreground">
-                  {managedTextingNumber ? formatPhoneForDisplay(managedTextingNumber) : 'No business number recorded yet'}
-                </p>
-              </div>
-              <div className="rounded-xl border bg-background/80 p-4 text-sm">
-                <p className="font-medium">Number path</p>
-                <p className="mt-2 text-muted-foreground">{setupFlow.phoneSetupPathLabel}</p>
-              </div>
-            </div>
-
-            {setupFlow.phoneSetupPath !== 'PORT_EXISTING_NUMBER' ? (
-              <form action={buyTwilioNumberAction} className="flex flex-col gap-3 md:flex-row md:items-end">
-                <div className="w-full md:max-w-xs">
-                  <Label htmlFor="setupAreaCode">Preferred area code</Label>
-                  <Input id="setupAreaCode" name="areaCode" inputMode="numeric" maxLength={3} placeholder="512" />
-                </div>
-                <Button size="sm" type="submit" disabled={Boolean(managedTextingNumber)}>
-                  {managedTextingNumber ? 'Routing number already assigned' : 'Provision routing number'}
-                </Button>
-              </form>
-            ) : (
-              <div className="space-y-3">
-                <p className="text-sm text-muted-foreground">{setupFlow.existingNumberMessage}</p>
-                <p className="text-sm text-muted-foreground">
-                  CallbackCloser does not automate porting in this step. Once the number is live in Twilio, an operator can save the routing number mapping.
-                </p>
-              </div>
-            )}
-
-            {adminSession?.isAdmin ? (
-              <form action={saveBusinessTwilioAdminOverridesAction} className="grid gap-4 md:grid-cols-2">
-                <HiddenBusinessTwilioFields defaults={twilioDefaults} exclude={['twilioPhoneNumber', 'twilioPhoneNumberSid']} />
-                <div className="space-y-2">
-                  <Label htmlFor="businessTwilioPhoneNumber">Twilio number</Label>
-                  <Input id="businessTwilioPhoneNumber" name="twilioPhoneNumber" defaultValue={managedTextingNumber || ''} placeholder="+15551234567" />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="businessTwilioPhoneNumberSid">Twilio number SID</Label>
-                  <Input
-                    id="businessTwilioPhoneNumberSid"
-                    name="twilioPhoneNumberSid"
-                    defaultValue={business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid || ''}
-                    placeholder="PN..."
-                  />
-                </div>
-                <div className="md:col-span-2">
-                  <Button size="sm" type="submit" variant="outline">
-                    Save number mapping
-                  </Button>
-                </div>
-              </form>
-            ) : null}
-          </div>
-        ),
-      };
-    }
-
-    if (step.key === 'forwarding_verified') {
-      return {
-        ...step,
-        body: (
-          <div className="space-y-3 text-sm text-muted-foreground">
-            {setupFlow.phoneSetupPath === 'CURRENT_NUMBER_FORWARDING' ? (
-              <>
-                <p>
-                  Forward your current public business number into the CallbackCloser routing number shown above. CallbackCloser marks this step complete after a fresh inbound test call reaches the routing number or an operator confirms it manually.
-                </p>
-                <p>
-                  Public business number: {business.publicBusinessPhone ? formatPhoneForDisplay(business.publicBusinessPhone) : 'Not saved yet'}
-                </p>
-              </>
-            ) : setupFlow.phoneSetupPath === 'PORT_EXISTING_NUMBER' ? (
-              <p>Porting stays admin-assisted for now. Keep the porting status updated, then save the Twilio routing number after the port completes.</p>
-            ) : (
-              <p>The new CallbackCloser number becomes your connected business line once it is assigned and working.</p>
-            )}
-          </div>
-        ),
-      };
-    }
-
-    if (step.key === 'voice_webhook_synced') {
-      return {
-        ...step,
-        body: (
-          <form action={resyncTwilioWebhooksAction} className="flex flex-wrap gap-3">
-            <Button size="sm" type="submit" disabled={!(business.twilioPrimaryNumberSid || business.twilioPhoneNumberSid)}>
-              Sync all webhooks
-            </Button>
-            <span className="text-sm text-muted-foreground">Voice, SMS, and status callback sync all happen together from this page.</span>
-          </form>
-        ),
-      };
-    }
-
-    if (step.key === 'a2p_status_recorded') {
-      return {
-        ...step,
-        body: adminSession?.isAdmin ? (
-          <form action={saveBusinessTwilioAdminOverridesAction}>
-            <HiddenBusinessTwilioFields
-              defaults={twilioDefaults}
-              exclude={[
-                'messagingComplianceType',
-                'managedTwilioStatus',
-                'a2pCustomerProfileSid',
-                'a2pBrandSid',
-                'a2pCampaignSid',
-                'a2pFailureReason',
-                'tollFreeVerificationStatus',
-                'tollFreeVerificationSid',
-                'tollFreeVerificationNote',
-              ]}
-            />
-            <MessagingComplianceFields
-              idPrefix="business"
-              initialMessagingComplianceType={business.messagingComplianceType}
-              initialManagedTwilioStatus={business.managedTwilioStatus}
-              initialA2pCustomerProfileSid={business.a2pCustomerProfileSid || ''}
-              initialA2pBrandSid={business.a2pBrandSid || ''}
-              initialA2pCampaignSid={business.a2pCampaignSid || ''}
-              initialA2pFailureReason={business.a2pFailureReason || ''}
-              initialTollFreeVerificationStatus={business.tollFreeVerificationStatus}
-              initialTollFreeVerificationSid={business.tollFreeVerificationSid || ''}
-              initialTollFreeVerificationNote={business.tollFreeVerificationNote || ''}
-              complianceTypeOptions={Object.entries(messagingComplianceTypeLabels).map(([value, label]) => ({ value, label }))}
-              managedTwilioStatusOptions={Object.entries(managedTwilioStatusLabels).map(([value, label]) => ({ value, label }))}
-              tollFreeVerificationStatusOptions={Object.entries(tollFreeVerificationStatusLabels).map(([value, label]) => ({
-                value,
-                label,
-              }))}
-              showSubmitButton
-              submitButtonVariant="outline"
-            />
-          </form>
-        ) : (
-          <div className="flex flex-wrap gap-2 text-sm">
-            <Badge variant={getBadgeVariant(step.tone)}>{step.stateLabel}</Badge>
-            <span className="text-muted-foreground">CallbackCloser keeps this launch status truthful even while review is pending.</span>
-          </div>
-        ),
-      };
-    }
-
-    if (step.key === 'test_sms_delivered') {
-      return {
-        ...step,
-        body: (
-          <form action={sendBusinessTwilioTestSmsAction} className="space-y-3" id="test-sms-step">
-            <div className="space-y-2">
-              <Label htmlFor="businessTwilioTestSmsPhone">Test SMS destination</Label>
-              <Input
-                id="businessTwilioTestSmsPhone"
-                name="destinationPhone"
-                defaultValue={notificationSettings?.ownerPhone || business.notifyPhone || ''}
-                placeholder="+15551234567"
-              />
-              <p className="text-xs text-muted-foreground">Send a real test text from the current business line before you treat this setup as launch-ready.</p>
-            </div>
-            <Button size="sm" type="submit">
-              Send test SMS
-            </Button>
-          </form>
-        ),
-      };
-    }
-
-    if (step.key === 'missed_call_validated') {
-      return {
-        ...step,
-        body: (
-          <div className="flex flex-wrap gap-3">
-            <Link className={buttonVariants({ size: 'sm' })} href="/app/call-flow">
-              Open call flow
-            </Link>
-            <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href="/app/leads">
-              Open recovered leads
-            </Link>
-          </div>
-        ),
-      };
-    }
-
-    if (step.key === 'safe_to_mark_live') {
-      return {
-        ...step,
-        body: adminSession?.isAdmin ? (
-          <div className="flex flex-wrap gap-3">
-            <form action={setBusinessProvisioningStatusAction}>
-              <input type="hidden" name="businessId" value={business.id} />
-              <input type="hidden" name="status" value="LIVE" />
-              <Button size="sm" type="submit" disabled={!setupFlow.safeToMarkLive || business.provisioningStatus === 'LIVE'}>
-                {business.provisioningStatus === 'LIVE' ? 'Already live' : 'Mark live'}
-              </Button>
-            </form>
-            <form action={setBusinessProvisioningStatusAction}>
-              <input type="hidden" name="businessId" value={business.id} />
-              <input type="hidden" name="status" value="PAUSED" />
-              <Button size="sm" type="submit" variant="outline">
-                Pause automation
-              </Button>
-            </form>
-          </div>
-        ) : (
-          <p className="text-sm text-muted-foreground">Launch state is managed after the setup checklist, test SMS, and missed-call validation all clear.</p>
-        ),
-      };
-    }
-
-    return step;
-  });
+  const statusCards = [
+    {
+      key: 'business-number',
+      title: 'Business number',
+      badge: businessNumberStatus,
+      detail: publicBusinessPhone
+        ? `Customers can keep calling ${formatPhoneForDisplay(publicBusinessPhone)}.`
+        : connectedNumber
+          ? `Use ${formatPhoneForDisplay(connectedNumber)} for missed-call coverage.`
+          : 'CallbackCloser is still finishing the number setup for this account.',
+    },
+    {
+      key: 'text-replies',
+      title: 'Text replies',
+      badge: {
+        label: textingStatus.variant === 'success' ? 'Ready' : textingStatus.variant === 'secondary' ? 'In progress' : 'Not live yet',
+        variant: textingStatus.variant,
+      },
+      detail: textingStatus.detail,
+    },
+    {
+      key: 'owner-alerts',
+      title: 'Owner alerts',
+      badge: ownerAlertStatus,
+      detail: ownerAlertPhone
+        ? `Lead summaries go to ${formatPhoneForDisplay(ownerAlertPhone)}.`
+        : ownerAlertEmail
+          ? `Lead summaries go to ${ownerAlertEmail}.`
+          : 'Add the phone or email that should receive lead summaries.',
+    },
+  ];
 
   return (
     <div className="mx-auto max-w-6xl space-y-6">
       <div className="space-y-2">
-        <Badge variant="outline">Twilio Setup</Badge>
+        <Badge variant="outline">Settings</Badge>
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <div className="space-y-2">
-            <h1 className="text-2xl font-semibold tracking-tight">Connect your business number</h1>
+            <h1 className="text-2xl font-semibold tracking-tight">Business settings</h1>
             <p className="max-w-3xl text-sm text-muted-foreground">
-              One guided place to choose the Twilio account mode, connect the right business-number path, and keep launch status honest without digging through admin screens.
+              Keep the business details and owner alert destinations current. CallbackCloser handles the phone and messaging setup in the background.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
             <Link className={buttonVariants({ variant: 'outline' })} href="/app/call-flow">
-              Open call flow
+              How missed calls work
             </Link>
             <Link className={buttonVariants({ variant: 'outline' })} href="/app/leads">
-              Open recovered leads
+              Open leads
             </Link>
           </div>
         </div>
@@ -666,34 +133,27 @@ export default async function SettingsPage({ searchParams }: { searchParams?: Re
 
       {error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{error}</div> : null}
       {saved ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Business settings saved.</div> : null}
-      {numberBought ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">A new business number was provisioned for the selected Twilio account mode.</div> : null}
-      {existingNumberIntent ? (
-        <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">
-          Porting path saved. CallbackCloser will keep this business on the admin-assisted porting workflow until the number is active and mapped into Twilio.
-        </div>
-      ) : null}
-      {twilioSynced ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Webhook sync completed for the current business number.</div> : null}
-      {twilioTestSms ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Test SMS requested. Wait for delivery before you treat the setup as launch-ready.</div> : null}
-      {adminTwilioSaved ? (
-        <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">
-          Internal setup state saved{adminChanged.length > 0 ? `: ${adminChanged.join(', ')}.` : '.'}
-        </div>
-      ) : null}
 
-      <div id="twilio-setup-flow">
-        <TwilioSetupChecklist
-          title="CallbackCloser Twilio launch flow"
-          description="The same step-by-step provisioning flow powers new-business setup and ongoing business control."
-          banner={setupFlow.banner}
-          bannerAction={bannerAction}
-          steps={setupSteps}
-        />
-      </div>
+      <section className="grid gap-4 md:grid-cols-3">
+        {statusCards.map((item) => (
+          <Card key={item.key} className="bg-card/90">
+            <CardHeader className="pb-3">
+              <div className="flex items-start justify-between gap-3">
+                <CardTitle className="text-base">{item.title}</CardTitle>
+                <Badge variant={item.badge.variant}>{item.badge.label}</Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">{item.detail}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
 
       <Card className="bg-card/90">
         <CardHeader>
-          <CardTitle>Business basics</CardTitle>
-          <CardDescription>Keep the public business number, live call path, and owner routing current while setup moves forward.</CardDescription>
+          <CardTitle>Business details</CardTitle>
+          <CardDescription>These details shape lead summaries, revenue estimates, and owner notifications.</CardDescription>
         </CardHeader>
         <CardContent>
           <form action={saveBusinessSettingsAction} className="grid gap-4 md:grid-cols-2">
@@ -709,23 +169,23 @@ export default async function SettingsPage({ searchParams }: { searchParams?: Re
               <Input id="settingsPublicBusinessPhone" name="publicBusinessPhone" defaultValue={business.publicBusinessPhone || ''} />
             </div>
             <div>
-              <Label htmlFor="settingsForwardingNumber">Owner forwarding / answer number</Label>
+              <Label htmlFor="settingsForwardingNumber">Number your team answers</Label>
               <Input id="settingsForwardingNumber" name="forwardingNumber" defaultValue={business.forwardingNumber} required />
             </div>
             <div>
               <Label htmlFor="settingsNotifyPhone">Owner alert phone</Label>
-              <Input id="settingsNotifyPhone" name="notifyPhone" defaultValue={notificationSettings?.ownerPhone || business.notifyPhone || ''} />
+              <Input id="settingsNotifyPhone" name="notifyPhone" defaultValue={ownerAlertPhone || ''} />
             </div>
             <div>
-              <Label htmlFor="settingsOwnerEmail">Owner email</Label>
-              <Input id="settingsOwnerEmail" name="ownerEmail" defaultValue={notificationSettings?.ownerEmail || ''} placeholder="owner@business.com" />
+              <Label htmlFor="settingsOwnerEmail">Owner alert email</Label>
+              <Input id="settingsOwnerEmail" name="ownerEmail" defaultValue={ownerAlertEmail || ''} placeholder="owner@business.com" />
             </div>
             <div>
               <Label htmlFor="settingsTimezone">Timezone</Label>
               <Input id="settingsTimezone" name="timezone" defaultValue={business.timezone} required />
             </div>
             <div>
-              <Label htmlFor="settingsMissedCallSeconds">Missed-call timeout (seconds)</Label>
+              <Label htmlFor="settingsMissedCallSeconds">Missed-call wait time (seconds)</Label>
               <Input id="settingsMissedCallSeconds" name="missedCallSeconds" type="number" min={5} max={90} defaultValue={business.missedCallSeconds} required />
             </div>
             <div>
@@ -757,7 +217,7 @@ export default async function SettingsPage({ searchParams }: { searchParams?: Re
             <label className="rounded-xl border bg-background/80 p-4 text-sm">
               <div className="flex items-start gap-3">
                 <input defaultChecked={notificationSettings?.notifySms ?? true} name="notifySms" type="checkbox" value="true" />
-                <span>Send owner SMS alerts</span>
+                <span>Send owner text alerts</span>
               </div>
             </label>
             <label className="rounded-xl border bg-background/80 p-4 text-sm">
@@ -769,17 +229,17 @@ export default async function SettingsPage({ searchParams }: { searchParams?: Re
             <label className="rounded-xl border bg-background/80 p-4 text-sm">
               <div className="flex items-start gap-3">
                 <input defaultChecked={notificationSettings?.notifyInApp ?? true} name="notifyInApp" type="checkbox" value="true" />
-                <span>Show in-app notifications</span>
+                <span>Show alerts in the dashboard</span>
               </div>
             </label>
             <label className="rounded-xl border bg-background/80 p-4 text-sm">
               <div className="flex items-start gap-3">
                 <input defaultChecked={notificationSettings?.urgentOnly ?? false} name="urgentOnly" type="checkbox" value="true" />
-                <span>Urgent leads only</span>
+                <span>Only alert me for urgent leads</span>
               </div>
             </label>
             <div className="md:col-span-2">
-              <Button type="submit">Save business basics</Button>
+              <Button type="submit">Save settings</Button>
             </div>
           </form>
         </CardContent>
@@ -787,23 +247,19 @@ export default async function SettingsPage({ searchParams }: { searchParams?: Re
 
       <Card className="bg-card/90">
         <CardHeader>
-          <CardTitle>Advanced</CardTitle>
-          <CardDescription>Rare setup notes and trust links that should stay visible without crowding the main flow.</CardDescription>
+          <CardTitle>Need setup help?</CardTitle>
+          <CardDescription>Phone changes and messaging approvals are handled by CallbackCloser support.</CardDescription>
         </CardHeader>
-        <CardContent className="grid gap-4 md:grid-cols-2">
-          <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground">
-            Existing-number support stays honest here. CallbackCloser does not automatically discover arbitrary Twilio subaccounts or numbers outside the selected account context.
-          </div>
-          <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground">
-            Public trust pages stay linked from setup: <Link className="underline underline-offset-4" href="/privacy">Privacy</Link>,{' '}
-            <Link className="underline underline-offset-4" href="/terms">Terms</Link>, and{' '}
-            <Link className="underline underline-offset-4" href="/sms-consent">SMS consent</Link>.
-          </div>
-          {adminSession?.isAdmin ? (
-            <div className="rounded-xl border bg-background/80 p-4 text-sm text-muted-foreground md:col-span-2">
-              Admin mode is active on this page, so the internal Twilio mapping fields above are editable without leaving the business workspace.
-            </div>
-          ) : null}
+        <CardContent className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+          <p className="w-full max-w-3xl">
+            If your business number, forwarding destination, or owner alert destination changes, update the fields above. CallbackCloser will handle any background setup needed to keep missed-call recovery working.
+          </p>
+          <Link className={buttonVariants({ variant: 'outline' })} href="/contact">
+            Contact support
+          </Link>
+          <Link className={buttonVariants({ variant: 'ghost' })} href="/sms-consent">
+            SMS consent
+          </Link>
         </CardContent>
       </Card>
     </div>

--- a/components/customer-lead-row.tsx
+++ b/components/customer-lead-row.tsx
@@ -72,6 +72,8 @@ export function CustomerLeadRow({
   const isOpen = isLeadOpenStatus(lead.status);
   const nextStep = getLeadNextStepLabel(lead.status);
   const activityAt = lead.lastInteractionAt || lead.createdAt;
+  const createdLabel = formatRelativeTime(lead.createdAt);
+  const activityLabel = formatRelativeTime(activityAt);
 
   return (
     <Link
@@ -94,7 +96,8 @@ export function CustomerLeadRow({
             <span>{getServiceLabel(lead)}</span>
             <span>{getUrgencyLabel(lead)}</span>
             <span>{getLocationLabel(lead)}</span>
-            <span>{formatRelativeTime(activityAt)}</span>
+            <span>Created {createdLabel}</span>
+            <span>Last activity {activityLabel}</span>
           </div>
         </div>
 
@@ -108,6 +111,9 @@ export function CustomerLeadRow({
         <div className="flex flex-wrap items-center gap-2 lg:justify-end">
           <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
           <Badge variant={getReadinessVariant(lead.readiness)}>{leadReadinessLabels[lead.readiness]}</Badge>
+          <span className="rounded-full border px-3 py-1 text-sm font-medium text-foreground transition-colors group-hover:bg-background">
+            Open lead
+          </span>
         </div>
       </div>
     </Link>

--- a/components/home-dashboard.tsx
+++ b/components/home-dashboard.tsx
@@ -257,7 +257,7 @@ export function HomeDashboard({
   hasRealLeadData,
   showSetupChecklist,
   setupChecklistItems,
-  finishActivationHref,
+  setupHref,
   simulatorHref,
 }: {
   attentionLeads: DashboardLeadCard[];
@@ -268,7 +268,7 @@ export function HomeDashboard({
   hasRealLeadData: boolean;
   showSetupChecklist: boolean;
   setupChecklistItems: SetupChecklistItem[];
-  finishActivationHref: string;
+  setupHref: string;
   simulatorHref: string;
 }) {
   const [showSampleLeads, setShowSampleLeads] = useState(!hasRealLeadData && isDemoMode);
@@ -415,8 +415,8 @@ export function HomeDashboard({
                     </div>
                   );
                 })}
-                <Link className={cn(buttonVariants({ size: 'sm' }), 'w-full')} href={finishActivationHref}>
-                  Finish activation
+                <Link className={cn(buttonVariants({ size: 'sm' }), 'w-full')} href={setupHref}>
+                  Review setup
                 </Link>
               </CardContent>
             </Card>

--- a/components/home-dashboard.tsx
+++ b/components/home-dashboard.tsx
@@ -1,334 +1,165 @@
-'use client';
-
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
 import { LeadStatus } from '@prisma/client';
 
 import { updateLeadStatusAction } from '@/app/app/leads/actions';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { DEFAULT_AVERAGE_JOB_VALUE } from '@/lib/business-settings';
-import { estimateRevenueSaved, formatCurrency, type RecoveryMetrics } from '@/lib/dashboard-home';
 import { getLeadStatusBadgeVariant, leadStatusLabels } from '@/lib/lead-presenters';
 import { cn } from '@/lib/utils';
-
-type SetupChecklistItem = {
-  key: string;
-  label: string;
-  detail: string;
-  state: 'complete' | 'in_progress' | 'pending';
-};
-
-export type DashboardLeadCard = {
-  id: string;
-  customerName: string;
-  serviceNeeded: string;
-  urgencyLabel: string;
-  locationLabel: string;
-  timeSinceMissedCall: string;
-  summary: string;
-  recommendedNextAction: string;
-  status: LeadStatus;
-  countsAsRecovered: boolean;
-  callHref: string | null;
-  sendTextHref: string | null;
-  leadHref: string | null;
-  sourceLabel: 'Sample lead' | 'Demo lead' | null;
-};
 
 type DashboardFeedback = {
   error?: string | null;
   saved?: boolean;
 };
 
-const sampleLeadSeed: DashboardLeadCard[] = [
-  {
-    id: 'sample-sarah',
-    customerName: 'Sarah M.',
-    serviceNeeded: 'Kitchen sink leak',
-    urgencyLabel: 'Urgent',
-    locationLabel: 'Knoxville',
-    timeSinceMissedCall: '4 min ago',
-    summary: 'Customer missed the call and replied by text. They need help today with a leaking sink and are ready for a callback.',
-    recommendedNextAction: 'Call now.',
-    status: LeadStatus.QUALIFIED,
-    countsAsRecovered: true,
-    callHref: null,
-    sendTextHref: null,
-    leadHref: null,
-    sourceLabel: 'Sample lead',
-  },
-  {
-    id: 'sample-james',
-    customerName: 'James R.',
-    serviceNeeded: 'Roof estimate',
-    urgencyLabel: 'This week',
-    locationLabel: 'Oak Ridge',
-    timeSinceMissedCall: '18 min ago',
-    summary: 'Customer wants a roof repair estimate and asked about availability this week.',
-    recommendedNextAction: 'Call now.',
-    status: LeadStatus.QUALIFIED,
-    countsAsRecovered: true,
-    callHref: null,
-    sendTextHref: null,
-    leadHref: null,
-    sourceLabel: 'Sample lead',
-  },
-];
+export type DashboardSummaryCard = {
+  label: string;
+  value: number;
+  detail: string;
+  href?: string;
+};
 
-function buildSampleMetrics(leads: DashboardLeadCard[]): RecoveryMetrics {
-  const missedCallsCaptured = leads.length;
-  const recoveredLeads = leads.filter((lead) => lead.countsAsRecovered).length;
-  const bookedJobs = leads.filter((lead) => lead.status === LeadStatus.BOOKED).length;
+export type DashboardStatusItem = {
+  label: string;
+  value: string;
+  detail: string;
+  tone: 'success' | 'secondary' | 'outline';
+};
 
-  return {
-    missedCallsCaptured,
-    recoveredLeads,
-    bookedJobs,
-    estimatedRevenueSaved: estimateRevenueSaved({
-      bookedJobs,
-      recoveredLeads,
-      averageJobValue: DEFAULT_AVERAGE_JOB_VALUE,
-    }),
-    averageJobValue: DEFAULT_AVERAGE_JOB_VALUE,
-    usesDefaultAverageJobValue: true,
-  };
-}
+export type DashboardLeadCard = {
+  id: string;
+  customerName: string;
+  customerPhone: string;
+  serviceNeeded: string;
+  urgencyLabel: string;
+  createdLabel: string;
+  lastActivityLabel: string;
+  summary: string;
+  recommendedNextAction: string;
+  status: LeadStatus;
+  callHref: string;
+  leadHref: string;
+};
 
-function getUrgencyVariant(label: string) {
-  const normalized = label.trim().toLowerCase();
-  if (normalized.includes('urgent') || normalized.includes('today') || normalized.includes('emergency')) return 'destructive';
-  if (normalized.includes('week') || normalized.includes('estimate')) return 'secondary';
-  return 'outline';
-}
-
-function getSetupItemBadge(item: SetupChecklistItem) {
-  if (item.state === 'complete') return { label: 'Complete', variant: 'success' as const };
-  if (item.state === 'in_progress') return { label: 'In progress', variant: 'secondary' as const };
-  return { label: 'Pending', variant: 'outline' as const };
-}
-
-function getProgressText(items: SetupChecklistItem[]) {
-  const completeCount = items.filter((item) => item.state === 'complete').length;
-  return `${completeCount} of ${items.length} steps complete`;
-}
-
-function getMetricBadgeLabel(input: { isDemoMode: boolean; showingSampleLeads: boolean; hasRealLeadData: boolean }) {
-  if (input.isDemoMode) return 'Demo data';
-  if (input.showingSampleLeads) return 'Sample data';
-  if (!input.hasRealLeadData) return 'No real lead data yet';
-  return 'Live data';
-}
-
-function LeadAttentionCard({
-  lead,
+function LeadStatusActionForm({
+  leadId,
+  status,
   redirectTo,
-  onDemoAction,
+  label,
+  variant,
 }: {
-  lead: DashboardLeadCard;
+  leadId: string;
+  status: 'CONTACTED' | 'BOOKED' | 'LOST';
   redirectTo: string;
-  onDemoAction: (leadId: string, action: 'call' | 'text' | 'booked') => void;
+  label: string;
+  variant?: 'default' | 'outline' | 'destructive';
 }) {
   return (
-    <div className="rounded-2xl border bg-background/95 p-4 shadow-sm">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="space-y-2">
-          <div className="flex flex-wrap items-center gap-2">
-            {lead.sourceLabel ? <Badge variant="outline">{lead.sourceLabel}</Badge> : null}
-            <Badge variant={getUrgencyVariant(lead.urgencyLabel)}>{lead.urgencyLabel}</Badge>
-            <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
-          </div>
-          <div>
-            <p className="text-lg font-semibold tracking-tight">{lead.customerName}</p>
-            <p className="text-sm text-muted-foreground">
-              {lead.serviceNeeded} · {lead.locationLabel} · {lead.timeSinceMissedCall}
-            </p>
-          </div>
-        </div>
-        {lead.leadHref ? (
-          <Link className="text-sm font-medium text-muted-foreground underline underline-offset-4" href={lead.leadHref}>
-            Open lead
-          </Link>
-        ) : null}
-      </div>
-
-      <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_220px]">
-        <div className="rounded-2xl bg-muted/30 p-3.5">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">AI Summary</p>
-          <p className="mt-2 text-sm text-foreground">{lead.summary}</p>
-        </div>
-        <div className="rounded-2xl border border-primary/15 bg-primary/5 p-3.5">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Recommended next action</p>
-          <p className="mt-2 text-sm font-medium text-foreground">{lead.recommendedNextAction}</p>
-        </div>
-      </div>
-
-      <div className="mt-4 flex flex-wrap gap-3">
-        {lead.callHref ? (
-          <Link className={buttonVariants({ size: 'sm' })} href={lead.callHref}>
-            Call Now
-          </Link>
-        ) : (
-          <Button onClick={() => onDemoAction(lead.id, 'call')} size="sm">
-            Call Now
-          </Button>
-        )}
-
-        {lead.sendTextHref ? (
-          <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={lead.sendTextHref}>
-            Send Text
-          </Link>
-        ) : (
-          <Button onClick={() => onDemoAction(lead.id, 'text')} size="sm" variant="outline">
-            Send Text
-          </Button>
-        )}
-
-        {lead.sourceLabel ? (
-          <Button onClick={() => onDemoAction(lead.id, 'booked')} size="sm" variant="secondary">
-            Mark Booked
-          </Button>
-        ) : (
-          <form action={updateLeadStatusAction}>
-            <input type="hidden" name="leadId" value={lead.id} />
-            <input type="hidden" name="status" value="BOOKED" />
-            <input type="hidden" name="redirectTo" value={redirectTo} />
-            <Button size="sm" type="submit" variant="secondary">
-              Mark Booked
-            </Button>
-          </form>
-        )}
-      </div>
-
-      {lead.sourceLabel ? <p className="mt-3 text-xs text-muted-foreground">Demo actions stay on this page and do not touch production data.</p> : null}
-    </div>
+    <form action={updateLeadStatusAction}>
+      <input type="hidden" name="leadId" value={leadId} />
+      <input type="hidden" name="status" value={status} />
+      <input type="hidden" name="redirectTo" value={redirectTo} />
+      <input type="hidden" name="successRedirectTo" value={redirectTo} />
+      <Button size="sm" type="submit" variant={variant}>
+        {label}
+      </Button>
+    </form>
   );
 }
 
-function RecoveryQueueRow({
-  lead,
-  onTestRecoveryFlow,
-}: {
-  lead?: DashboardLeadCard;
-  onTestRecoveryFlow: () => void;
-}) {
-  if (!lead) {
-    return (
-      <div className="rounded-2xl border border-dashed bg-muted/20 p-6">
-        <p className="text-sm font-medium text-foreground">Your recovered leads will appear here after the first missed call.</p>
-        <Button className="mt-4" onClick={onTestRecoveryFlow} size="sm" variant="outline">
-          Test recovery flow
-        </Button>
-      </div>
-    );
-  }
-
+function LeadAttentionCard({ lead }: { lead: DashboardLeadCard }) {
   return (
-    <div className="rounded-2xl border bg-background/90 p-4">
-      <div className="flex flex-wrap items-center gap-2">
-        {lead.sourceLabel ? <Badge variant="outline">{lead.sourceLabel}</Badge> : null}
-        <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
-      </div>
-      <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+    <Card className="border-primary/15 bg-card/95">
+      <CardHeader className="space-y-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="text-xl">{lead.customerName}</CardTitle>
+            <CardDescription>{lead.customerPhone}</CardDescription>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
+            <Badge variant={lead.urgencyLabel.toLowerCase().includes('urgent') ? 'destructive' : 'outline'}>{lead.urgencyLabel}</Badge>
+          </div>
+        </div>
+        <div className="rounded-2xl border bg-background/80 p-3 text-sm">
+          <p className="font-medium">{lead.recommendedNextAction}</p>
+          <p className="mt-2 text-muted-foreground">{lead.serviceNeeded}</p>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">{lead.summary}</p>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span>Created {lead.createdLabel}</span>
+          <span>Last activity {lead.lastActivityLabel}</span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link className={buttonVariants({ size: 'sm' })} href={lead.callHref}>
+            Call now
+          </Link>
+          <Link className={buttonVariants({ size: 'sm', variant: 'outline' })} href={lead.leadHref}>
+            Open lead
+          </Link>
+          <LeadStatusActionForm leadId={lead.id} label="Mark contacted" redirectTo="/app" status="CONTACTED" variant="outline" />
+          <LeadStatusActionForm leadId={lead.id} label="Mark booked" redirectTo="/app" status="BOOKED" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecentLeadRow({ lead }: { lead: DashboardLeadCard }) {
+  return (
+    <Link className="block rounded-2xl border bg-background/90 p-4 transition-colors hover:bg-muted/20" href={lead.leadHref}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <p className="font-medium">{lead.customerName}</p>
-          <p className="text-sm text-muted-foreground">
-            {lead.serviceNeeded} · {lead.locationLabel} · {lead.timeSinceMissedCall}
+          <p className="mt-1 text-sm text-muted-foreground">{lead.serviceNeeded}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Created {lead.createdLabel} · Last activity {lead.lastActivityLabel}
           </p>
-          <p className="mt-2 text-sm text-muted-foreground">{lead.summary}</p>
         </div>
-        {lead.leadHref ? (
-          <Link className={buttonVariants({ variant: 'ghost', size: 'sm' })} href={lead.leadHref}>
-            Open
-          </Link>
-        ) : null}
+        <div className="flex flex-wrap gap-2 sm:justify-end">
+          <Badge variant={getLeadStatusBadgeVariant(lead.status)}>{leadStatusLabels[lead.status]}</Badge>
+          <Badge variant="outline">{lead.urgencyLabel}</Badge>
+        </div>
       </div>
-    </div>
+    </Link>
   );
 }
 
 export function HomeDashboard({
   attentionLeads,
-  queueLeads,
-  metrics,
+  recentLeads,
   feedback,
   isDemoMode,
-  hasRealLeadData,
-  showSetupChecklist,
-  setupChecklistItems,
-  setupHref,
+  statusItems,
+  summaryCards,
   simulatorHref,
 }: {
   attentionLeads: DashboardLeadCard[];
-  queueLeads: DashboardLeadCard[];
-  metrics: RecoveryMetrics;
+  recentLeads: DashboardLeadCard[];
   feedback: DashboardFeedback;
   isDemoMode: boolean;
-  hasRealLeadData: boolean;
-  showSetupChecklist: boolean;
-  setupChecklistItems: SetupChecklistItem[];
-  setupHref: string;
+  statusItems: DashboardStatusItem[];
+  summaryCards: DashboardSummaryCard[];
   simulatorHref: string;
 }) {
-  const [showSampleLeads, setShowSampleLeads] = useState(!hasRealLeadData && isDemoMode);
-  const [sampleLeads, setSampleLeads] = useState(sampleLeadSeed);
-  const [demoNotice, setDemoNotice] = useState<string | null>(null);
-
-  const showingSampleLeads = showSampleLeads && !hasRealLeadData;
-  const displayedAttentionLeads = showingSampleLeads ? sampleLeads : attentionLeads;
-  const displayedQueueLeads = showingSampleLeads ? sampleLeads : queueLeads;
-  const displayedMetrics = useMemo(
-    () => (showingSampleLeads ? buildSampleMetrics(sampleLeads) : metrics),
-    [metrics, sampleLeads, showingSampleLeads],
-  );
-  const queueIsEmpty = displayedQueueLeads.length === 0;
-  const attentionIsEmpty = displayedAttentionLeads.length === 0;
-
-  function testRecoveryFlow() {
-    setShowSampleLeads(true);
-    setDemoNotice('Sample leads are now visible on this dashboard. These cards stay in the browser only and do not affect production data.');
-  }
-
-  function handleDemoAction(leadId: string, action: 'call' | 'text' | 'booked') {
-    setSampleLeads((currentLeads) =>
-      currentLeads.map((lead) => {
-        if (lead.id !== leadId) return lead;
-        if (action === 'booked') {
-          return {
-            ...lead,
-            status: LeadStatus.BOOKED,
-            recommendedNextAction: 'Booked. Keep this one for proof of recovered revenue.',
-          };
-        }
-        return {
-          ...lead,
-          status: LeadStatus.CONTACTED,
-          recommendedNextAction: action === 'call' ? 'Follow up by text if they do not answer.' : 'Wait for the reply, then mark the job outcome.',
-        };
-      }),
-    );
-
-    setDemoNotice(
-      action === 'booked'
-        ? 'Sample lead marked booked. The revenue estimate updated on this page only.'
-        : 'Sample lead updated. This is a frontend-only demo action and does not send live outreach.',
-    );
-  }
-
   return (
     <div className="space-y-6">
       {feedback.error ? <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{feedback.error}</div> : null}
       {feedback.saved ? <div className="rounded-md border border-accent bg-accent/40 p-3 text-sm">Lead updated.</div> : null}
-      {demoNotice ? <div className="rounded-md border border-primary/20 bg-primary/5 p-3 text-sm text-foreground">{demoNotice}</div> : null}
 
       <section className="space-y-4">
-        <Badge variant="outline">Lead recovery command center</Badge>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="outline">Owner dashboard</Badge>
+          {isDemoMode ? <Badge variant="secondary">Demo data</Badge> : null}
+        </div>
         <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
           <div className="space-y-3">
-            <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Missed-call leads that need action</h1>
+            <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Missed-call leads</h1>
             <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
-              CallbackCloser follows up instantly, qualifies the customer, and shows you who to call back first.
+              See who needs a callback, open the lead, and mark the outcome after you talk to them.
             </p>
           </div>
           <div className="flex flex-wrap gap-3">
@@ -342,28 +173,54 @@ export function HomeDashboard({
         </div>
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start">
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {summaryCards.map((card) => {
+          const content = (
+            <Card className={cn('h-full bg-card/95', card.href && 'transition-colors hover:bg-muted/20')}>
+              <CardHeader className="pb-3">
+                <CardDescription>{card.label}</CardDescription>
+                <CardTitle className="text-3xl">{card.value}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">{card.detail}</p>
+              </CardContent>
+            </Card>
+          );
+
+          return card.href ? (
+            <Link key={card.label} href={card.href}>
+              {content}
+            </Link>
+          ) : (
+            <div key={card.label}>{content}</div>
+          );
+        })}
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_340px] xl:items-start">
         <div className="space-y-6">
           <Card className="bg-card/95">
-            <CardHeader>
-              <CardTitle>Leads needing attention first</CardTitle>
-              <CardDescription>These missed callers are the clearest path to recovered jobs right now.</CardDescription>
+            <CardHeader className="gap-4 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <CardTitle>Leads needing attention</CardTitle>
+                <CardDescription>Call these missed callers first.</CardDescription>
+              </div>
+              <Link className={buttonVariants({ variant: 'ghost' })} href="/app/leads?view=attention">
+                View inbox
+              </Link>
             </CardHeader>
             <CardContent className="space-y-4">
-              {attentionIsEmpty ? (
+              {attentionLeads.length === 0 ? (
                 <div className="rounded-2xl border border-dashed bg-muted/20 p-6">
-                  <p className="text-sm font-medium text-foreground">No real leads need action yet.</p>
+                  <p className="text-sm font-medium text-foreground">No leads need follow-up right now.</p>
                   <p className="mt-2 text-sm text-muted-foreground">
-                    Once CallbackCloser captures a missed call, the lead will appear here with a summary, urgency level, and one-click follow-up actions.
+                    When a missed caller replies or needs a callback, they will appear here first.
                   </p>
-                  <Button className="mt-4" onClick={testRecoveryFlow} variant="outline">
-                    Test recovery flow
-                  </Button>
                 </div>
               ) : (
-                <div className="grid gap-4 xl:grid-cols-2">
-                  {displayedAttentionLeads.map((lead) => (
-                    <LeadAttentionCard key={lead.id} lead={lead} onDemoAction={handleDemoAction} redirectTo="/app" />
+                <div className="grid gap-4 2xl:grid-cols-2">
+                  {attentionLeads.map((lead) => (
+                    <LeadAttentionCard key={lead.id} lead={lead} />
                   ))}
                 </div>
               )}
@@ -373,101 +230,52 @@ export function HomeDashboard({
           <Card className="bg-card/95">
             <CardHeader className="gap-4 sm:flex-row sm:items-end sm:justify-between">
               <div>
-                <CardTitle>Today&apos;s recovery queue</CardTitle>
-                <CardDescription>Every missed-call lead captured today.</CardDescription>
+                <CardTitle>Recent leads</CardTitle>
+                <CardDescription>The latest missed-call leads captured for your business.</CardDescription>
               </div>
               <Link className={buttonVariants({ variant: 'ghost' })} href="/app/leads">
                 View all leads
               </Link>
             </CardHeader>
             <CardContent className="space-y-3">
-              {queueIsEmpty ? (
-                <RecoveryQueueRow onTestRecoveryFlow={testRecoveryFlow} />
+              {recentLeads.length === 0 ? (
+                <div className="rounded-2xl border border-dashed bg-muted/20 p-6">
+                  <p className="text-sm font-medium text-foreground">No leads yet.</p>
+                  <p className="mt-2 text-sm text-muted-foreground">Your first missed-call lead will appear here automatically.</p>
+                </div>
               ) : (
-                displayedQueueLeads.map((lead) => <RecoveryQueueRow key={lead.id} lead={lead} onTestRecoveryFlow={testRecoveryFlow} />)
+                recentLeads.map((lead) => <RecentLeadRow key={lead.id} lead={lead} />)
               )}
             </CardContent>
           </Card>
         </div>
 
-        <div className="space-y-4 lg:sticky lg:top-6 lg:self-start">
-          {showSetupChecklist ? (
-            <Card className="border-primary/15 bg-gradient-to-br from-card via-card to-primary/5">
-              <CardHeader className="pb-4">
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="space-y-1">
-                    <CardTitle>Finish setup</CardTitle>
-                    <CardDescription>{getProgressText(setupChecklistItems)}</CardDescription>
-                  </div>
-                  <Badge variant="outline">{getProgressText(setupChecklistItems)}</Badge>
-                </div>
-              </CardHeader>
-              <CardContent className="space-y-2.5">
-                {setupChecklistItems.map((item) => {
-                  const badge = getSetupItemBadge(item);
-                  return (
-                    <div key={item.key} className="rounded-2xl border bg-background/80 p-3">
-                      <div className="flex flex-wrap items-center justify-between gap-2">
-                        <p className="text-sm font-medium">{item.label}</p>
-                        <Badge variant={badge.variant}>{badge.label}</Badge>
-                      </div>
-                      <p className="mt-1 text-xs text-muted-foreground">{item.detail}</p>
-                    </div>
-                  );
-                })}
-                <Link className={cn(buttonVariants({ size: 'sm' }), 'w-full')} href={setupHref}>
-                  Review setup
-                </Link>
-              </CardContent>
-            </Card>
-          ) : null}
-
+        <div className="space-y-4 xl:sticky xl:top-6 xl:self-start">
           <Card className="bg-card/95">
-            <CardHeader className="pb-4">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div>
-                  <CardTitle>Recovery numbers</CardTitle>
-                  <CardDescription>Keep the value of missed-call follow-up obvious without opening another report.</CardDescription>
-                </div>
-                <Badge variant={showingSampleLeads || isDemoMode ? 'secondary' : hasRealLeadData ? 'success' : 'outline'}>
-                  {getMetricBadgeLabel({ isDemoMode, showingSampleLeads, hasRealLeadData })}
-                </Badge>
-              </div>
+            <CardHeader>
+              <CardTitle>System status</CardTitle>
+              <CardDescription>Simple setup signals only.</CardDescription>
             </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="rounded-2xl border bg-background/90 p-3.5">
-                  <p className="text-sm text-muted-foreground">Missed calls captured</p>
-                  <p className="mt-2 text-2xl font-semibold tracking-tight">{displayedMetrics.missedCallsCaptured}</p>
+            <CardContent className="space-y-3">
+              {statusItems.map((item) => (
+                <div key={item.label} className="rounded-2xl border bg-background/90 p-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-medium">{item.label}</p>
+                    <Badge variant={item.tone}>{item.value}</Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">{item.detail}</p>
                 </div>
-                <div className="rounded-2xl border bg-background/90 p-3.5">
-                  <p className="text-sm text-muted-foreground">Recovered leads</p>
-                  <p className="mt-2 text-2xl font-semibold tracking-tight">{displayedMetrics.recoveredLeads}</p>
-                </div>
-                <div className="rounded-2xl border bg-background/90 p-3.5">
-                  <p className="text-sm text-muted-foreground">Booked jobs</p>
-                  <p className="mt-2 text-2xl font-semibold tracking-tight">{displayedMetrics.bookedJobs}</p>
-                </div>
-                <div className="rounded-2xl border bg-background/90 p-3.5">
-                  <p className="text-sm text-muted-foreground">Estimated revenue saved</p>
-                  <p className="mt-2 text-2xl font-semibold tracking-tight">{formatCurrency(displayedMetrics.estimatedRevenueSaved)}</p>
-                </div>
-              </div>
-              <p className="text-xs text-muted-foreground">Revenue saved is estimated from booked/recovered leads and your average job value.</p>
-              {displayedMetrics.usesDefaultAverageJobValue ? (
-                <p className="text-xs text-muted-foreground">
-                  Using the default {formatCurrency(displayedMetrics.averageJobValue)} average job value until a business-specific average is configured.
-                </p>
-              ) : (
-                <p className="text-xs text-muted-foreground">Using your configured {formatCurrency(displayedMetrics.averageJobValue)} average job value.</p>
-              )}
+              ))}
+              <Link className={cn(buttonVariants({ size: 'sm', variant: 'outline' }), 'w-full')} href="/app/settings">
+                Review settings
+              </Link>
             </CardContent>
           </Card>
 
           <Card className="bg-card/95">
-            <CardHeader className="pb-4">
-              <CardTitle>Test recovery flow</CardTitle>
-              <CardDescription>Send yourself a sample missed-call lead so you can see the text flow, owner alert, and dashboard update.</CardDescription>
+            <CardHeader>
+              <CardTitle>Want to test it?</CardTitle>
+              <CardDescription>Run the public simulator to see a sample missed-call flow.</CardDescription>
             </CardHeader>
             <CardContent>
               <Link className={cn(buttonVariants(), 'w-full')} href={simulatorHref}>

--- a/lib/system-status.ts
+++ b/lib/system-status.ts
@@ -55,16 +55,16 @@ export function getCustomerSystemStatus(business: StatusBusiness, successfulLead
       key: 'live' as const,
       label: 'Live',
       badgeVariant: 'success' as const,
-      description: 'Missed-call recovery is compliant, synced, and ready for another test call.',
+      description: 'Missed-call recovery is live and ready for another test call.',
     };
   }
 
   if (managedSummary.onboardingReady || managedSummary.complianceStarted || phoneSetupGate.complete || hasSuccessfulTestLead) {
     return {
       key: 'activating' as const,
-      label: 'Activating',
+      label: 'Setup pending',
       badgeVariant: 'secondary' as const,
-      description: 'Setup is underway. Finish the remaining activation steps to go live.',
+      description: 'CallbackCloser is finishing the remaining setup before missed-call recovery goes live.',
     };
   }
 

--- a/tests/customer-home-dashboard.test.ts
+++ b/tests/customer-home-dashboard.test.ts
@@ -100,8 +100,11 @@ test('customer home dashboard keeps setup state compact and demo actions fronten
 
   assert.match(appHomePage, /buildRecoveryMetrics\(allLeads, business\.averageJobValueCents\)/);
   assert.match(appHomePage, /showSetupChecklist=\{systemStatus\.key !== 'live'\}/);
+  assert.match(appHomePage, /setupHref="\/app\/settings"/);
   assert.match(appHomePage, /label: 'Phone line connected'/);
+  assert.match(appHomePage, /label: 'Text replies being prepared'/);
   assert.match(homeDashboard, /Finish setup/);
+  assert.match(homeDashboard, /Review setup/);
   assert.match(homeDashboard, /Test recovery flow/);
   assert.match(homeDashboard, /lg:grid-cols-\[minmax\(0,1fr\)_360px\]/);
   assert.match(homeDashboard, /lg:sticky lg:top-6 lg:self-start/);
@@ -111,6 +114,8 @@ test('customer home dashboard keeps setup state compact and demo actions fronten
   assert.doesNotMatch(homeDashboard, /Run test missed call/);
   assert.doesNotMatch(homeDashboard, /Run demo lead/);
   assert.doesNotMatch(homeDashboard, /Test demo flow/);
+  assert.doesNotMatch(homeDashboard, /Finish activation/);
+  assert.doesNotMatch(appHomePage, /twilio-setup-flow|Texting activation/);
 });
 
 test('business settings UI and action wire average job value persistence into the dashboard', () => {

--- a/tests/customer-home-dashboard.test.ts
+++ b/tests/customer-home-dashboard.test.ts
@@ -94,27 +94,32 @@ test('business settings schema accepts a blank average job value and rejects inv
   assert.equal(invalid.success, false);
 });
 
-test('customer home dashboard keeps setup state compact and demo actions frontend-only', () => {
+test('customer home dashboard focuses on owner lead follow-up', () => {
   const appHomePage = read('app/app/page.tsx');
   const homeDashboard = read('components/home-dashboard.tsx');
 
-  assert.match(appHomePage, /buildRecoveryMetrics\(allLeads, business\.averageJobValueCents\)/);
-  assert.match(appHomePage, /showSetupChecklist=\{systemStatus\.key !== 'live'\}/);
-  assert.match(appHomePage, /setupHref="\/app\/settings"/);
-  assert.match(appHomePage, /label: 'Phone line connected'/);
-  assert.match(appHomePage, /label: 'Text replies being prepared'/);
-  assert.match(homeDashboard, /Finish setup/);
-  assert.match(homeDashboard, /Review setup/);
+  assert.match(appHomePage, /listAllDashboardLeadsForBusiness\(business\.id\)/);
+  assert.match(appHomePage, /label: 'New leads'/);
+  assert.match(appHomePage, /label: 'Needs follow-up'/);
+  assert.match(appHomePage, /label: 'Booked leads'/);
+  assert.match(appHomePage, /label: 'Missed calls today'/);
+  assert.match(appHomePage, /statusItems=\{getStatusItems\(\{ ownerAlertsReady, systemStatus \}\)\}/);
+  assert.match(homeDashboard, /Missed-call leads/);
+  assert.match(homeDashboard, /Leads needing attention/);
+  assert.match(homeDashboard, /Recent leads/);
+  assert.match(homeDashboard, /System status/);
+  assert.match(homeDashboard, /Call now/);
+  assert.match(homeDashboard, /Mark contacted/);
+  assert.match(homeDashboard, /Mark booked/);
   assert.match(homeDashboard, /Test recovery flow/);
-  assert.match(homeDashboard, /lg:grid-cols-\[minmax\(0,1fr\)_360px\]/);
-  assert.match(homeDashboard, /lg:sticky lg:top-6 lg:self-start/);
+  assert.match(homeDashboard, /xl:grid-cols-\[minmax\(0,1fr\)_340px\]/);
+  assert.match(homeDashboard, /xl:sticky xl:top-6 xl:self-start/);
   assert.match(homeDashboard, /variant="outline"/);
-  assert.match(homeDashboard, /frontend-only demo action/);
-  assert.match(homeDashboard, /do not affect production data/);
   assert.doesNotMatch(homeDashboard, /Run test missed call/);
   assert.doesNotMatch(homeDashboard, /Run demo lead/);
   assert.doesNotMatch(homeDashboard, /Test demo flow/);
   assert.doesNotMatch(homeDashboard, /Finish activation/);
+  assert.doesNotMatch(homeDashboard, /Recovery numbers|AI Summary|command center|Estimated revenue saved/);
   assert.doesNotMatch(appHomePage, /twilio-setup-flow|Texting activation/);
 });
 

--- a/tests/leads-workspace-routing.test.ts
+++ b/tests/leads-workspace-routing.test.ts
@@ -15,32 +15,35 @@ test('lead inbox stays list-only while lead detail is the main action workspace'
   const conversationsPage = read('app/app/conversations/page.tsx');
 
   assert.match(appHomePage, /HomeDashboard/);
-  assert.match(appHomePage, /buildRecoveryMetrics/);
+  assert.match(appHomePage, /label: 'New leads'/);
+  assert.match(appHomePage, /label: 'Needs follow-up'/);
+  assert.match(appHomePage, /label: 'Booked leads'/);
+  assert.match(appHomePage, /label: 'Missed calls today'/);
   assert.match(appHomePage, /return `\/app\/leads\/\$\{leadId\}\?from=%2Fapp`/);
-  assert.match(homeDashboard, /Missed-call leads that need action/);
-  assert.match(homeDashboard, /Leads needing attention first/);
-  assert.match(homeDashboard, /Today&apos;s recovery queue/);
+  assert.match(homeDashboard, /Missed-call leads/);
+  assert.match(homeDashboard, /Leads needing attention/);
+  assert.match(homeDashboard, /Recent leads/);
+  assert.match(homeDashboard, /System status/);
   assert.match(homeDashboard, /Test recovery flow/);
   assert.doesNotMatch(homeDashboard, /Run test missed call/);
   assert.doesNotMatch(homeDashboard, /Run demo lead/);
   assert.doesNotMatch(homeDashboard, /Test demo flow/);
 
   assert.match(leadsPage, /Lead inbox/);
-  assert.match(leadsPage, /LeadConversionSummaryCard/);
-  assert.match(leadsPage, /getLeadOutcomeSummary/);
-  assert.match(leadsPage, /This page is only for scanning/i);
+  assert.match(leadsPage, /Scan missed-call leads/i);
   assert.match(leadsPage, /Needs follow-up/);
-  assert.match(leadsPage, /Closed/);
+  assert.match(leadsPage, /Booked/);
   assert.doesNotMatch(leadsPage, /selectedLeadId/);
   assert.doesNotMatch(leadsPage, /Lead detail panel/);
   assert.doesNotMatch(leadsPage, /Quick actions/);
   assert.doesNotMatch(leadsPage, /Open Conversations/);
+  assert.doesNotMatch(leadsPage, /LeadConversionSummaryCard|getLeadOutcomeSummary/);
 
   assert.match(leadDetailPage, /Lead details/);
   assert.match(leadDetailPage, /Call now/);
   assert.match(leadDetailPage, /Mark contacted/);
-  assert.match(leadDetailPage, /Mark as Closed \(Won\)/);
-  assert.match(leadDetailPage, /Mark as Lost/);
+  assert.match(leadDetailPage, /Mark booked/);
+  assert.match(leadDetailPage, /Mark lost/);
   assert.match(leadDetailPage, /Did this lead turn into a real job\?/);
   assert.match(leadDetailPage, /Conversation history/);
   assert.match(leadDetailPage, /Qualification info/);
@@ -51,7 +54,9 @@ test('lead inbox stays list-only while lead detail is the main action workspace'
   assert.match(leadDetailPage, /No preferred time yet/);
   assert.match(leadDetailPage, /const error = typeof searchParams\?\.error === 'string' \? searchParams\.error : undefined;/);
   assert.match(leadDetailPage, /border-destructive\/30 bg-destructive\/5 p-3 text-sm text-destructive/);
+  assert.doesNotMatch(leadDetailPage, /Mark as Closed \(Won\)|Mark as Lost/);
 
-  assert.match(conversationsPage, /href=\{`\/app\/leads\/\$\{selectedLead\.id\}\?from=%2Fapp%2Fconversations`\}/);
-  assert.match(conversationsPage, /Open lead details/);
+  assert.match(conversationsPage, /Latest conversations/);
+  assert.match(conversationsPage, /href=\{`\/app\/leads\/\$\{lead\.id\}\?from=%2Fapp%2Fconversations`\}/);
+  assert.doesNotMatch(conversationsPage, /selectedLeadId|getConversationDetailForBusiness|Conversation detail|Open lead details/);
 });

--- a/tests/pilot-safety.test.ts
+++ b/tests/pilot-safety.test.ts
@@ -13,8 +13,12 @@ test('customer setup pages keep operator setup details out of owner view', () =>
   const settingsPage = read('app/app/settings/page.tsx');
   const callFlowPage = read('app/app/call-flow/page.tsx');
   const homeDashboard = read('components/home-dashboard.tsx');
+  const leadsPage = read('app/app/leads/page.tsx');
+  const leadDetailPage = read('app/app/leads/[leadId]/page.tsx');
+  const conversationsPage = read('app/app/conversations/page.tsx');
+  const billingPage = read('app/app/billing/page.tsx');
   const forbiddenOwnerTerms =
-    /\bTwilio\b|\bA2P\b|toll-free|webhook|subaccount|\bSID\b|Provision routing number|Sync all webhooks|Test SMS|Messaging Service|account mode|admin-assisted|pilot sender|Finish activation|twilio-setup-flow/i;
+    /\bTwilio\b|\bA2P\b|toll-free|webhook|subaccount|\bSID\b|Provision routing number|Sync all webhooks|Test SMS|Messaging Service|account mode|admin-assisted|pilot sender|Finish activation|twilio-setup-flow|operator event|status callback|activation/i;
 
   assert.match(settingsPage, /Business settings/);
   assert.match(settingsPage, /Text replies/);
@@ -23,10 +27,14 @@ test('customer setup pages keep operator setup details out of owner view', () =>
   assert.match(callFlowPage, /How missed calls are handled/);
   assert.match(callFlowPage, /A customer calls/);
   assert.match(callFlowPage, /You get a lead summary/);
-  assert.match(homeDashboard, /Review setup/);
+  assert.match(homeDashboard, /Review settings/);
   assert.doesNotMatch(settingsPage, forbiddenOwnerTerms);
   assert.doesNotMatch(callFlowPage, forbiddenOwnerTerms);
   assert.doesNotMatch(homeDashboard, forbiddenOwnerTerms);
+  assert.doesNotMatch(leadsPage, forbiddenOwnerTerms);
+  assert.doesNotMatch(leadDetailPage, forbiddenOwnerTerms);
+  assert.doesNotMatch(conversationsPage, forbiddenOwnerTerms);
+  assert.doesNotMatch(billingPage, forbiddenOwnerTerms);
 });
 
 test('managed setup handoff replaces the old self-serve onboarding route', () => {

--- a/tests/pilot-safety.test.ts
+++ b/tests/pilot-safety.test.ts
@@ -9,23 +9,24 @@ function read(relativePath: string) {
   return readFileSync(path.join(process.cwd(), relativePath), 'utf8');
 }
 
-test('settings page no longer exposes shared Twilio number inventory', () => {
+test('customer setup pages keep operator setup details out of owner view', () => {
   const settingsPage = read('app/app/settings/page.tsx');
+  const callFlowPage = read('app/app/call-flow/page.tsx');
+  const homeDashboard = read('components/home-dashboard.tsx');
+  const forbiddenOwnerTerms =
+    /\bTwilio\b|\bA2P\b|toll-free|webhook|subaccount|\bSID\b|Provision routing number|Sync all webhooks|Test SMS|Messaging Service|account mode|admin-assisted|pilot sender|Finish activation|twilio-setup-flow/i;
 
-  assert.doesNotMatch(settingsPage, /incomingPhoneNumbers\.list/);
-  assert.match(settingsPage, /account mode/);
-  assert.match(settingsPage, /Existing-number support stays honest/i);
-});
-
-test('existing-number selection reports a truthful setup state instead of a fake error', () => {
-  const settingsPage = read('app/app/settings/page.tsx');
-  const settingsAction = read('app/app/settings/actions.ts');
-
-  assert.match(settingsAction, /redirect\('\/app\/settings\?existingNumberIntent=1'\)/);
-  assert.doesNotMatch(settingsAction, /Keeping an existing number is still an admin-assisted launch step/);
-  assert.match(settingsPage, /const existingNumberIntent = searchParams\?\.existingNumberIntent === '1';/);
-  assert.match(settingsPage, /Porting path saved\./);
-  assert.match(settingsPage, /admin-assisted porting workflow/i);
+  assert.match(settingsPage, /Business settings/);
+  assert.match(settingsPage, /Text replies/);
+  assert.match(settingsPage, /Owner alerts/);
+  assert.match(settingsPage, /Need setup help/);
+  assert.match(callFlowPage, /How missed calls are handled/);
+  assert.match(callFlowPage, /A customer calls/);
+  assert.match(callFlowPage, /You get a lead summary/);
+  assert.match(homeDashboard, /Review setup/);
+  assert.doesNotMatch(settingsPage, forbiddenOwnerTerms);
+  assert.doesNotMatch(callFlowPage, forbiddenOwnerTerms);
+  assert.doesNotMatch(homeDashboard, forbiddenOwnerTerms);
 });
 
 test('managed setup handoff replaces the old self-serve onboarding route', () => {

--- a/tests/tenant-isolation-wiring.test.ts
+++ b/tests/tenant-isolation-wiring.test.ts
@@ -26,9 +26,11 @@ test('protected app surfaces use shared tenant-scoped access helpers', () => {
   assert.match(leadsPage, /buildLeadDetailHref/);
   assert.doesNotMatch(leadsPage, /selectedLeadId/);
   assert.match(leadDetailPage, /getLeadDetailForBusiness/);
+  assert.match(leadDetailPage, /notFound\(\)/);
   assert.match(conversationsPage, /listConversationsForBusiness/);
-  assert.match(conversationsPage, /getConversationDetailForBusiness/);
+  assert.doesNotMatch(conversationsPage, /getConversationDetailForBusiness/);
   assert.match(leadActions, /updateLeadStatusForBusiness/);
+  assert.match(leadActions, /requireBusiness/);
   assert.match(settingsPage, /getBusinessNotificationSettingsForBusiness/);
   assert.match(settingsActions, /requireBusiness/);
   assert.match(billingPage, /getBillingUsageSnapshotForBusiness/);


### PR DESCRIPTION
## Summary
- Carries forward the existing owner-safe setup cleanup on this branch.
- Refactors the owner dashboard around missed-call lead follow-up instead of technical setup or revenue/demo framing.
- Keeps `/app/leads` as a scoped inbox/list and makes `/app/leads/[leadId]` the primary action workspace for calling, reviewing conversations, and marking contacted/booked/lost.
- Simplifies `/app/conversations` into a conversation index that deep-links directly to the matching lead detail page.
- Preserves owner alert deep links to `/app/leads/[leadId]` and strengthens regression coverage for tenant safety and customer-visible language.

## Tenant and owner-safety checks
- Customer-visible pages avoid Twilio, A2P, provisioning, SID, webhook, admin, and setup-control terminology.
- Lead inbox and detail routes remain business-scoped through the existing `requireBusiness` and business-id data access patterns.
- Status actions remain protected by business-scoped updates.

## Validation
- `./node_modules/.bin/tsx --test tests/customer-home-dashboard.test.ts tests/leads-workspace-routing.test.ts tests/tenant-isolation-wiring.test.ts tests/tenant-isolation.test.ts tests/owner-notification-idempotency.test.ts tests/pilot-safety.test.ts`
- `npm run env:check`
- `npm run preflight:providers`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`
