### PR TITLE
Improve GitHub portfolio discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **A missed-call recovery system that follows up by SMS, qualifies the request, notifies the business, and keeps the complete conversation in an operator dashboard.**
 
-[Simulator (hosting remediation pending)](https://callbackcloser.com/simulator) · [Review the architecture](docs/ARCHITECTURE.md) · [Work with RelayWorks](https://getrelayworks.com/contact/)
+**Live simulator unavailable while hosting is remediated.** · [Review the architecture](docs/ARCHITECTURE.md) · [Work with RelayWorks](https://getrelayworks.com/contact/)
 
 ![Portfolio](https://img.shields.io/badge/portfolio-RelayWorks-126355) ![Next.js](https://img.shields.io/badge/Next.js-14-111820) ![Tests](https://img.shields.io/badge/tests-71%20files-3178C6)
 


### PR DESCRIPTION
## What changed
Removed the broken live simulator link while retaining the explicit hosting-remediation status and local evaluation guidance.

## Why
Avoid sending portfolio visitors to an unavailable deployment.

## Impact
Documentation only; no application behavior changes.

## Validation
- External portfolio links: HTTP 200
- Markdown local links: passed